### PR TITLE
chore: further expanded test coverage

### DIFF
--- a/src/test/java/io/naftiko/CapabilityBootstrapTest.java
+++ b/src/test/java/io/naftiko/CapabilityBootstrapTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.naftiko;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.naftiko.spec.NaftikoSpec;
+import org.junit.jupiter.api.Test;
+
+public class CapabilityBootstrapTest {
+
+    @Test
+    public void constructorShouldFailWhenNoExposesDefined() throws Exception {
+        NaftikoSpec spec = parseYaml("""
+                naftiko: "0.5"
+                capability:
+                  exposes: []
+                  consumes: []
+                """);
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+                () -> new Capability(spec));
+        assertEquals("Capability must expose at least one endpoint.", error.getMessage());
+    }
+
+    @Test
+    public void constructorShouldCreateServerAndClientAdapters() throws Exception {
+        NaftikoSpec spec = parseYaml("""
+                naftiko: "0.5"
+                capability:
+                  exposes:
+                    - type: "rest"
+                      address: "localhost"
+                      port: 0
+                      namespace: "orders-api"
+                      resources:
+                        - path: "/orders"
+                          operations:
+                            - method: "GET"
+                              name: "list-orders"
+                  consumes:
+                    - type: "http"
+                      namespace: "orders-client"
+                      baseUri: "http://localhost:8080"
+                      resources:
+                        - path: "/orders"
+                          name: "orders"
+                          operations:
+                            - method: "GET"
+                              name: "list-orders"
+                """);
+
+        Capability capability = new Capability(spec);
+
+        assertEquals(1, capability.getServerAdapters().size());
+        assertEquals(1, capability.getClientAdapters().size());
+    }
+
+    @Test
+    public void constructorShouldResolveRuntimeExternalReferences() throws Exception {
+        NaftikoSpec spec = parseYaml("""
+                naftiko: "0.5"
+                externalRefs:
+                  - type: variables
+                    keys:
+                      env_path: PATH
+                capability:
+                  exposes:
+                    - type: "rest"
+                      address: "localhost"
+                      port: 0
+                      namespace: "orders-api"
+                      resources:
+                        - path: "/orders"
+                          operations:
+                            - method: "GET"
+                              name: "list-orders"
+                  consumes: []
+                """);
+
+        Capability capability = new Capability(spec);
+
+        Object value = capability.getExternalRefVariables().get("env_path");
+        assertTrue(value != null && !String.valueOf(value).isBlank());
+    }
+
+    private static NaftikoSpec parseYaml(String yaml) throws Exception {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        return mapper.readValue(yaml, NaftikoSpec.class);
+    }
+}

--- a/src/test/java/io/naftiko/cli/FileGeneratorTest.java
+++ b/src/test/java/io/naftiko/cli/FileGeneratorTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.naftiko.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.io.FileNotFoundException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import io.naftiko.cli.enums.FileFormat;
+
+public class FileGeneratorTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    public void generateCapabilityFileShouldRenderYamlAndJsonTemplates() throws Exception {
+        String capabilityName = "orders-" + UUID.randomUUID().toString().replace("-", "");
+        Path yaml = Paths.get(capabilityName + ".capability.yaml");
+        Path json = Paths.get(capabilityName + ".capability.json");
+        try {
+            FileGenerator.generateCapabilityFile(capabilityName, FileFormat.YAML,
+                    "https://api.example.com", "8080");
+            FileGenerator.generateCapabilityFile(capabilityName, FileFormat.JSON,
+                    "https://api.example.com", "8080");
+            assertTrue(Files.exists(yaml));
+            assertTrue(Files.exists(json));
+
+            String yamlContent = Files.readString(yaml);
+            String jsonContent = Files.readString(json);
+
+            assertTrue(yamlContent.contains(capabilityName));
+            assertTrue(yamlContent.contains("https://api.example.com"));
+            assertTrue(yamlContent.contains("8080"));
+            assertTrue(yamlContent.contains("{{path}}"));
+
+            assertTrue(jsonContent.contains(capabilityName));
+            assertTrue(jsonContent.contains("https://api.example.com"));
+            assertTrue(jsonContent.contains("8080"));
+        } finally {
+            Files.deleteIfExists(yaml);
+            Files.deleteIfExists(json);
+        }
+    }
+
+    @Test
+    public void generateCapabilityFileShouldFailForUnknownTemplate() {
+        FileNotFoundException error = assertThrows(FileNotFoundException.class,
+                () -> FileGenerator.generateCapabilityFile("orders", FileFormat.UNKNOWN,
+                        "https://api.example.com", "8080"));
+
+        assertEquals("Template not found: templates/capability.unknown.mustache",
+                error.getMessage());
+    }
+}

