### PR TITLE
feat: checking proper runtime of cli binaries

### DIFF
--- a/.github/workflows/publish-cli-bin.yml
+++ b/.github/workflows/publish-cli-bin.yml
@@ -65,27 +65,41 @@ jobs:
           files: target/${{ matrix.artifact_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   test-binary:
-    name: Test binary with register.capability.yml
+    name: Test binary on ${{ matrix.os }}
     needs: build-native
-    runs-on: macos-latest  # pour tester uniquement sur macOS
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact_name: naftiko-cli-linux-amd64
+          - os: macos-latest
+            artifact_name: naftiko-cli-macos-arm64
+          - os: windows-latest
+            artifact_name: naftiko-cli-windows-amd64.exe
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4  # récup le register.capability.yml
-
-      - name: Download macOS binary
+      - name: Download binary
         uses: actions/download-artifact@v4
         with:
-          name: naftiko-cli-macos-arm64
+          name: ${{ matrix.artifact_name }}
           path: ./bin
 
       - name: Make binary executable
-        run: chmod +x ./bin/naftiko-cli-macos-arm64
+        if: runner.os != 'Windows'
+        run: chmod +x ./bin/${{ matrix.artifact_name }}
 
-      - name: Run binary with register.capability.yml
+      - name: Test create + validate (Unix)
+        if: runner.os != 'Windows'
         run: |
-          output=$(./bin/naftiko-cli-macos-arm64 v src/test/resources/register.capability.yml)
-          exit_code=$?
-          echo "Output: $output"
-          echo "Exit code: $exit_code"
+          printf "test\nhttps://api.com\n8080\n" | ./bin/${{ matrix.artifact_name }} create capability
+          ./bin/${{ matrix.artifact_name }} v test.naftiko.yaml
+
+      - name: Test create + validate (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          "test`nhttps://api.com`n8080`n" | & ./bin/${{ matrix.artifact_name }} create capability
+          & ./bin/${{ matrix.artifact_name }} v test.naftiko.yaml


### PR DESCRIPTION
## Related Issue

Closes [#93](https://github.com/naftiko/framework/issues/93)
---

## What does this PR do?

We needed to be sure that when there's an update on the framework, the cli binaries are still working as intended, via an automated github action.

---

## Checklist

- [X] CI is green (build, tests, schema validation, security scans)
- [X] Rebased on latest `main`
- [X] Small and focused — one concern per PR
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---
