### PR TITLE
fix(orchestration): resolve cross-step with templates using prior step outputs

### DIFF
--- a/src/main/java/io/naftiko/engine/exposes/ApiResourceRestlet.java
+++ b/src/main/java/io/naftiko/engine/exposes/ApiResourceRestlet.java
@@ -13,6 +13,7 @@
  */
 package io.naftiko.engine.exposes;
 
+import org.restlet.Context;
 import org.restlet.Request;
 import org.restlet.Response;
 import org.restlet.Restlet;
@@ -97,7 +98,7 @@ public class ApiResourceRestlet extends Restlet {
                         found = stepExecutor.findClientRequestFor(serverOp.getCall(),
                                 inputParameters);
                     } catch (IllegalArgumentException e) {
-                        getContext().getLogger().warning("Error resolving request parameters: " + e);
+                        Context.getCurrentLogger().warning("Error resolving request parameters: " + e);
                         response.setStatus(Status.CLIENT_ERROR_BAD_REQUEST);
                         response.setEntity("Error resolving request parameters: " + e.getMessage(),
                                 MediaType.TEXT_PLAIN);
@@ -110,7 +111,7 @@ public class ApiResourceRestlet extends Restlet {
                             found.handle();
                             response.setStatus(found.clientResponse.getStatus());
                         } catch (Exception e) {
-                            getContext().getLogger().warning("Error while handling HTTP client call in call mode: " + e);
+                            Context.getCurrentLogger().warning("Error while handling HTTP client call in call mode: " + e);
                             response.setStatus(Status.SERVER_ERROR_INTERNAL);
                             response.setEntity(
                                     "Error while handling an HTTP client call\n\n" + e.toString(),
@@ -139,12 +140,12 @@ public class ApiResourceRestlet extends Restlet {
                                 stepExecutor.executeSteps(serverOp.getSteps(), inputParameters);
                         found = stepResult.lastContext;
                     } catch (IllegalArgumentException e) {
-                        getContext().getLogger().warning("Invalid argument in orchestrated steps: " + e);
+                        Context.getCurrentLogger().warning("Invalid argument in orchestrated steps: " + e);
                         response.setStatus(Status.CLIENT_ERROR_BAD_REQUEST);
                         response.setEntity(e.getMessage(), MediaType.TEXT_PLAIN);
                         return true;
                     } catch (RuntimeException e) {
-                        getContext().getLogger().warning("Error while handling orchestrated steps: " + e);
+                        Context.getCurrentLogger().warning("Error while handling orchestrated steps: " + e);
                         response.setStatus(Status.SERVER_ERROR_INTERNAL);
                         response.setEntity(
                                 "Error while handling an HTTP client call\n\n" + e.toString(),

--- a/src/main/java/io/naftiko/engine/exposes/OperationStepExecutor.java
+++ b/src/main/java/io/naftiko/engine/exposes/OperationStepExecutor.java
@@ -127,6 +127,11 @@ public class OperationStepExecutor {
             Map<String, Object> baseParameters) {
         HandlingContext lastContext = null;
         StepExecutionContext stepContext = new StepExecutionContext();
+        Map<String, Object> runtimeParameters = new ConcurrentHashMap<>();
+
+        if (baseParameters != null) {
+            runtimeParameters.putAll(baseParameters);
+        }
 
         if (steps == null || steps.isEmpty()) {
             return new StepExecutionResult(lastContext, stepContext);
@@ -135,7 +140,7 @@ public class OperationStepExecutor {
         for (OperationStepSpec step : steps) {
             switch (step) {
                 case OperationStepCallSpec callStep -> {
-                    lastContext = executeCallStep(callStep, baseParameters);
+                    lastContext = executeCallStep(callStep, runtimeParameters);
 
                     if (lastContext == null) {
                         throw new IllegalArgumentException("Invalid call format: "
@@ -155,6 +160,8 @@ public class OperationStepExecutor {
                             JsonNode stepOutput = mapper
                                     .readTree(lastContext.clientResponse.getEntity().getText());
                             stepContext.storeStepOutput(callStep.getName(), stepOutput);
+                            addStepOutputToParameters(runtimeParameters, callStep.getName(),
+                                    stepOutput);
                         } catch (Exception ignoreJsonParseError) {
                             // Ignore non-JSON call output for lookup indexing
                         }
@@ -170,7 +177,7 @@ public class OperationStepExecutor {
                     }
 
                     String resolvedLookupValue = Resolver.resolveMustacheTemplate(
-                            lookupStep.getLookupValue(), baseParameters);
+                            lookupStep.getLookupValue(), runtimeParameters);
 
                     JsonNode lookupResult = LookupExecutor.executeLookup(indexData,
                             lookupStep.getMatch(), resolvedLookupValue,
@@ -198,7 +205,15 @@ public class OperationStepExecutor {
         Map<String, Object> stepParams = new ConcurrentHashMap<>(baseParameters);
 
         if (callStep.getWith() != null) {
-            stepParams.putAll(callStep.getWith());
+            for (Map.Entry<String, Object> entry : callStep.getWith().entrySet()) {
+                Object rawValue = entry.getValue();
+                if (rawValue instanceof String rawStringValue) {
+                    stepParams.put(entry.getKey(),
+                            Resolver.resolveMustacheTemplate(rawStringValue, stepParams));
+                } else {
+                    stepParams.put(entry.getKey(), rawValue);
+                }
+            }
         }
 
         if (callStep.getCall() != null) {
@@ -214,6 +229,20 @@ public class OperationStepExecutor {
         }
 
         return null;
+    }
+
+    /**
+     * Expose each step JSON output under the step name so downstream templates can reference
+     * fields with syntax like {{step-name.field}}.
+     */
+    private void addStepOutputToParameters(Map<String, Object> runtimeParameters, String stepName,
+            JsonNode stepOutput) {
+        if (runtimeParameters == null || stepName == null || stepOutput == null) {
+            return;
+        }
+
+        Object converted = mapper.convertValue(stepOutput, Object.class);
+        runtimeParameters.put(stepName, converted);
     }
 
     /**


### PR DESCRIPTION
Step-level `with` values were evaluated only against the initial base parameters. As a result, references like `{{fetch-me-user.userid}}` could not resolve in later steps because previous call outputs were not available in the template context.

Changes:
- Introduce runtime parameter map persisted across step execution.
- Store each call step JSON output under its step name in runtime parameters.
- Resolve string values inside step `with` before request construction.
- Use runtime parameters for lookup value template resolution as well.