--- a/src/test/java/io/naftiko/cli/ValidateCommandTest.java
+++ b/src/test/java/io/naftiko/cli/ValidateCommandTest.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.naftiko.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class ValidateCommandTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    public void loadFileShouldParseYamlAndJson() throws Exception {
+        Path yaml = tempDir.resolve("sample.yaml");
+        Files.writeString(yaml, "name: test\n");
+
+        Path json = tempDir.resolve("sample.json");
+        Files.writeString(json, "{\"name\":\"test\"}\n");
+
+        ValidateCommand command = new ValidateCommand();
+        Method loadFile = ValidateCommand.class.getDeclaredMethod("loadFile", File.class);
+        loadFile.setAccessible(true);
+
+        JsonNode yamlNode = (JsonNode) loadFile.invoke(command, yaml.toFile());
+        JsonNode jsonNode = (JsonNode) loadFile.invoke(command, json.toFile());
+
+        assertEquals("test", yamlNode.path("name").asText());
+        assertEquals("test", jsonNode.path("name").asText());
+    }
+
+    @Test
+    public void loadFileShouldRejectUnsupportedExtensions() throws Exception {
+        Path txt = tempDir.resolve("sample.txt");
+        Files.writeString(txt, "content\n");
+
+        ValidateCommand command = new ValidateCommand();
+        Method loadFile = ValidateCommand.class.getDeclaredMethod("loadFile", File.class);
+        loadFile.setAccessible(true);
+
+        InvocationTargetException error = assertThrows(InvocationTargetException.class,
+                () -> loadFile.invoke(command, txt.toFile()));
+
+        assertEquals(IllegalArgumentException.class, error.getCause().getClass());
+        assertEquals("Unsupported file format. Only .yaml, .yml, and .json are supported.",
+                error.getCause().getMessage());
+    }
+}

--- a/src/test/java/io/naftiko/engine/exposes/mcp/ProtocolDispatcherNegativeTest.java
+++ b/src/test/java/io/naftiko/engine/exposes/mcp/ProtocolDispatcherNegativeTest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.naftiko.engine.exposes.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import java.io.File;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.naftiko.Capability;
+import io.naftiko.spec.NaftikoSpec;
+
+public class ProtocolDispatcherNegativeTest {
+
+    private ObjectMapper mapper;
+    private ProtocolDispatcher dispatcher;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        mapper = new ObjectMapper();
+        String resourcePath = "src/test/resources/mcp-resources-prompts-capability.yaml";
+        File file = new File(resourcePath);
+        ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
+        yamlMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        NaftikoSpec spec = yamlMapper.readValue(file, NaftikoSpec.class);
+        Capability capability = new Capability(spec);
+        dispatcher = new ProtocolDispatcher((McpServerAdapter) capability.getServerAdapters().get(0));
+    }
+
+    @Test
+    public void dispatchShouldRejectInvalidJsonRpcVersion() throws Exception {
+        JsonNode response = dispatcher.dispatch(mapper.readTree("""
+                {"jsonrpc":"1.0","id":1,"method":"ping"}
+                """));
+
+        assertEquals(-32600, response.path("error").path("code").asInt());
+    }
+
+    @Test
+    public void dispatchShouldRejectUnknownMethod() throws Exception {
+        JsonNode response = dispatcher.dispatch(mapper.readTree("""
+                {"jsonrpc":"2.0","id":2,"method":"unknown/method"}
+                """));
+
+        assertEquals(-32601, response.path("error").path("code").asInt());
+    }
+
+    @Test
+    public void dispatchShouldRejectToolsCallWithoutParams() throws Exception {
+        JsonNode response = dispatcher.dispatch(mapper.readTree("""
+                {"jsonrpc":"2.0","id":3,"method":"tools/call"}
+                """));
+
+        assertEquals(-32602, response.path("error").path("code").asInt());
+        assertEquals("Invalid params: missing params", response.path("error").path("message").asText());
+    }
+
+    @Test
+    public void dispatchShouldRejectResourcesReadWithoutUri() throws Exception {
+        JsonNode response = dispatcher.dispatch(mapper.readTree("""
+                {"jsonrpc":"2.0","id":4,"method":"resources/read","params":{}}
+                """));
+
+        assertEquals(-32602, response.path("error").path("code").asInt());
+        assertEquals("Invalid params: uri is required", response.path("error").path("message").asText());
+    }
+
+    @Test
+    public void dispatchShouldRejectPromptsGetWithoutName() throws Exception {
+        JsonNode response = dispatcher.dispatch(mapper.readTree("""
+                {"jsonrpc":"2.0","id":5,"method":"prompts/get","params":{}}
+                """));
+
+        assertNotNull(response.path("error"));
+        assertEquals(-32602, response.path("error").path("code").asInt());
+        assertEquals("Invalid params: name is required", response.path("error").path("message").asText());
+    }
+}

