### PR TITLE
fix(resolver): recurse into nested object properties without top-leve…

### DIFF
--- a/src/main/java/io/naftiko/engine/BindingResolver.java
+++ b/src/main/java/io/naftiko/engine/BindingResolver.java
@@ -18,7 +18,6 @@ import java.lang.Iterable;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/io/naftiko/engine/Resolver.java
+++ b/src/main/java/io/naftiko/engine/Resolver.java
@@ -295,9 +295,15 @@ public class Resolver {
             for (OutputParameterSpec prop : spec.getProperties()) {
                 String propName = prop.getName();
                 String propMapping = prop.getMapping();
-                JsonNode val = Converter.jsonPathExtract(clientRoot, propMapping);
-                val = Converter.applyMaxLengthIfNeeded(prop, val);
-                if (val == null) {
+                JsonNode val;
+                if (propMapping == null && "object".equalsIgnoreCase(prop.getType())
+                        && prop.getProperties() != null && !prop.getProperties().isEmpty()) {
+                    val = resolveOutputMappings(prop, clientRoot, mapper);
+                } else {
+                    val = Converter.jsonPathExtract(clientRoot, propMapping);
+                    val = Converter.applyMaxLengthIfNeeded(prop, val);
+                }
+                if (val == null || val instanceof NullNode) {
                     outObj.putNull(propName);
                 } else {
                     outObj.set(propName, val);

--- a/src/test/java/io/naftiko/engine/ResolverTest.java
+++ b/src/test/java/io/naftiko/engine/ResolverTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.naftiko.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.naftiko.spec.OutputParameterSpec;
+
+public class ResolverTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /**
+     * Regression test for: nested object property without a top-level mapping (e.g. "specs") must
+     * recurse into its own properties and resolve them against the same root, instead of returning
+     * null.
+     *
+     * <p>Scenario: a "get-ship" output spec declares a "specs" property of type object with no
+     * mapping key. Its children (yearBuilt, tonnage, length) each have their own JSONPath mappings
+     * that point to flat fields on the API response ($.year_built, $.gross_tonnage,
+     * $.dimensions.length_overall). Before the fix, "specs" was always resolved as NullNode
+     * because the resolver tried to jsonPathExtract with a null mapping.</p>
+     */
+    @Test
+    public void resolveOutputMappingsShouldRecurseIntoNestedObjectWithoutTopLevelMapping()
+            throws Exception {
+        JsonNode apiResponse = MAPPER.readTree("""
+                {
+                  "imo_number": "IMO-9321483",
+                  "vessel_name": "Northern Star",
+                  "vessel_type": "cargo",
+                  "flag_code": "NO",
+                  "operational_status": "active",
+                  "year_built": 2015,
+                  "gross_tonnage": 42000,
+                  "dimensions": {
+                    "length_overall": 229
+                  }
+                }
+                """);
+
+        // Build the "specs" sub-spec (type object, no mapping, has properties)
+        OutputParameterSpec yearBuilt = new OutputParameterSpec("yearBuilt", "number", null, "$.year_built");
+        OutputParameterSpec tonnage = new OutputParameterSpec("tonnage", "number", null, "$.gross_tonnage");
+        OutputParameterSpec length = new OutputParameterSpec("length", "number", null, "$.dimensions.length_overall");
+
+        OutputParameterSpec specsSpec = new OutputParameterSpec();
+        specsSpec.setName("specs");
+        specsSpec.setType("object");
+        specsSpec.getProperties().addAll(List.of(yearBuilt, tonnage, length));
+
+        // Build the root object spec
+        OutputParameterSpec imoSpec = new OutputParameterSpec("imo", "string", null, "$.imo_number");
+        OutputParameterSpec nameSpec = new OutputParameterSpec("name", "string", null, "$.vessel_name");
+        OutputParameterSpec statusSpec = new OutputParameterSpec("status", "string", null, "$.operational_status");
+
+        OutputParameterSpec rootSpec = new OutputParameterSpec();
+        rootSpec.setType("object");
+        rootSpec.getProperties().addAll(List.of(imoSpec, nameSpec, statusSpec, specsSpec));
+
+        JsonNode result = Resolver.resolveOutputMappings(rootSpec, apiResponse, MAPPER);
+
+        assertNotNull(result);
+        assertTrue(result.isObject());
+        assertEquals("IMO-9321483", result.path("imo").asText());
+        assertEquals("Northern Star", result.path("name").asText());
+        assertEquals("active", result.path("status").asText());
+
+        JsonNode specs = result.path("specs");
+        assertFalse(specs.isMissingNode(), "specs must be present");
+        assertFalse(specs.isNull(), "specs must not be null");
+        assertTrue(specs.isObject(), "specs must be an object");
+        assertEquals(2015, specs.path("yearBuilt").asInt());
+        assertEquals(42000, specs.path("tonnage").asInt());
+        assertEquals(229, specs.path("length").asInt());
+    }
+}

--- a/src/test/java/io/naftiko/engine/exposes/mcp/NestedObjectOutputMappingIntegrationTest.java
+++ b/src/test/java/io/naftiko/engine/exposes/mcp/NestedObjectOutputMappingIntegrationTest.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.naftiko.engine.exposes.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.File;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.naftiko.Capability;
+import io.naftiko.engine.exposes.OperationStepExecutor;
+import io.naftiko.spec.NaftikoSpec;
+import io.naftiko.spec.exposes.McpServerSpec;
+import io.naftiko.spec.exposes.McpServerToolSpec;
+
+/**
+ * Non-regression test for nested object output mapping.
+ *
+ * <p>Verifies end-to-end that a tool spec declaring a nested object property without a top-level
+ * mapping (e.g. "specs") correctly resolves its children against the raw API response,
+ * instead of producing null.</p>
+ *
+ * <p>Related fix: {@code Resolver#resolveOutputMappings} now recurses into sub-object
+ * properties when no mapping key is present at the object level.</p>
+ */
+public class NestedObjectOutputMappingIntegrationTest {
+
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+
+    private McpServerToolSpec toolSpec;
+    private OperationStepExecutor stepExecutor;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        String resourcePath = "src/test/resources/nested-object-output-capability.yaml";
+        File file = new File(resourcePath);
+        assertTrue(file.exists(), "Test fixture not found: " + resourcePath);
+
+        ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
+        yamlMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        NaftikoSpec spec = yamlMapper.readValue(file, NaftikoSpec.class);
+
+        Capability capability = new Capability(spec);
+        McpServerAdapter adapter = (McpServerAdapter) capability.getServerAdapters().get(0);
+        McpServerSpec mcpSpec = adapter.getMcpServerSpec();
+
+        toolSpec = mcpSpec.getTools().get(0);
+        stepExecutor = new OperationStepExecutor(null);
+    }
+
+    @Test
+    public void outputParametersShouldDeserializeNestedSpecsProperty() {
+        assertNotNull(toolSpec.getOutputParameters(), "outputParameters must not be null");
+        assertFalse(toolSpec.getOutputParameters().isEmpty(), "outputParameters must not be empty");
+
+        var rootSpec = toolSpec.getOutputParameters().get(0);
+        assertEquals("object", rootSpec.getType());
+
+        var specsProperty = rootSpec.getProperties().stream()
+                .filter(p -> "specs".equals(p.getName()))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(specsProperty, "specs property must be deserialized");
+        assertEquals("object", specsProperty.getType());
+        assertFalse(specsProperty.getProperties().isEmpty(), "specs must have child properties");
+    }
+
+    @Test
+    public void applyOutputMappingsShouldProduceNestedSpecsObject() throws Exception {
+        String apiResponse = """
+                {
+                  "imo_number": "IMO-9321483",
+                  "vessel_name": "Northern Star",
+                  "operational_status": "active",
+                  "year_built": 2015,
+                  "gross_tonnage": 42000,
+                  "dimensions": {
+                    "length_overall": 229
+                  }
+                }
+                """;
+
+        String result = stepExecutor.applyOutputMappings(apiResponse, toolSpec.getOutputParameters());
+
+        assertNotNull(result, "mapped result must not be null");
+
+        JsonNode node = JSON_MAPPER.readTree(result);
+        assertEquals("IMO-9321483", node.path("imo").asText());
+        assertEquals("Northern Star", node.path("name").asText());
+        assertEquals("active", node.path("status").asText());
+
+        JsonNode specs = node.path("specs");
+        assertFalse(specs.isNull(), "specs must not be null");
+        assertFalse(specs.isMissingNode(), "specs must be present");
+        assertTrue(specs.isObject(), "specs must be an object");
+        assertEquals(2015, specs.path("yearBuilt").asInt());
+        assertEquals(42000, specs.path("tonnage").asInt());
+        assertEquals(229, specs.path("length").asInt());
+    }
+}

--- a/src/test/resources/nested-object-output-capability.yaml
+++ b/src/test/resources/nested-object-output-capability.yaml
@@ -1,0 +1,64 @@
+# yaml-language-server: $schema=../../main/resources/schemas/naftiko-schema.json
+---
+naftiko: "1.0.0-alpha1"
+info:
+  label: "Nested Object Output Capability"
+  description: "Test fixture for verifying that output mappings correctly resolve nested object
+    properties without a top-level mapping key (regression for resolver nested object bug)."
+
+capability:
+  consumes:
+    - namespace: registry
+      type: http
+      baseUri: "http://localhost:9999"
+      resources:
+        - name: ship
+          path: "/ships/{{imo_number}}"
+          operations:
+            - name: get-ship
+              method: GET
+              inputParameters:
+                - name: imo_number
+                  in: path
+
+  exposes:
+    - type: mcp
+      address: "localhost"
+      port: 9099
+      namespace: test-tools
+      description: "Test MCP for nested object output mapping"
+      tools:
+        - name: get-ship
+          description: "Get ship details"
+          inputParameters:
+            - name: imo
+              type: string
+              description: "IMO number of the ship"
+              required: true
+          call: registry.get-ship
+          with:
+            imo_number: "{{imo}}"
+          outputParameters:
+            - type: object
+              properties:
+                imo:
+                  type: string
+                  mapping: "$.imo_number"
+                name:
+                  type: string
+                  mapping: "$.vessel_name"
+                status:
+                  type: string
+                  mapping: "$.operational_status"
+                specs:
+                  type: object
+                  properties:
+                    yearBuilt:
+                      type: number
+                      mapping: "$.year_built"
+                    tonnage:
+                      type: number
+                      mapping: "$.gross_tonnage"
+                    length:
+                      type: number
+                      mapping: "$.dimensions.length_overall"


### PR DESCRIPTION
## Related Issue

Closes #209

---

## What does this PR do?

When an `outputParameter` of type `object` declares child `properties` but no top-level `mapping` key, `Resolver#resolveOutputMappings` was calling `Converter.jsonPathExtract(clientRoot, null)`, which returns `NullNode` immediately — the child properties were never visited.

Added a guard in the property loop: if `propMapping == null` and the property is of type `object` with non-empty `properties`, call `resolveOutputMappings` recursively with the same `clientRoot`.

Also removes an unused `import java.nio.file.Paths` from `BindingResolver` introduced in 70a0f95.

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

agent_name: GitHub Copilot
model: claude-sonnet-4-6
tool: VS Code Copilot Chat
confidence: high
source_event: user reported specs field returning null when calling get-ship MCP tool
discovery_method: runtime observation + code inspection of Resolver#resolveOutputMappings
fix_branch: fix/resolver-nested-object-mapping