### PR TITLE
Feat/update validate GitHub action with megalinter

### DIFF
--- a/.github/workflows/mega-linter-validate.yml
+++ b/.github/workflows/mega-linter-validate.yml
@@ -1,0 +1,35 @@
+name: Lint Naftiko Capabilities
+
+on:
+  push:
+    paths:
+      - 'src/main/resources/schemas/**'
+      - 'src/main/resources/rules/**'
+      - 'src/main/resources/tutorial/**'
+      - 'src/test/resources/**'
+      - '.mega-linter.yml'
+  pull_request:
+    paths:
+      - 'src/main/resources/schemas/**'
+      - 'src/main/resources/rules/**'
+      - 'src/main/resources/tutorial/**'
+      - 'src/test/resources/**'
+      - '.mega-linter.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: MegaLinter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: oxsecurity/megalinter@v9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_ALL_CODEBASE: true

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -1,0 +1,13 @@
+APPLY_FIXES: none
+
+ENABLE_LINTERS:
+  - YAML_V8R
+
+POST_COMMANDS:
+  - name: Naftiko Spectral Validation
+    command: "spectral lint -r .spectral.yaml 'src/main/resources/schemas/examples/*.yml' 'src/main/resources/tutorial/**/*.yml' 'src/test/resources/*.yaml'"
+    continue_on_error: false
+
+YAML_V8R_FILTER_REGEX_INCLUDE: "src/(main/resources/(schemas/examples|tutorial)|test/resources)/.*\\.(yaml|yml)$"
+YAML_V8R_ARGUMENTS: "--schema src/main/resources/schemas/naftiko-schema.json"
+YAML_V8R_FILTER_REGEX_EXCLUDE: "(secrets|sample-users|package-lock)"

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,0 +1,2 @@
+extends:
+  - ./src/main/resources/rules/naftiko-rules.yml

--- a/src/main/resources/blueprints/meta-linter-integration.md
+++ b/src/main/resources/blueprints/meta-linter-integration.md
@@ -90,12 +90,16 @@ This means v8r could **replace the custom `ajv` workflow** for JSON Schema valid
 
 ### Spectral file detection caveat
 
-MegaLinter's Spectral integration auto-detects files using **content regex**: `"openapi":`, `"swagger":`, `"asyncapi":` (and YAML variants). Naftiko YAML files contain `naftiko:` instead, so they **will not be auto-detected**.
+MegaLinter's Spectral integration (API_SPECTRAL) uses a "Smart Detection" engine. It looks for signatures like openapi: 3.0 inside files. Because Naftiko files use a custom naftiko: key, they are ignored by the default linter, even if included in the regex.
 
-**Workaround:** Override file targeting with:
+Solution: Use POST_COMMANDS to bypass the identification engine and force Spectral execution via the CLI already bundled in the MegaLinter image.
+
+**Workaround:** 
 ```yaml
-API_SPECTRAL_FILTER_REGEX_INCLUDE: "src/main/resources/schemas/(examples|tutorial)/.*\\.(yaml|yml)$"
-API_SPECTRAL_FILE_NAMES_REGEX: [".*"]
+POST_COMMANDS:
+  - name: Naftiko Spectral Validation
+    command: "spectral lint -r .spectral.yaml 'src/main/resources/schemas/examples/*.yml' 'src/main/resources/tutorial/**/*.yml' 'src/test/resources/*.yaml'"
+    continue_on_error: false
 ```
 
 ### v8r and Draft 2020-12
@@ -146,16 +150,17 @@ MegaLinter uses a repo-root config file instead of inline env vars:
 # .mega-linter.yml
 APPLY_FIXES: none
 ENABLE_LINTERS:
-  - API_SPECTRAL
   - YAML_V8R
 
-# ── Spectral (semantic rules) ──
-API_SPECTRAL_CONFIG_FILE: .spectral.yaml
-API_SPECTRAL_FILTER_REGEX_INCLUDE: "src/main/resources/schemas/(examples|tutorial)/.*\\.(yaml|yml)$"
-
 # ── v8r (JSON Schema validation) ──
-YAML_V8R_FILTER_REGEX_INCLUDE: "src/main/resources/schemas/(examples|tutorial)/.*\\.(yaml|yml)$"
-YAML_V8R_ARGUMENTS: "--ignore-errors"
+YAML_V8R_FILTER_REGEX_INCLUDE: "src/(main/resources/(schemas/examples|tutorial)|test/resources)/.*\\.(yaml|yml)$"
+YAML_V8R_ARGUMENTS: "--schema src/main/resources/schemas/naftiko-schema.json"
+
+# ── Spectral (Naftiko Business Rules) ──
+POST_COMMANDS:
+  - name: Naftiko Spectral Validation
+    command: "spectral lint -r .spectral.yaml 'src/main/resources/schemas/examples/*.yml' 'src/main/resources/tutorial/**/*.yml' 'src/test/resources/*.yaml'"
+    continue_on_error: false
 ```
 
 **Key design choices:**


### PR DESCRIPTION
## Related Issue

Closes [#199](https://github.com/naftiko/framework/issues/199)
---

## What does this PR do?

Updates the json validation with mega linter, the AJV (v8r) worked but API_SPECTRAL linter failed to trigger automatically while the POST_COMMAND methods worked.
The issue wasn't the ruleset itself, but the Automated Identification Logic used by MegaLinter.
MegaLinter is designed to be "smart" to save time. Instead of running every linter on every file, it uses Fingerprinting.

The Problem: The API_SPECTRAL descriptor only activates if it "recognizes" an API file. It looks for specific keywords like openapi:, swagger:, or asyncapi:.

The Consequence: Since Naftiko files use a custom schema (naftiko: "1.0.0-alpha1"), MegaLinter classified them as "generic YAML" rather than "API files." It triggered the YAML linter (v8r) but completely skipped the Spectral linter.

TBD
---

## Checklist

- [X] CI is green (build, tests, schema validation, security scans)
- [X] Rebased on latest `main`
- [X] Small and focused — one concern per PR
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)


