### PR TITLE
fix: resolve Mustache templates in 'with' params before upstream call (#229)

### DIFF
--- a/src/main/java/io/naftiko/engine/exposes/OperationStepExecutor.java
+++ b/src/main/java/io/naftiko/engine/exposes/OperationStepExecutor.java
@@ -210,6 +210,30 @@ public class OperationStepExecutor {
     }
 
     /**
+     * Merges 'with' parameters into a target map, resolving any Mustache templates
+     * against the current state of the target map. This allows parameter renaming
+     * (e.g. {@code imo_number: "{{imo}}"}) using values already present in the map.
+     *
+     * @param with   the 'with' map from a spec; may be null (no-op)
+     * @param target the map to merge into; Mustache resolution uses its current state
+     */
+    public static void mergeWithParameters(Map<String, Object> with,
+            Map<String, Object> target) {
+        if (with == null) {
+            return;
+        }
+        for (Map.Entry<String, Object> entry : with.entrySet()) {
+            Object rawValue = entry.getValue();
+            if (rawValue instanceof String rawStringValue) {
+                target.put(entry.getKey(),
+                        Resolver.resolveMustacheTemplate(rawStringValue, target));
+            } else {
+                target.put(entry.getKey(), rawValue);
+            }
+        }
+    }
+
+    /**
      * Execute a single call step.
      */
     private HandlingContext executeCallStep(OperationStepCallSpec callStep,
@@ -217,17 +241,7 @@ public class OperationStepExecutor {
         // Merge step-level 'with' parameters with base parameters
         Map<String, Object> stepParams = new ConcurrentHashMap<>(baseParameters);
 
-        if (callStep.getWith() != null) {
-            for (Map.Entry<String, Object> entry : callStep.getWith().entrySet()) {
-                Object rawValue = entry.getValue();
-                if (rawValue instanceof String rawStringValue) {
-                    stepParams.put(entry.getKey(),
-                            Resolver.resolveMustacheTemplate(rawStringValue, stepParams));
-                } else {
-                    stepParams.put(entry.getKey(), rawValue);
-                }
-            }
-        }
+        mergeWithParameters(callStep.getWith(), stepParams);
 
         if (callStep.getCall() != null) {
             String[] tokens = callStep.getCall().split("\\.");
@@ -315,9 +329,7 @@ public class OperationStepExecutor {
             merged.putAll(requestParams);
         }
 
-        if (call.getWith() != null) {
-            merged.putAll(call.getWith());
-        }
+        mergeWithParameters(call.getWith(), merged);
 
         if (call.getOperation() != null) {
             String[] tokens = call.getOperation().split("\\.");

--- a/src/main/java/io/naftiko/engine/exposes/mcp/ResourceHandler.java
+++ b/src/main/java/io/naftiko/engine/exposes/mcp/ResourceHandler.java
@@ -253,9 +253,7 @@ public class ResourceHandler {
             Map<String, String> templateParams) throws Exception {
 
         Map<String, Object> parameters = new HashMap<>(templateParams);
-        if (spec.getWith() != null) {
-            parameters.putAll(spec.getWith());
-        }
+        OperationStepExecutor.mergeWithParameters(spec.getWith(), parameters);
 
         OperationStepExecutor.HandlingContext found =
                 stepExecutor.execute(spec.getCall(), spec.getSteps(), parameters,

--- a/src/main/java/io/naftiko/engine/exposes/rest/ResourceRestlet.java
+++ b/src/main/java/io/naftiko/engine/exposes/rest/ResourceRestlet.java
@@ -90,9 +90,7 @@ public class ResourceRestlet extends Restlet {
                         getResourceSpec(), serverOp);
 
                 // Include operation-level 'with' parameters for template resolution
-                if (serverOp.getWith() != null) {
-                    inputParameters.putAll(serverOp.getWith());
-                }
+                OperationStepExecutor.mergeWithParameters(serverOp.getWith(), inputParameters);
 
                 if (serverOp.getCall() != null) {
                     try {

--- a/src/test/java/io/naftiko/engine/exposes/rest/RestPathParamWithResolutionTest.java
+++ b/src/test/java/io/naftiko/engine/exposes/rest/RestPathParamWithResolutionTest.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.naftiko.engine.exposes.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.net.ServerSocket;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.restlet.Application;
+import org.restlet.Component;
+import org.restlet.Request;
+import org.restlet.Restlet;
+import org.restlet.Response;
+import org.restlet.data.MediaType;
+import org.restlet.data.Method;
+import org.restlet.data.Protocol;
+import org.restlet.data.Status;
+import org.restlet.routing.Router;
+import org.restlet.routing.TemplateRoute;
+import org.restlet.routing.Variable;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.naftiko.Capability;
+import io.naftiko.spec.NaftikoSpec;
+import io.naftiko.spec.exposes.RestServerResourceSpec;
+import io.naftiko.spec.exposes.RestServerSpec;
+
+/**
+ * Regression test: REST adapter must resolve Mustache templates in 'with' parameters
+ * before passing them to the upstream call.
+ *
+ * When a REST resource defines path="/ships/{{imo}}" and the operation uses
+ * with: { imo_number: "{{imo}}" }, the upstream consumes URI /ships/{{imo_number}}
+ * must be resolved to /ships/IMO-9321483, not left as /ships/{{imo}}.
+ */
+public class RestPathParamWithResolutionTest {
+
+    @Test
+    public void withParametersShouldResolveMustacheTemplatesFromPathParams() throws Exception {
+        AtomicReference<String> receivedPath = new AtomicReference<>();
+
+        int mockPort = findFreePort();
+        Component mockServer = new Component();
+        mockServer.getServers().add(Protocol.HTTP, mockPort);
+        mockServer.getDefaultHost().attach(new Application() {
+            @Override
+            public Restlet createInboundRoot() {
+                Router router = new Router(getContext());
+                TemplateRoute route = router.attach("/ships/{imo_number}", new Restlet() {
+                    @Override
+                    public void handle(Request request, Response response) {
+                        receivedPath.set(request.getResourceRef().getPath());
+                        response.setStatus(Status.SUCCESS_OK);
+                        response.setEntity(
+                                "{\"imo_number\":\"IMO-9321483\",\"vessel_name\":\"Northern Star\"}",
+                                MediaType.APPLICATION_JSON);
+                    }
+                });
+                route.getTemplate().getVariables()
+                        .put("imo_number", new Variable(Variable.TYPE_URI_PATH));
+                return router;
+            }
+        });
+        mockServer.start();
+
+        try {
+            String yaml = """
+                    naftiko: "1.0.0-alpha1"
+                    capability:
+                      exposes:
+                        - type: "rest"
+                          address: "localhost"
+                          port: 0
+                          namespace: "shipyard-api"
+                          resources:
+                            - name: ship-by-imo
+                              path: "/ships/{{imo}}"
+                              operations:
+                                - name: get-ship
+                                  method: GET
+                                  inputParameters:
+                                    - name: imo
+                                      in: path
+                                      type: string
+                                  call: registry.get-ship
+                                  with:
+                                    imo_number: "{{imo}}"
+                      consumes:
+                        - type: "http"
+                          namespace: "registry"
+                          baseUri: "http://localhost:%d"
+                          resources:
+                            - name: ship
+                              path: "/ships/{{imo_number}}"
+                              operations:
+                                - name: get-ship
+                                  method: GET
+                                  inputParameters:
+                                    - name: imo_number
+                                      in: path
+                    """.formatted(mockPort);
+
+            ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+            mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            NaftikoSpec spec = mapper.readValue(yaml, NaftikoSpec.class);
+
+            Capability capability = new Capability(spec);
+            RestServerAdapter adapter = (RestServerAdapter) capability.getServerAdapters().get(0);
+            RestServerSpec serverSpec = (RestServerSpec) adapter.getSpec();
+            RestServerResourceSpec resourceSpec = serverSpec.getResources().get(0);
+            ResourceRestlet restlet = new ResourceRestlet(capability, serverSpec, resourceSpec);
+
+            Request request = new Request(Method.GET, "http://localhost/ships/IMO-9321483");
+            request.getAttributes().put("imo", "IMO-9321483");
+            Response response = new Response(request);
+
+            restlet.handle(request, response);
+
+            assertEquals(Status.SUCCESS_OK, response.getStatus(),
+                    "REST adapter should resolve {{imo}} in 'with' and call upstream successfully");
+            assertEquals("/ships/IMO-9321483", receivedPath.get(),
+                    "Upstream should receive resolved path /ships/IMO-9321483, not /ships/{{imo}}");
+        } finally {
+            mockServer.stop();
+        }
+    }
+
+    private static int findFreePort() throws Exception {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+}


### PR DESCRIPTION
## Related Issue

Closes #229

---

## What does this PR do?

When a REST (or MCP resource) operation used 'with' to remap a parameter
(e.g. imo_number: "{{imo}}"), the Mustache template was copied as-is
into the parameter map via putAll() — without resolution.
The upstream call received the literal {{imo}} instead of the actual value,
resulting in a 400 "Unresolved template parameters in URI".

Fix: extract a static helper OperationStepExecutor.mergeWithParameters(with, target)
that resolves Mustache templates against the current parameter map before inserting,
and use it in all three affected call sites:
- ResourceRestlet.handleFromOperationSpec
- OperationStepExecutor.findClientRequestFor(ServerCallSpec)
- ResourceHandler.readDynamic

---

## Tests

Added RestPathParamWithResolutionTest — integration test that starts a real
mock HTTP server, calls a REST adapter with a path param remapped via 'with',
and asserts the upstream receives the resolved path /ships/IMO-9321483.

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest main
- [ ] Small and focused — one concern per PR
- [ ] Commit messages follow Conventional Commits

---

## Agent Context (optional)

agent_name: GitHub Copilot
llm: Claude Sonnet 4.6
tool: VS Code Copilot Chat
confidence: high
source_event: Manual testing of tutorial step-7 and step-9 — GET /ships/{imo} returned 400
discovery_method: runtime_observation
review_focus: OperationStepExecutor.java:mergeWithParameters, ResourceRestlet.java:handleFromOperationSpec