### PR TITLE
feat: publishing wiki with Github Actions

### DIFF
--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -1,0 +1,45 @@
+name: Publish Wiki
+
+on:
+  workflow_dispatch:
+
+
+jobs:
+  Update-Wiki:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: update wiki data
+      env:
+        GH_WIKI_PUBLISH_TOKEN: ${{ secrets.GH_WIKI_PUBLISH_TOKEN }}
+        WIKI_DIR: src/main/resources/wiki
+      run: |
+        echo $GITHUB_ACTOR
+        WIKI_COMMIT_MESSAGE='Automatically publish wiki'
+        GIT_REPOSITORY_URL="https://${GH_WIKI_PUBLISH_TOKEN}@${GITHUB_SERVER_URL#https://}/$GITHUB_REPOSITORY.wiki.git"
+
+        echo "Checking out wiki repository"
+        tmp_dir=$(mktemp -d -t ci-XXXXXXXXXX)
+        (
+            cd "$tmp_dir" || exit 1
+            git init
+            git config user.name $GITHUB_ACTOR
+            git config user.email $GITHUB_ACTOR@users.noreply.github.com
+            git pull "$GIT_REPOSITORY_URL"
+            echo "Removing Files, ensuring deletion."
+            rm -r -f ./*
+        ) || exit 1
+
+        echo "Copying contents of $WIKI_DIR"
+        cp -R $WIKI_DIR/. "$tmp_dir"
+
+        echo "Committing and pushing changes"
+        (
+            cd "$tmp_dir" || exit 1
+            git add .
+            git commit -m "$WIKI_COMMIT_MESSAGE"
+            git push --set-upstream "$GIT_REPOSITORY_URL" master
+        ) || exit 1
+
+        rm -rf "$tmp_dir"

--- a/src/main/resources/wiki/Home.md
+++ b/src/main/resources/wiki/Home.md
@@ -1,0 +1,31 @@
+Welcome to Naftiko Framework, the fist Open Source project for [Spec-Driven Integration](https://github.com/naftiko/framework/wiki/Spec%E2%80%90Driven-Integration) reinventing API integration for the AI era with governed and versatile capabilities that streamline API sprawl from massive SaaS and microservices growth.
+
+<img src="https://naftiko.github.io/docs/images/technology/architecture_capability.png" width="600">
+
+Each capability is a coarse piece of domain that consumes existing HTTP-based APIs then exposes them in several protocols to enable AI integration and self-integrating agents. Naftiko Framework includes a specification, an engine and a CLI.
+
+| Feature | Description |
+|---|---|
+| Spec-Driven | Declare capabilities entirely in **YAML** — no Java required |
+| Multi-Protocol Servers | Expose capabilities via **MCP**, **SKILL**, or **REST** servers out of the box |
+| Data Format Conversion | Transform **Protobuf**, **XML**, **YAML**, **CSV**, and **Avro** payloads into JSON |
+| HTTP API Consumption | Connect to any HTTP-based API with built-in authentication support |
+| Templating & Querying | Use **Mustache** templates and **JSONPath** expressions for flexible data mapping |
+| AI Native | Designed for Context Engineering and Agent Orchestration, making capabilities directly consumable by AI agents |
+| Docker Native | Ships as a ready-to-run **Docker** container |
+| Extensible | Open-source core extensible with new protocols and adapters |
+
+Here are additional documents to learn more:
+
+- :rowboat: [Installation](https://github.com/naftiko/framework/wiki/Installation)
+- :sailboat: [Tutorial](https://github.com/naftiko/framework/wiki/Tutorial)
+- :ship: [Use cases](https://github.com/naftiko/framework/wiki/Use-Cases)
+- :anchor: [Specification](https://github.com/naftiko/framework/wiki/Specification)
+- :mega: [Releases](https://github.com/naftiko/framework/wiki/Releases)
+- :telescope: [Roadmap](https://github.com/naftiko/framework/wiki/Roadmap)
+- :nut_and_bolt: [Contribute](https://github.com/naftiko/framework/wiki/Contribute)
+- :ocean: [FAQ](https://github.com/naftiko/framework/wiki/FAQ)
+
+Please join the community of users and contributors in [this GitHub Discussion forum!](https://github.com/orgs/naftiko/discussions).
+
+<img src="https://naftiko.github.io/docs/images/navi/navi_hello.svg" width="50">


### PR DESCRIPTION
Github Action making the project documentation automatically update the wiki when a new release is published, so that users always see documentation that matches the latest version of the software.