### PR TITLE
feat(ci): adding test step to validate binary build

### DIFF
--- a/.github/workflows/publish_cli_bin.yml
+++ b/.github/workflows/publish_cli_bin.yml
@@ -65,3 +65,27 @@ jobs:
           files: target/${{ matrix.artifact_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  test-binary:
+    name: Test binary with register.capability.yml
+    needs: build-native
+    runs-on: macos-latest  # pour tester uniquement sur macOS
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4  # récup le register.capability.yml
+
+      - name: Download macOS binary
+        uses: actions/download-artifact@v4
+        with:
+          name: naftiko-cli-macos-arm64
+          path: ./bin
+
+      - name: Make binary executable
+        run: chmod +x ./bin/naftiko-cli-macos-arm64
+
+      - name: Run binary with register.capability.yml
+        run: |
+          output=$(./bin/naftiko-cli-macos-arm64 v src/test/resources/register.capability.yml)
+          exit_code=$?
+          echo "Output: $output"
+          echo "Exit code: $exit_code"

--- a/src/test/resources/register.capability.yml
+++ b/src/test/resources/register.capability.yml
@@ -1,0 +1,32 @@
+naftiko: "0.4"
+info:
+  label: "register"
+  description: "Business description of your capability"
+capability:
+  exposes:
+  - type: "api"
+    namespace: "documentation"
+    port: 8081
+    resources:
+    - path: "/notion/{{path}}"
+      label: "Notion API Pass-thru Proxy"
+      description: "A proxy to forward requests to the Notion API while the capability is being configured"
+      forward:
+        targetNamespace: "notion"
+        trustedHeaders:
+        - "Notion-Version"
+  consumes:
+  - type: "http"
+    namespace: "notion"
+    description: "Notion base API"
+    baseUri: "http://host.docker.internal:8080/rest/Notion+API/1.0.0/"
+    authentication:
+        type: "basic"
+        username: "scott"
+        password: "tiger"
+    resources:
+    - name: "users"
+      path:  "users/me"
+      operations:
+      - name: get-my-user
+        method: GET


### PR DESCRIPTION
Added a test-binary job in the GitHub Actions pipeline that runs after the build-native job completes. This job downloads as an example the macOS ARM64 artifact and executes it against src/test/resources/register.capability.yml to verify the binary is not broken after each build.