--- a/src/test/java/io/naftiko/engine/exposes/mcp/ResourceHandlerSafetyTest.java
+++ b/src/test/java/io/naftiko/engine/exposes/mcp/ResourceHandlerSafetyTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.naftiko.engine.exposes.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import io.naftiko.spec.exposes.McpServerResourceSpec;
+
+public class ResourceHandlerSafetyTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    public void readShouldRejectPathTraversalSegments() throws Exception {
+        Path docs = tempDir.resolve("docs");
+        Files.createDirectories(docs);
+        Files.writeString(docs.resolve("readme.md"), "hello\n");
+                Files.writeString(tempDir.resolve("secrets.txt"), "do-not-read\n");
+
+        ResourceHandler handler = new ResourceHandler(null,
+                List.of(staticResource("docs", "data://docs", docs)));
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+                () -> handler.read("data://docs/../secrets.txt"));
+        assertEquals("Path traversal detected for resource URI: data://docs/../secrets.txt",
+                error.getMessage());
+    }
+
+    @Test
+    public void readShouldRejectDirectoryAsConcreteTarget() throws Exception {
+        Path docs = tempDir.resolve("docs");
+        Files.createDirectories(docs);
+
+        ResourceHandler handler = new ResourceHandler(null,
+                List.of(staticResource("docs", "data://docs", docs)));
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+                () -> handler.read("data://docs"));
+        assertEquals("Resource URI resolves to a directory, not a file: data://docs",
+                error.getMessage());
+    }
+
+    @Test
+    public void readShouldReturnTextAndDetectedMimeTypeForMarkdown() throws Exception {
+        Path docs = tempDir.resolve("docs");
+        Files.createDirectories(docs);
+        Files.writeString(docs.resolve("guide.md"), "# guide\n");
+
+        ResourceHandler handler = new ResourceHandler(null,
+                List.of(staticResource("docs", "data://docs", docs)));
+
+        List<ResourceHandler.ResourceContent> content = handler.read("data://docs/guide.md");
+
+        assertEquals(1, content.size());
+        assertEquals("text/markdown", content.get(0).mimeType);
+        assertEquals("# guide\n", content.get(0).text);
+    }
+
+    @Test
+    public void matchTemplateShouldNotMatchAcrossSlashBoundaries() {
+        Map<String, String> params = ResourceHandler.matchTemplate(
+                "data://users/{userId}/profile", "data://users/a/b/profile");
+
+        assertEquals(null, params);
+    }
+
+    private static McpServerResourceSpec staticResource(String name, String uri, Path dir) {
+        McpServerResourceSpec spec = new McpServerResourceSpec();
+        spec.setName(name);
+        spec.setUri(uri);
+        spec.setLocation(dir.toUri().toString());
+        return spec;
+    }
+}

