### PR TITLE
feature: add dummy GitHub action

### DIFF
--- a/.github/workflows/publish_cli_bin.yml
+++ b/.github/workflows/publish_cli_bin.yml
@@ -1,0 +1,12 @@
+name: Dummy Publish CLI binaries
+
+on:
+  workflow_dispatch:
+
+jobs:
+  say-hello:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Print Hello World
+        run: echo "Hello world"


### PR DESCRIPTION
Add dummy GitHub action in prevision of pushing CLI binaries into GitHub release