### PR TITLE
feat: support relative file:///./path in BindingResolver, fix Windows…

### DIFF
--- a/src/main/java/io/naftiko/engine/BindingResolver.java
+++ b/src/main/java/io/naftiko/engine/BindingResolver.java
@@ -151,8 +151,14 @@ public class BindingResolver {
     @SuppressWarnings("unchecked")
     private Map<String, Object> parseFileContent(String uriString) throws IOException {
         try {
-            URI uri = URI.create(uriString);
-            Path filePath = Paths.get(uri.getPath());
+            Path filePath;
+            if (uriString.startsWith("file:///./") || uriString.startsWith("file://./")) {
+                // Relative path: resolve against current working directory
+                String relative = uriString.replaceFirst("file:///\\./|file://\\./", "");
+                filePath = Path.of(System.getProperty("user.dir")).resolve(relative);
+            } else {
+                filePath = Path.of(URI.create(uriString));
+            }
 
             if (!Files.exists(filePath)) {
                 throw new IOException("File not found: " + filePath);

--- a/src/test/java/io/naftiko/engine/BindingResolverTest.java
+++ b/src/test/java/io/naftiko/engine/BindingResolverTest.java
@@ -96,6 +96,30 @@ public class BindingResolverTest {
                 error.getMessage());
     }
 
+    @Test
+    public void resolveFileBindingShouldSupportRelativePathWithDotSlash() throws Exception {
+        // Simulate file:///./subdir/secrets.yaml resolved against user.dir (cwd)
+        Path cwd = Path.of(System.getProperty("user.dir"));
+        Path subDir = cwd.resolve("test-binds-tmp");
+        Files.createDirectories(subDir);
+        Path secretsFile = subDir.resolve("secrets.yaml");
+        Files.writeString(secretsFile, "my-token: relative-value\n");
+
+        try {
+            BindingSpec bind = new BindingSpec();
+            bind.setLocation("file:///./test-binds-tmp/secrets.yaml");
+            bind.setKeys(keysSpec(Map.of("TOKEN", "my-token")));
+
+            BindingResolver resolver = new BindingResolver();
+            Map<String, String> resolved = resolver.resolveFileBinding(bind);
+
+            assertEquals("relative-value", resolved.get("TOKEN"));
+        } finally {
+            Files.deleteIfExists(secretsFile);
+            Files.deleteIfExists(subDir);
+        }
+    }
+
     private static BindingSpec fileBind(Path path, Map<String, String> keys) {
         BindingSpec bind = new BindingSpec();
         bind.setLocation(toResolverFriendlyFileUri(path));
@@ -116,10 +140,6 @@ public class BindingResolverTest {
     }
 
     private static String toResolverFriendlyFileUri(Path path) {
-        String normalized = path.toAbsolutePath().toString().replace('\\', '/');
-        if (normalized.length() > 2 && normalized.charAt(1) == ':') {
-            normalized = normalized.substring(2);
-        }
-        return "file://" + normalized;
+        return path.toAbsolutePath().toUri().toString();
     }
 }


### PR DESCRIPTION
## Related Issue

N/A — standalone feature

---

## What does this PR do?

`BindingResolver` previously used `URI.create(location).getPath()` to resolve `file://` URIs, which does not support relative paths. A location like `file:///./shared/secrets.yaml` would resolve to `\.\shared\secrets.yaml` on Windows (absolute from drive root) instead of relative to the current working directory.

This PR adds support for `file:///./` and `file://./` prefixes: the relative portion is resolved against `System.getProperty("user.dir")`, allowing capability authors to ship secrets files alongside their YAML without hardcoding absolute paths.

Also fixes a pre-existing bug in `BindingResolverTest` where `toResolverFriendlyFileUri()` was stripping the drive letter on Windows, causing 2 tests to silently fail when run on drives other than C:.

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow Conventional Commits

---

## Agent Context (optional)

agent_name: GitHub Copilot
tool: VS Code Copilot Chat
model: Claude Sonnet 4.6
confidence: high