### PR TITLE
chore: bump version number

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.naftiko</groupId>
     <artifactId>framework</artifactId>
-    <version>1.0.0-alpha1-SNAPSHOT</version>
+    <version>1.0.0-alpha2-SNAPSHOT</version>
 
     <properties>
         <java.version>21</java.version>


### PR DESCRIPTION
## Related Issue

none

---

## What does this PR do?

Bumping version number to 1.0.0-alpha2
