### PR TITLE
Feat/publish maven artifacts

### DIFF
--- a/.github/workflows/publish-mvn-release.yml
+++ b/.github/workflows/publish-mvn-release.yml
@@ -1,11 +1,23 @@
 name: Publish Release to GitHub Packages
 on:
-  push:
-    branches: [main]
+  release:
+    types: [created]
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
-      - name: Dummy - always green
-        run: echo "ok"
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - name: Strip SNAPSHOT from version
+        run: mvn versions:set -DremoveSnapshot -DgenerateBackupPoms=false
+      - name: Publish release
+        run: mvn --batch-mode deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -6,6 +6,16 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
-      - name: Dummy - always green
-        run: echo "ok"
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - name: Publish snapshot
+        run: mvn --batch-mode deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,18 @@
         <jetty.version>12.0.25</jetty.version>
         <json-smart.version>2.5.2</json-smart.version>
     </properties>
-
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Releases</name>
+            <url>https://maven.pkg.github.com/naftiko/framework</url>
+        </repository>
+        <snapshotRepository>
+            <id>github</id>
+            <name>GitHub Snapshots</name>
+            <url>https://maven.pkg.github.com/naftiko/framework</url>
+        </snapshotRepository>
+    </distributionManagement>
     <dependencies>
         <dependency>
             <groupId>info.picocli</groupId>


### PR DESCRIPTION
## Related Issue

Closes https://github.com/naftiko/framework/issues/128
---

## What does this PR do?

2 workflows 
publish-snapshot.yml — triggered on push to main
Publishes 1.0.0-alpha1-SNAPSHOT

publish-release.yml — triggered only on tag/release
Publishes 1.0.0-alpha1 (w/o SNAPSHOT)
Stable version, production ready.

---

## Checklist

- [X] CI is green (build, tests, schema validation, security scans)
- [X] Rebased on latest `main`
- [X] Small and focused — one concern per PR
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---
