### PR TITLE
fix: changing the package name

### DIFF
--- a/.github/workflows/publish-engine-docker.yml
+++ b/.github/workflows/publish-engine-docker.yml
@@ -29,7 +29,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ghcr.io/${{ github.repository_owner }}/naftiko-cli 
           tags: |
             type=sha,prefix=sha-
             type=raw,value=latest


### PR DESCRIPTION


## What does this PR do?

replacing github.repository with github.repository_owner in order to change package name to naftiko-cli

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

