### PR TITLE
fix(resolver): JSON-serialize array params in Mustache body templates…

### DIFF
--- a/src/main/java/io/naftiko/engine/Resolver.java
+++ b/src/main/java/io/naftiko/engine/Resolver.java
@@ -56,8 +56,29 @@ public class Resolver {
             return template;
         }
 
-        return Mustache.compiler().defaultValue("").compile(template)
-            .execute(new HashMap<>(parameters));
+        // JSON-serialize non-scalar values (arrays, maps) so that Mustache substitution
+        // produces valid JSON instead of calling toString() (e.g. [CREW-001, CREW-003]).
+        Map<String, Object> serialized = new HashMap<>();
+        ObjectMapper jsonMapper = new ObjectMapper();
+        for (Map.Entry<String, Object> entry : parameters.entrySet()) {
+            Object val = entry.getValue();
+            if (val instanceof java.util.Collection || val instanceof Object[]) {
+                try {
+                    serialized.put(entry.getKey(), jsonMapper.writeValueAsString(val));
+                } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+                    serialized.put(entry.getKey(), val);
+                }
+            } else {
+                serialized.put(entry.getKey(), val);
+            }
+        }
+
+        // escapeHTML(false): JMustache escapes HTML entities by default (e.g. " → &quot;).
+        // This is desirable for HTML output, but templates here produce JSON bodies or URI strings —
+        // never HTML. Without this, serialized array values like ["CREW-001"] would be rendered
+        // as [&quot;CREW-001&quot;], producing invalid JSON.
+        return Mustache.compiler().escapeHTML(false).defaultValue("").compile(template)
+            .execute(serialized);
     }
 
     /**

--- a/src/test/java/io/naftiko/engine/ResolverTest.java
+++ b/src/test/java/io/naftiko/engine/ResolverTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -90,5 +91,45 @@ public class ResolverTest {
         assertEquals(2015, specs.path("yearBuilt").asInt());
         assertEquals(42000, specs.path("tonnage").asInt());
         assertEquals(229, specs.path("length").asInt());
+    }
+
+    /**
+     * Regression test for #213: array parameters in Mustache body templates must be
+     * JSON-serialized, not converted via toString().
+     *
+     * <p>Before the fix, passing a List as a parameter value produced [CREW-001, CREW-003]
+     * (no quotes), resulting in invalid JSON when substituted into a body template.</p>
+     */
+    @Test
+    public void resolveMustacheTemplateShouldJsonSerializeArrayParameters() {
+        String template = "{\"shipImo\": \"{{shipImo}}\", \"crewIds\": {{crewIds}}}";
+        Map<String, Object> params = Map.of(
+            "shipImo", "IMO-9321483",
+            "crewIds", List.of("CREW-001", "CREW-003")
+        );
+
+        String result = Resolver.resolveMustacheTemplate(template, params);
+
+        assertEquals("{\"shipImo\": \"IMO-9321483\", \"crewIds\": [\"CREW-001\",\"CREW-003\"]}", result);
+    }
+
+    /**
+     * Regression test for #213 (escapeHTML): Mustache HTML-escaping is disabled, so non-ASCII
+     * characters must pass through unchanged.
+     *
+     * <p>Before the fix, escapeHTML was enabled by default, which would have corrupted characters
+     * like ø (U+00F8) into their HTML entity equivalents.</p>
+     */
+    @Test
+    public void resolveMustacheTemplateShouldPreserveNonAsciiCharacters() {
+        String template = "{\"name\": \"{{name}}\", \"port\": \"{{port}}\"}";
+        Map<String, Object> params = Map.of(
+            "name", "Erik Lindstrøm",
+            "port", "Göteborg"
+        );
+
+        String result = Resolver.resolveMustacheTemplate(template, params);
+
+        assertEquals("{\"name\": \"Erik Lindstrøm\", \"port\": \"Göteborg\"}", result);
     }
 }


### PR DESCRIPTION
## Related Issue

Closes #213

---

## What does this PR do?

`Resolver.resolveMustacheTemplate` was using JMustache with default settings, causing two issues:

1. `Collection` and `Object[]` values were substituted via `toString()`, producing `[CREW-001, CREW-003]` (no quotes) — invalid JSON when inserted into a body template.
2. JMustache HTML-escapes by default (`"` → `&quot;`). Templates here produce JSON/URI output, never HTML, so this escaping corrupted the serialized JSON values.

Fix: JSON-serialize collections using Jackson before substitution, and disable HTML escaping via `escapeHTML(false)`.

---

## Tests

- `ResolverTest#resolveMustacheTemplateShouldJsonSerializeArrayParameters` — verifies that a `List` is properly serialized as a JSON array in the template
- `ResolverTest#resolveMustacheTemplateShouldPreserveNonAsciiCharacters` — verifies that non-ASCII characters (e.g. `ø`) are not corrupted by HTML escaping

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow Conventional Commits

---

## Agent Context (optional)

agent_name: GitHub Copilot
llm: Claude Sonnet 4.6
tool: VS Code Copilot Chat
confidence: high
source_event: step-6 tutorial debug — create-voyage body rendered as invalid JSON
discovery_method: runtime_observation
review_focus: Resolver.java:resolveMustacheTemplate