### PR TITLE
fix: resolve namespace-qualified references in 'with' params (#231)

### DIFF
--- a/src/main/java/io/naftiko/engine/Resolver.java
+++ b/src/main/java/io/naftiko/engine/Resolver.java
@@ -154,7 +154,20 @@ public class Resolver {
                         }
                     }
 
-                    // Otherwise return raw body text
+                    // When a field name is given with no explicit path, extract that field
+                    // from the body by name so that named body parameters bind to individual
+                    // request fields (e.g. name: shipImo → $.shipImo).
+                    if (name != null && root.has(name)) {
+                        JsonNode field = root.get(name);
+                        if (field.isTextual()) {
+                            return field.asText();
+                        } else if (!field.isNull()) {
+                            return mapper.convertValue(field, Object.class);
+                        }
+                        return null;
+                    }
+
+                    // Otherwise return raw body node
                     return root;
                 }
             }

--- a/src/main/java/io/naftiko/engine/exposes/OperationStepExecutor.java
+++ b/src/main/java/io/naftiko/engine/exposes/OperationStepExecutor.java
@@ -210,23 +210,37 @@ public class OperationStepExecutor {
     }
 
     /**
-     * Merges 'with' parameters into a target map, resolving any Mustache templates
-     * against the current state of the target map. This allows parameter renaming
-     * (e.g. {@code imo_number: "{{imo}}"}) using values already present in the map.
+     * Merges 'with' parameters into a target map, resolving values against the current state of
+     * the target map. Handles two value syntaxes:
+     * <ul>
+     *   <li>Mustache template ({@code {{paramName}}}) — resolved via JMustache.</li>
+     *   <li>Namespace-qualified reference ({@code namespace.paramName}) — resolved by looking up
+     *       {@code paramName} in the target map when a matching namespace prefix is provided.</li>
+     * </ul>
      *
-     * @param with   the 'with' map from a spec; may be null (no-op)
-     * @param target the map to merge into; Mustache resolution uses its current state
+     * @param with      the 'with' map from a spec; may be null (no-op)
+     * @param target    the map to merge into; resolution uses its current state
+     * @param namespace the expose namespace used to detect qualified references (e.g.
+     *                  {@code "shipyard-api"}); may be null to skip namespace resolution
      */
