### PR TITLE
Chore/sync schema and rules to fabric

### DIFF
--- a/.github/workflows/synchronize-schema-and-rules.yml
+++ b/.github/workflows/synchronize-schema-and-rules.yml
@@ -1,0 +1,12 @@
+name: Synchronize Schema and Rules to Fabric
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sync-to-fabric:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Dummy sync
+        run: echo "Dummy sync"

--- a/src/main/resources/rules/functions/unique-namespaces.js
+++ b/src/main/resources/rules/functions/unique-namespaces.js
@@ -1,4 +1,4 @@
-module.exports = function uniqueNamespaces(targetVal) {
+export default function uniqueNamespaces(targetVal) {
   if (!targetVal || typeof targetVal !== "object") {
     return;
   }


### PR DESCRIPTION
## Related Issue

Closes https://github.com/naftiko/fabric/issues/57

---

## What does this PR do?

- Add a dummy GitHub action (goal is tho synchronize schemas and rules with fabric vs code extension)
- Fix the export default for unique-namespace function

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main`
- [ ] Small and focused — one concern per PR
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

<!-- If this PR was created or assisted by an AI agent, provide metadata below (YAML) -->
<!-- Example fields: agent_name, tool, run_id, confidence, source_event -->