--- a/src/test/java/io/naftiko/engine/exposes/rest/AuthenticationIntegrationTest.java
+++ b/src/test/java/io/naftiko/engine/exposes/rest/AuthenticationIntegrationTest.java
@@ -35,7 +35,7 @@ public class AuthenticationIntegrationTest {
     public void bearerAuthenticationShouldReturnUnauthorizedWithoutTokenAndOkWithToken()
             throws Exception {
         String yaml = """
-                naftiko: "0.4"
+                naftiko: "0.5"
                 info:
                   label: "Auth test"
                   description: "Auth test"
@@ -85,7 +85,7 @@ public class AuthenticationIntegrationTest {
     public void apiKeyAuthenticationShouldReturnUnauthorizedWithoutHeaderAndOkWithHeader()
             throws Exception {
         String yaml = """
-                naftiko: "0.4"
+                naftiko: "0.5"
                 info:
                   label: "Auth test"
                   description: "Auth test"

--- a/src/test/java/io/naftiko/engine/exposes/rest/RestServerAdapterTest.java
+++ b/src/test/java/io/naftiko/engine/exposes/rest/RestServerAdapterTest.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.naftiko.engine.exposes.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.lang.reflect.Method;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.restlet.Restlet;
+import org.restlet.security.ChallengeAuthenticator;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.naftiko.Capability;
+import io.naftiko.spec.NaftikoSpec;
+
+public class RestServerAdapterTest {
+
+    @Test
+    public void basicAuthShouldBuildChallengeAuthenticatorChain() throws Exception {
+        RestServerAdapter adapter = adapterFromYaml("""
+                naftiko: "0.5"
+                capability:
+                  exposes:
+                    - type: "rest"
+                      address: "localhost"
+                      port: 0
+                      namespace: "api"
+                      authentication:
+                        type: basic
+                        username: demo
+                        password: demo
+                      resources:
+                        - path: "/orders"
+                          operations:
+                            - method: "GET"
+                              name: "list-orders"
+                  consumes: []
+                """);
+
+        Restlet chain = adapter.getServer().getNext();
+        assertTrue(chain instanceof ChallengeAuthenticator);
+    }
+
+    @Test
+    public void digestAuthShouldBuildChallengeAuthenticatorChain() throws Exception {
+        RestServerAdapter adapter = adapterFromYaml("""
+                naftiko: "0.5"
+                capability:
+                  exposes:
+                    - type: "rest"
+                      address: "localhost"
+                      port: 0
+                      namespace: "api"
+                      authentication:
+                        type: digest
+                        username: demo
+                        password: demo
+                      resources:
+                        - path: "/orders"
+                          operations:
+                            - method: "GET"
+                              name: "list-orders"
+                  consumes: []
+                """);
+
+        Restlet chain = adapter.getServer().getNext();
+        assertTrue(chain instanceof ChallengeAuthenticator);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void extractAllowedVariablesShouldReturnAllExternalRefKeys() throws Exception {
+        NaftikoSpec spec = parseYaml("""
+                naftiko: "0.5"
+                externalRefs:
+                  - type: variables
+                    keys:
+                      auth_token: AUTH_TOKEN
+                      api_key: API_KEY
+                capability:
+                  exposes: []
+                  consumes: []
+                """);
+
+        Method method = RestServerAdapter.class
+                .getDeclaredMethod("extractAllowedVariables", io.naftiko.spec.NaftikoSpec.class);
+        method.setAccessible(true);
+        Set<String> keys = (Set<String>) method.invoke(null, spec);
+
+        assertEquals(2, keys.size());
+        assertTrue(keys.contains("auth_token"));
+        assertTrue(keys.contains("api_key"));
+    }
+
+    private static RestServerAdapter adapterFromYaml(String yaml) throws Exception {
+        NaftikoSpec spec = parseYaml(yaml);
+        Capability capability = new Capability(spec);
+        return (RestServerAdapter) capability.getServerAdapters().get(0);
+    }
+
+    private static NaftikoSpec parseYaml(String yaml) throws Exception {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        return mapper.readValue(yaml, NaftikoSpec.class);
+    }
+}


### PR DESCRIPTION
## Related Issue

Relates to #139

---

## What does this PR do?

 - Increased test coverage towards CLI/Capability/REST/MCP features
 - Fix FileGenerator test path assumptions

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context

GPT-5.3-Codex