-    public static void mergeWithParameters(Map<String, Object> with,
-            Map<String, Object> target) {
+    public static void mergeWithParameters(Map<String, Object> with, Map<String, Object> target,
+            String namespace) {
         if (with == null) {
             return;
         }
         for (Map.Entry<String, Object> entry : with.entrySet()) {
             Object rawValue = entry.getValue();
             if (rawValue instanceof String rawStringValue) {
-                target.put(entry.getKey(),
-                        Resolver.resolveMustacheTemplate(rawStringValue, target));
+                if (namespace != null && rawStringValue.startsWith(namespace + ".")) {
+                    String paramName = rawStringValue.substring(namespace.length() + 1);
+                    Object resolved = target.get(paramName);
+                    if (resolved != null) {
+                        target.put(entry.getKey(), resolved);
+                    }
+                } else {
+                    target.put(entry.getKey(),
+                            Resolver.resolveMustacheTemplate(rawStringValue, target));
+                }
             } else {
                 target.put(entry.getKey(), rawValue);
             }
@@ -241,7 +255,7 @@ public class OperationStepExecutor {
         // Merge step-level 'with' parameters with base parameters
         Map<String, Object> stepParams = new ConcurrentHashMap<>(baseParameters);
 
-        mergeWithParameters(callStep.getWith(), stepParams);
+        mergeWithParameters(callStep.getWith(), stepParams, null);
 
         if (callStep.getCall() != null) {
             String[] tokens = callStep.getCall().split("\\.");
@@ -329,7 +343,7 @@ public class OperationStepExecutor {
             merged.putAll(requestParams);
         }
 
-        mergeWithParameters(call.getWith(), merged);
+        mergeWithParameters(call.getWith(), merged, null);
 
         if (call.getOperation() != null) {
             String[] tokens = call.getOperation().split("\\.");

--- a/src/main/java/io/naftiko/engine/exposes/mcp/McpServerAdapter.java
+++ b/src/main/java/io/naftiko/engine/exposes/mcp/McpServerAdapter.java
@@ -76,7 +76,8 @@ public class McpServerAdapter extends ServerAdapter {
                 serverSpec.getNamespace());
 
         // Create the resource handler (transport-agnostic)
-        this.resourceHandler = new ResourceHandler(capability, serverSpec.getResources());
+        this.resourceHandler = new ResourceHandler(capability, serverSpec.getResources(),
+                serverSpec.getNamespace());
 
         // Create the prompt handler (transport-agnostic)
         this.promptHandler = new PromptHandler(serverSpec.getPrompts());

--- a/src/main/java/io/naftiko/engine/exposes/mcp/ResourceHandler.java
+++ b/src/main/java/io/naftiko/engine/exposes/mcp/ResourceHandler.java
@@ -51,11 +51,14 @@ public class ResourceHandler {
     private final Capability capability;
     private final List<McpServerResourceSpec> resourceSpecs;
     private final OperationStepExecutor stepExecutor;
+    private final String namespace;
 
-    public ResourceHandler(Capability capability, List<McpServerResourceSpec> resources) {
+    public ResourceHandler(Capability capability, List<McpServerResourceSpec> resources,
+            String namespace) {
         this.capability = capability;
         this.resourceSpecs = new ArrayList<>(resources);
         this.stepExecutor = new OperationStepExecutor(capability);
+        this.namespace = namespace;
     }
 
     /**
@@ -253,7 +256,7 @@ public class ResourceHandler {
             Map<String, String> templateParams) throws Exception {
 
         Map<String, Object> parameters = new HashMap<>(templateParams);
-        OperationStepExecutor.mergeWithParameters(spec.getWith(), parameters);
+        OperationStepExecutor.mergeWithParameters(spec.getWith(), parameters, namespace);
 
         OperationStepExecutor.HandlingContext found =
                 stepExecutor.execute(spec.getCall(), spec.getSteps(), parameters,

--- a/src/main/java/io/naftiko/engine/exposes/rest/ResourceRestlet.java
+++ b/src/main/java/io/naftiko/engine/exposes/rest/ResourceRestlet.java
@@ -90,7 +90,8 @@ public class ResourceRestlet extends Restlet {
                         getResourceSpec(), serverOp);
 
                 // Include operation-level 'with' parameters for template resolution
-                OperationStepExecutor.mergeWithParameters(serverOp.getWith(), inputParameters);
+                OperationStepExecutor.mergeWithParameters(serverOp.getWith(), inputParameters,
+                        getServerSpec().getNamespace());
 
                 if (serverOp.getCall() != null) {
                     try {

--- a/src/test/java/io/naftiko/engine/exposes/OperationStepExecutorTest.java
+++ b/src/test/java/io/naftiko/engine/exposes/OperationStepExecutorTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.naftiko.engine.exposes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link OperationStepExecutor#mergeWithParameters(Map, Map, String)}.
+ */
+public class OperationStepExecutorTest {
+
+    @Test
+    public void mergeWithShouldResolveMustacheTemplate() {
+        Map<String, Object> target = new HashMap<>();
+        target.put("imo", "IMO-9321483");
+
+        Map<String, Object> with = new HashMap<>();
+        with.put("imo_number", "{{imo}}");
+
+        OperationStepExecutor.mergeWithParameters(with, target, null);
+
+        assertEquals("IMO-9321483", target.get("imo_number"),
+                "Mustache template {{imo}} should be resolved to the actual value");
+    }
+
+    @Test
+    public void mergeWithShouldResolveNamespaceQualifiedReference() {
+        Map<String, Object> target = new HashMap<>();
+        target.put("shipImo", "IMO-9321483");
+
+        Map<String, Object> with = new HashMap<>();
+        with.put("shipImo", "shipyard-api.shipImo");
+
+        OperationStepExecutor.mergeWithParameters(with, target, "shipyard-api");
+
+        assertEquals("IMO-9321483", target.get("shipImo"),
+                "Namespace-qualified reference shipyard-api.shipImo should resolve to actual value");
+    }
+
+    @Test
+    public void mergeWithShouldReturnNullForUnresolvedNamespaceRef() {
+        Map<String, Object> target = new HashMap<>();
+
+        Map<String, Object> with = new HashMap<>();
+        with.put("shipImo", "shipyard-api.shipImo");
+
+        OperationStepExecutor.mergeWithParameters(with, target, "shipyard-api");
+
+        assertNull(target.get("shipImo"),
+                "Unresolved namespace-qualified reference should not add a null entry");
+    }
+
+    @Test
+    public void mergeWithShouldPassThroughNonStringValue() {
+        Map<String, Object> target = new HashMap<>();
+
+        Map<String, Object> with = new HashMap<>();
+        with.put("pageSize", 100);
+
+        OperationStepExecutor.mergeWithParameters(with, target, null);
+
+        assertEquals(100, target.get("pageSize"),
+                "Non-string values should be passed through as-is");
+    }
+
+    @Test
+    public void mergeWithNullShouldBeNoOp() {
+        Map<String, Object> target = new HashMap<>();
+        target.put("existing", "value");
+
+        OperationStepExecutor.mergeWithParameters(null, target, null);
+
+        assertEquals(1, target.size(), "Null 'with' map should not modify the target");
+    }
+}

--- a/src/test/java/io/naftiko/engine/exposes/mcp/ResourceHandlerSafetyTest.java
+++ b/src/test/java/io/naftiko/engine/exposes/mcp/ResourceHandlerSafetyTest.java
@@ -36,7 +36,7 @@ public class ResourceHandlerSafetyTest {
                 Files.writeString(tempDir.resolve("secrets.txt"), "do-not-read\n");
 
         ResourceHandler handler = new ResourceHandler(null,
-                List.of(staticResource("docs", "data://docs", docs)));
+                List.of(staticResource("docs", "data://docs", docs)), null);
 
         IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
                 () -> handler.read("data://docs/../secrets.txt"));
@@ -50,7 +50,7 @@ public class ResourceHandlerSafetyTest {
         Files.createDirectories(docs);
 
         ResourceHandler handler = new ResourceHandler(null,
-                List.of(staticResource("docs", "data://docs", docs)));
+                List.of(staticResource("docs", "data://docs", docs)), null);
 
         IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
                 () -> handler.read("data://docs"));
@@ -65,7 +65,7 @@ public class ResourceHandlerSafetyTest {
         Files.writeString(docs.resolve("guide.md"), "# guide\n");
 
         ResourceHandler handler = new ResourceHandler(null,
-                List.of(staticResource("docs", "data://docs", docs)));
+                List.of(staticResource("docs", "data://docs", docs)), null);
 
         List<ResourceHandler.ResourceContent> content = handler.read("data://docs/guide.md");
 

--- a/src/test/java/io/naftiko/engine/exposes/rest/RestNamespaceRefWithResolutionTest.java
+++ b/src/test/java/io/naftiko/engine/exposes/rest/RestNamespaceRefWithResolutionTest.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.naftiko.engine.exposes.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.ServerSocket;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+import org.restlet.Application;
+import org.restlet.Component;
+import org.restlet.Request;
+import org.restlet.Restlet;
+import org.restlet.Response;
+import org.restlet.data.MediaType;
+import org.restlet.data.Method;
+import org.restlet.data.Protocol;
+import org.restlet.data.Status;
+import org.restlet.routing.Router;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import io.naftiko.Capability;
+import io.naftiko.spec.NaftikoSpec;
+import io.naftiko.spec.exposes.RestServerResourceSpec;
+import io.naftiko.spec.exposes.RestServerSpec;
+
+/**
+ * Regression test: REST adapter must resolve namespace-qualified 'with' references
+ * (e.g. shipyard-api.shipImo) before passing them to the upstream body template.
+ *
+ * When an operation uses with: { shipImo: shipyard-api.shipImo }, the upstream
+ * body template {{shipImo}} must receive the actual request value "IMO-9321483",
+ * not the literal string "shipyard-api.shipImo".
+ */
+public class RestNamespaceRefWithResolutionTest {
+
+    @Test
+    public void withNamespaceRefsShouldResolveToActualValuesInUpstreamBody() throws Exception {
+        AtomicReference<String> receivedBody = new AtomicReference<>();
+
+        int mockPort = findFreePort();
+        Component mockServer = new Component();
+        mockServer.getServers().add(Protocol.HTTP, mockPort);
+        mockServer.getDefaultHost().attach(new Application() {
+            @Override
+            public Restlet createInboundRoot() {
+                Router router = new Router(getContext());
+                router.attach("/voyages", new Restlet() {
+                    @Override
+                    public void handle(Request request, Response response) {
+                        try {
+                            receivedBody.set(request.getEntity().getText());
+                        } catch (Exception e) {
+                            receivedBody.set("error: " + e.getMessage());
+                        }
+                        response.setStatus(Status.SUCCESS_CREATED);
+                        response.setEntity(
+                                "{\"voyageId\":\"VOY-001\",\"shipImo\":\"IMO-9321483\"}",
+                                MediaType.APPLICATION_JSON);
+                    }
+                });
+                return router;
+            }
+        });
+        mockServer.start();
+
+        try {
+            String yaml = """
+                    naftiko: "1.0.0-alpha1"
+                    capability:
+                      exposes:
+                        - type: "rest"
+                          address: "localhost"
+                          port: 0
+                          namespace: "shipyard-api"
+                          resources:
+                            - name: voyages
+                              path: "/voyages"
+                              operations:
+                                - name: create-voyage
+                                  method: POST
+                                  inputParameters:
+                                    - name: shipImo
+                                      in: body
+                                  call: registry.create-voyage
+                                  with:
+                                    shipImo: "shipyard-api.shipImo"
+                      consumes:
+                        - type: "http"
+                          namespace: "registry"
+                          baseUri: "http://localhost:%d"
+                          resources:
+                            - name: voyages
+                              path: "/voyages"
+                              operations:
+                                - name: create-voyage
+                                  method: POST
+                                  body: |
+                                    {"shipImo": "{{shipImo}}"}
+                    """.formatted(mockPort);
+
+            ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+            mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            NaftikoSpec spec = mapper.readValue(yaml, NaftikoSpec.class);
+
+            Capability capability = new Capability(spec);
+            RestServerAdapter adapter = (RestServerAdapter) capability.getServerAdapters().get(0);
+            RestServerSpec serverSpec = (RestServerSpec) adapter.getSpec();
+            RestServerResourceSpec resourceSpec = serverSpec.getResources().get(0);
+            ResourceRestlet restlet = new ResourceRestlet(capability, serverSpec, resourceSpec);
+
+            Request request = new Request(Method.POST, "http://localhost/voyages");
+            request.setEntity("{\"shipImo\":\"IMO-9321483\"}", MediaType.APPLICATION_JSON);
+            Response response = new Response(request);
+
+            restlet.handle(request, response);
+
+            assertEquals(Status.SUCCESS_CREATED, response.getStatus(),
+                    "REST adapter should resolve namespace ref in 'with' and call upstream successfully");
+
+            String body = receivedBody.get();
+            assertEquals("{\"shipImo\": \"IMO-9321483\"}\n", body,
+                    "Upstream should receive resolved shipImo value, not the namespace reference literal");
+        } finally {
+            mockServer.stop();
+        }
+    }
+
+    private static int findFreePort() throws Exception {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+}


### PR DESCRIPTION
## Related Issue

Closes #231

⚠️ This PR should be reviewed and merged after PR #230 (which fixes #229). Both PRs touch mergeWithParameters in OperationStepExecutor — #230 introduces the method, this PR extends it with namespace resolution. If #230 is merged first, this branch will need a rebase to resolve trivial conflicts.

---

## What does this PR do?

When an expose operation uses with: with namespace-qualified references (e.g. shipImo: shipyard-api.shipImo), the literal string "shipyard-api.shipImo" was forwarded as-is to the upstream call instead of being resolved to the actual caller-provided value (e.g. "IMO-9321483"). This affected both REST and MCP resource adapters. The MCP tool adapter (ToolHandler) already handled this correctly via its own resolveWithValue().

Root cause: ResourceRestlet, ResourceHandler.readDynamic(), and OperationStepExecutor.findClientRequestFor() all used putAll() to merge with parameters — copying raw values without any resolution.

Fix:
- OperationStepExecutor: added namespace parameter to mergeWithParameters() — when a value starts with namespace + ".", it resolves by looking up the suffix in the target map
- ResourceRestlet: passes getServerSpec().getNamespace() to mergeWithParameters
- ResourceHandler + McpServerAdapter: propagated namespace through the constructor to readDynamic()
- Resolver: when in: body has no JSONPath/template, extract the field by its name from the body JSON instead of returning the entire body node

---

## Tests

- OperationStepExecutorTest — 5 unit tests for mergeWithParameters (Mustache, namespace ref, unresolved ref, non-string passthrough, null no-op)
- RestNamespaceRefWithResolutionTest — integration test with a mock HTTP server verifying namespace refs are resolved in the upstream body

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest main
- [x] Small and focused — one concern per PR
- [x] Commit messages follow Conventional Commits

---

## Agent Context (optional)

agent_name: GitHub Copilot
llm: Claude Opus 4.6
tool: VS Code Chat
confidence: high
source_event: Issue #231
discovery_method: runtime_observation
review_focus: OperationStepExecutor.java:226-250, Resolver.java:154-170, ResourceRestlet.java:90-95, ResourceHandler.java:51-62+256-258
