### PR TITLE
Chore/sync wiki

### DIFF
--- a/src/main/resources/wiki/Installation.md
+++ b/src/main/resources/wiki/Installation.md
@@ -31,7 +31,7 @@ To use Naftiko Framework, you must install and then run its engine.
   * If your capability refers to some local hosts, be careful to not use 'localhost', but 'host.docker.internal' instead. This is because your capability will run into an isolated docker container, so 'localhost' will refer to the container and not your local machine.\
     For example:
     ```bash
-    baseUri: "http://host.docker.internal:8080/api"
+    baseUri: "http://host.docker.internal:8080/api/"
     ```
   * In the same way, if your capability expose a local host, be careful to not use 'localhost', but '0.0.0.0' instead. Else requests to localhost coming from outside of the container won't succeed.\
     For example:


### PR DESCRIPTION
## What does this PR do?

Syncs the in-repo wiki content (wiki) with the latest published wiki, aligning it with the v1.0.0-alpha1 release. Two categories of changes:

**File renames** — Wiki page filenames now use non-breaking hyphens (`‐`) as separators (e.g. `Guide-Use-Cases.md` → `Guide-‐-Use-Cases.md`, `Tutorial-Part-1.md` → `Tutorial-‐-Part-1.md`) to match the GitHub Wiki URL scheme. Affected files: Specification-Schema, Specification-Rules, Spec-Driven-Integration, Guide-Linting, Guide-Use-Cases, Tutorial-Part-1, Tutorial-Part-2.

**Content updates:**
- **FAQ** — Added new Q&A entry for MCP mock tools with `const`-valued output parameters (no `consumes` block required).
- **Guide - Use Cases** — Added detailed "Key features" checklists to all 9 use cases, covering authentication, orchestration, output shaping, format conversion, forward proxy, binds, and multi-adapter exposure.
- **Guide - Linting** — Fixed internal wiki links to use percent-encoded non-breaking hyphen URLs.
- **Installation** — Fixed typos (`reffers` → `refers`, `carefull` → `careful`), updated tutorial download links to point to the `v1.0.0-alpha1` tag on GitHub raw content, and added trailing slash to `baseUri` example.
- **Releases** — Updated 1.0 Alpha 1 row with release link to `v1.0.0-alpha1` tag.
- **Tutorial Part 1** — Converted relative file download links to absolute raw GitHub URLs pinned to `v1.0.0-alpha1`; added download links for shared consumes files; fixed internal wiki cross-links.
- **Tutorial Part 2** — Same link fixes as Part 1; switched Part 1 back-reference to relative wiki link.

---

## Tests

No tests added — documentation-only changes to wiki Markdown files. No Java code modified.

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Claude Opus 4.6
tool: VS Code Chat
confidence: high
source_event: user request to prepare PR message
discovery_method: code_review
# review_focus: src/main/resources/wiki/
```