### PR TITLE
chore: store pom version as resource property and use it for capabili…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,19 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>version.properties</include>
+                </includes>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/io/naftiko/Cli.java
+++ b/src/main/java/io/naftiko/Cli.java
@@ -21,7 +21,7 @@ import picocli.CommandLine.Command;
 @Command(
     name = "naftiko",
     mixinStandardHelpOptions = true, 
-    version = "1.0.0-alpha1",
+    version = "1.0.0-alpha2",
     description = "Naftiko CLI",
     subcommands = {CreateCommand.class, ValidateCommand.class}
 )

--- a/src/main/java/io/naftiko/cli/FileGenerator.java
+++ b/src/main/java/io/naftiko/cli/FileGenerator.java
@@ -24,8 +24,22 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 
 public class FileGenerator {
+    private static final String VERSION;
+
+    static {
+        try (InputStream versionStream = FileGenerator.class.getClassLoader().getResourceAsStream("version.properties")) {
+            Properties props = new Properties();
+            props.load(versionStream);
+            String v = props.getProperty("version");
+            VERSION = v.endsWith("-SNAPSHOT") ? v.substring(0, v.length() - "-SNAPSHOT".length()) : v;
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError("Could not load version.properties: " + e.getMessage());
+        }
+    }
+
     public static void generateCapabilityFile(String capabilityName, FileFormat format, String baseUri, String port) throws IOException {
         String templatePath = "templates/capability." + format.pathName + ".mustache";
         String outputFileName = capabilityName + ".naftiko." + format.pathName;
@@ -41,6 +55,7 @@ public class FileGenerator {
         // Render template and write file.
         Template mustache = Mustache.compiler().compile(new InputStreamReader(templateStream));
         Map<String, Object> scope = new HashMap<>();
+        scope.put("version", VERSION);
         scope.put("capabilityName", capabilityName);
         scope.put("port", port);
         scope.put("baseUri", baseUri);

--- a/src/main/resources/META-INF/native-image/resource-config.json
+++ b/src/main/resources/META-INF/native-image/resource-config.json
@@ -2,6 +2,7 @@
   "resources": [
     { "pattern": "schemas/.*" },
     { "pattern": "templates/.*" },
-    { "pattern": "jsv-messages.*\\.properties" }
+    { "pattern": "jsv-messages.*\\.properties" },
+    { "pattern": "version\\.properties" }
   ]
 }

--- a/src/main/resources/schemas/naftiko-schema.json
+++ b/src/main/resources/schemas/naftiko-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://naftiko.io/schemas/v1.0.0-alpha1/naftiko.json",
+  "$id": "https://naftiko.io/schemas/v1.0.0-alpha2/naftiko.json",
   "name": "Naftiko Specification",
   "description": "This Schema should be used to describe and validate Naftiko Capabilities",
   "type": "object",
@@ -8,7 +8,7 @@
     "naftiko": {
       "type": "string",
       "description": "Version of the Naftiko specification",
-      "const": "1.0.0-alpha1"
+      "const": "1.0.0-alpha2"
     },
     "info": {
       "$ref": "#/$defs/Info"

--- a/src/main/resources/templates/capability.yaml.mustache
+++ b/src/main/resources/templates/capability.yaml.mustache
@@ -1,4 +1,4 @@
-naftiko: "1.0.0-alpha1"
+naftiko: "{{version}}"
 info:
   label: "{{capabilityName}}"
   description: "business-description-of-your-capability"

--- a/src/main/resources/tutorial/shared/legacy-consumes.yaml
+++ b/src/main/resources/tutorial/shared/legacy-consumes.yaml
@@ -1,4 +1,4 @@
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 consumes:
   - namespace: legacy
     type: http

--- a/src/main/resources/tutorial/shared/registry-consumes.yaml
+++ b/src/main/resources/tutorial/shared/registry-consumes.yaml
@@ -1,4 +1,4 @@
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 consumes:
   - namespace: registry
     type: http

--- a/src/main/resources/tutorial/shared/secrets.yaml
+++ b/src/main/resources/tutorial/shared/secrets.yaml
@@ -1,3 +1,3 @@
 registry-bearer-token: "dummy-token"
-registry-api-version: "1.0.0-alpha1"
+registry-api-version: "1.0.0-alpha2"
 dockyard-api-key: "dummy-dockyard-key"

--- a/src/main/resources/tutorial/shared/step10-registry-consumes.yml
+++ b/src/main/resources/tutorial/shared/step10-registry-consumes.yml
@@ -1,5 +1,5 @@
 # shared/registry-consumes.yaml (final — added get-voyage + cargo resource)
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 consumes:
   - namespace: registry
     type: http

--- a/src/main/resources/tutorial/shared/step5-registry-consumes.yaml
+++ b/src/main/resources/tutorial/shared/step5-registry-consumes.yaml
@@ -1,4 +1,4 @@
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 consumes:
   - namespace: registry
     type: http

--- a/src/main/resources/tutorial/shared/step6-registry-consumes.yaml
+++ b/src/main/resources/tutorial/shared/step6-registry-consumes.yaml
@@ -1,5 +1,5 @@
 # shared/registry-consumes.yaml (updated — added voyages resource)
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 consumes:
   - namespace: registry
     type: http

--- a/src/main/resources/tutorial/shared/step7-registry-consumes.yml
+++ b/src/main/resources/tutorial/shared/step7-registry-consumes.yml
@@ -1,4 +1,4 @@
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 consumes:
   - namespace: registry
     type: http

--- a/src/main/resources/tutorial/step-1-shipyard-first-capability.yml
+++ b/src/main/resources/tutorial/step-1-shipyard-first-capability.yml
@@ -1,5 +1,5 @@
 ---
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 
 capability:
   consumes:

--- a/src/main/resources/tutorial/step-10-shipyard-fleet-manifest.yml
+++ b/src/main/resources/tutorial/step-10-shipyard-fleet-manifest.yml
@@ -1,5 +1,5 @@
 ---
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 
 info:
   label: "Shipyard Fleet Management"

--- a/src/main/resources/tutorial/step-2-shipyard-input-parameters.yml
+++ b/src/main/resources/tutorial/step-2-shipyard-input-parameters.yml
@@ -1,5 +1,5 @@
 ---
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 
 capability:
   consumes:

--- a/src/main/resources/tutorial/step-3-shipyard-auth-and-binds.yml
+++ b/src/main/resources/tutorial/step-3-shipyard-auth-and-binds.yml
@@ -1,5 +1,5 @@
 ---
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 
 binds:
   - namespace: "registry-env"

--- a/src/main/resources/tutorial/step-4-shipyard-output-shaping.yml
+++ b/src/main/resources/tutorial/step-4-shipyard-output-shaping.yml
@@ -1,5 +1,5 @@
 ---
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 
 binds:
   - namespace: "registry-env"

--- a/src/main/resources/tutorial/step-5-shipyard-multi-source.yml
+++ b/src/main/resources/tutorial/step-5-shipyard-multi-source.yml
@@ -1,5 +1,5 @@
 ---
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 
 binds:
   - namespace: "registry-env"

--- a/src/main/resources/tutorial/step-6-shipyard-write-operations.yml
+++ b/src/main/resources/tutorial/step-6-shipyard-write-operations.yml
@@ -1,5 +1,5 @@
 ---
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 
 binds:
   - namespace: "registry-env"

--- a/src/main/resources/tutorial/step-7-shipyard-orchestrated-lookup.yml
+++ b/src/main/resources/tutorial/step-7-shipyard-orchestrated-lookup.yml
@@ -1,5 +1,5 @@
 ---
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 
 binds:
   - namespace: "registry-env"

--- a/src/main/resources/tutorial/step-8-shipyard-skill-groups.yml
+++ b/src/main/resources/tutorial/step-8-shipyard-skill-groups.yml
@@ -1,5 +1,5 @@
 ---
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 
 binds:
   - namespace: "registry-env"

--- a/src/main/resources/tutorial/step-9-shipyard-rest-adapter.yml
+++ b/src/main/resources/tutorial/step-9-shipyard-rest-adapter.yml
@@ -1,5 +1,5 @@
 ---
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 
 binds:
   - namespace: "registry-env"

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,0 +1,1 @@
+version=${project.version}

--- a/src/test/java/io/naftiko/engine/consumes/http/CsvIntegrationTest.java
+++ b/src/test/java/io/naftiko/engine/consumes/http/CsvIntegrationTest.java
@@ -57,7 +57,7 @@ public class CsvIntegrationTest {
     public void testCapabilityLoaded() {
         assertNotNull(capability, "Capability should be initialized");
         assertNotNull(capability.getSpec(), "Capability spec should be loaded");
-        assertEquals("1.0.0-alpha1", capability.getSpec().getNaftiko(), "Naftiko version should be 0.5");
+        assertEquals("1.0.0-alpha2", capability.getSpec().getNaftiko(), "Naftiko version should be 0.5");
     }
 
     @Test

--- a/src/test/java/io/naftiko/engine/consumes/http/HtmlIntegrationTest.java
+++ b/src/test/java/io/naftiko/engine/consumes/http/HtmlIntegrationTest.java
@@ -50,7 +50,7 @@ public class HtmlIntegrationTest {
     @Test
     public void testCapabilityLoaded() {
         assertNotNull(capability, "Capability should be initialized");
-        assertEquals("1.0.0-alpha1", capability.getSpec().getNaftiko());
+        assertEquals("1.0.0-alpha2", capability.getSpec().getNaftiko());
     }
 
     @Test

--- a/src/test/java/io/naftiko/engine/consumes/http/MarkdownIntegrationTest.java
+++ b/src/test/java/io/naftiko/engine/consumes/http/MarkdownIntegrationTest.java
@@ -50,7 +50,7 @@ public class MarkdownIntegrationTest {
     @Test
     public void testCapabilityLoaded() {
         assertNotNull(capability, "Capability should be initialized");
-        assertEquals("1.0.0-alpha1", capability.getSpec().getNaftiko());
+        assertEquals("1.0.0-alpha2", capability.getSpec().getNaftiko());
     }
 
     @Test

--- a/src/test/java/io/naftiko/engine/consumes/http/ProtobufIntegrationTest.java
+++ b/src/test/java/io/naftiko/engine/consumes/http/ProtobufIntegrationTest.java
@@ -58,7 +58,7 @@ public class ProtobufIntegrationTest {
         public void testCapabilityLoaded() {
                 assertNotNull(capability, "Capability should be initialized");
                 assertNotNull(capability.getSpec(), "Capability spec should be loaded");
-                assertEquals("1.0.0-alpha1", capability.getSpec().getNaftiko(),
+                assertEquals("1.0.0-alpha2", capability.getSpec().getNaftiko(),
                                 "Naftiko version should be 0.5");
         }
 

--- a/src/test/java/io/naftiko/engine/consumes/http/XmlIntegrationTest.java
+++ b/src/test/java/io/naftiko/engine/consumes/http/XmlIntegrationTest.java
@@ -61,7 +61,7 @@ public class XmlIntegrationTest {
     public void testCapabilityLoaded() {
         assertNotNull(capability, "Capability should be initialized");
         assertNotNull(capability.getSpec(), "Capability spec should be loaded");
-        assertEquals("1.0.0-alpha1", capability.getSpec().getNaftiko(), "Naftiko version should be 0.5");
+        assertEquals("1.0.0-alpha2", capability.getSpec().getNaftiko(), "Naftiko version should be 0.5");
     }
 
     @Test

--- a/src/test/java/io/naftiko/engine/consumes/http/YamlIntegrationTest.java
+++ b/src/test/java/io/naftiko/engine/consumes/http/YamlIntegrationTest.java
@@ -60,7 +60,7 @@ public class YamlIntegrationTest {
     public void testCapabilityLoaded() {
         assertNotNull(capability, "Capability should be initialized");
         assertNotNull(capability.getSpec(), "Capability spec should be loaded");
-        assertEquals("1.0.0-alpha1", capability.getSpec().getNaftiko(), "Naftiko version should be 0.5");
+        assertEquals("1.0.0-alpha2", capability.getSpec().getNaftiko(), "Naftiko version should be 0.5");
     }
 
     @Test

--- a/src/test/java/io/naftiko/engine/exposes/mcp/McpIntegrationTest.java
+++ b/src/test/java/io/naftiko/engine/exposes/mcp/McpIntegrationTest.java
@@ -54,7 +54,7 @@ public class McpIntegrationTest {
     public void testCapabilityLoaded() {
         assertNotNull(capability, "Capability should be initialized");
         assertNotNull(capability.getSpec(), "Capability spec should be loaded");
-        assertEquals("1.0.0-alpha1", capability.getSpec().getNaftiko(), "Naftiko version should be 0.5");
+        assertEquals("1.0.0-alpha2", capability.getSpec().getNaftiko(), "Naftiko version should be 1.0.0-alpha2");
     }
 
     @Test

--- a/src/test/java/io/naftiko/engine/exposes/mcp/ResourcesPromptsIntegrationTest.java
+++ b/src/test/java/io/naftiko/engine/exposes/mcp/ResourcesPromptsIntegrationTest.java
@@ -63,7 +63,7 @@ public class ResourcesPromptsIntegrationTest {
     @Test
     public void testCapabilityLoaded() {
         assertNotNull(capability, "Capability should be initialized");
-        assertEquals("1.0.0-alpha1", capability.getSpec().getNaftiko(), "Naftiko version should be 0.5");
+        assertEquals("1.0.0-alpha2", capability.getSpec().getNaftiko(), "Naftiko version should be 1.0.0-alpha2");
     }
 
     @Test

--- a/src/test/java/io/naftiko/engine/exposes/skill/SkillIntegrationTest.java
+++ b/src/test/java/io/naftiko/engine/exposes/skill/SkillIntegrationTest.java
@@ -78,7 +78,7 @@ public class SkillIntegrationTest {
     @Test
     public void testCapabilityLoaded() {
         assertNotNull(capability.getSpec());
-        assertEquals("1.0.0-alpha1", capability.getSpec().getNaftiko());
+        assertEquals("1.0.0-alpha2", capability.getSpec().getNaftiko());
     }
 
     @Test

--- a/src/test/java/io/naftiko/spec/exposes/SkillServerSpecRoundTripTest.java
+++ b/src/test/java/io/naftiko/spec/exposes/SkillServerSpecRoundTripTest.java
@@ -49,7 +49,7 @@ public class SkillServerSpecRoundTripTest {
 
     @Test
     public void testNaftikoVersionLoaded() {
-        assertEquals("1.0.0-alpha1", naftikoSpec.getNaftiko());
+        assertEquals("1.0.0-alpha2", naftikoSpec.getNaftiko());
     }
 
     @Test

--- a/src/test/resources/avro-capability.yaml
+++ b/src/test/resources/avro-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/naftiko-schema.json
 ---
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 info:
   label: "Avro Test Capability"
   description: "Test capability for Avro message decoding from API responses"

--- a/src/test/resources/baseuri-trailing-slash-capability.yaml
+++ b/src/test/resources/baseuri-trailing-slash-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/naftiko-schema.json
 ---
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 info:
   label: "BaseUri Trailing Slash Regression Test"
   description: "Capability intentionally using a trailing-slash baseUri to test strict validation"

--- a/src/test/resources/csv-capability.yaml
+++ b/src/test/resources/csv-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/naftiko-schema.json
 ---
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 info:
   label: "CSV Test Capability"
   description: "Test capability for CSV parsing from API responses"
@@ -48,7 +48,7 @@ capability:
       inputParameters:
         - name: "User-Agent"
           in: "header"
-          value: "Naftiko/1.0.0-alpha1"
+          value: "Naftiko/1.0.0-alpha2"
 
       resources:
         - path: "api/users"

--- a/src/test/resources/html-capability.yaml
+++ b/src/test/resources/html-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/naftiko-schema.json
 ---
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 info:
   label: "HTML Test Capability"
   description: "Test capability for HTML table parsing"

--- a/src/test/resources/http-body-capability.yaml
+++ b/src/test/resources/http-body-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/naftiko-schema.json
 ---
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 capability:
   exposes:
     - type: "rest"

--- a/src/test/resources/http-forward-value-capability.yaml
+++ b/src/test/resources/http-forward-value-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/naftiko-schema.json
 ---
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 info:
   label: "HTTP Forward with Value Field Test"
   description: "Test capability for forward spec with value field supporting Mustache templates"

--- a/src/test/resources/http-header-query-capability.yaml
+++ b/src/test/resources/http-header-query-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/naftiko-schema.json
 ---
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 capability:
   exposes:
     - type: "rest"

--- a/src/test/resources/markdown-capability.yaml
+++ b/src/test/resources/markdown-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/naftiko-schema.json
 ---
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 info:
   label: "Markdown Test Capability"
   description: "Test capability for Markdown parsing"

--- a/src/test/resources/mcp-capability.yaml
+++ b/src/test/resources/mcp-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/naftiko-schema.json
 ---
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 info:
   label: "MCP Test Capability"
   description: "Test capability for MCP Server Adapter deserialization and wiring"

--- a/src/test/resources/mcp-hints-capability.yaml
+++ b/src/test/resources/mcp-hints-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/naftiko-schema.json
 ---
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 info:
   label: "MCP Hints Test Capability"
   description: "Test capability for MCP tool hints (ToolAnnotations) support"

--- a/src/test/resources/mcp-resources-prompts-capability.yaml
+++ b/src/test/resources/mcp-resources-prompts-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/naftiko-schema.json
 ---
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 info:
   label: "MCP Resources & Prompts Test Capability"
   description: "Test capability for MCP Server Adapter resources and prompts support"

--- a/src/test/resources/mcp-stdio-capability.yaml
+++ b/src/test/resources/mcp-stdio-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/naftiko-schema.json
 ---
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 info:
   label: "MCP Stdio Test Capability"
   description: "Test capability for MCP Server Adapter with stdio transport"

--- a/src/test/resources/nested-object-output-capability.yaml
+++ b/src/test/resources/nested-object-output-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/naftiko-schema.json
 ---
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 info:
   label: "Nested Object Output Capability"
   description: "Test fixture for verifying that output mappings correctly resolve nested object

--- a/src/test/resources/proto-capability.yaml
+++ b/src/test/resources/proto-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/naftiko-schema.json
 ---
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 info:
   label: "Protobuf Test Capability"
   description: "Test capability for Protobuf message decoding from API responses"

--- a/src/test/resources/register.capability.yml
+++ b/src/test/resources/register.capability.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/naftiko-schema.json
 ---
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 info:
   label: "register"
   description: "Business description of your capability"

--- a/src/test/resources/skill-capability.yaml
+++ b/src/test/resources/skill-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/naftiko-schema.json
 ---
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 info:
   label: "Skill Test Capability"
   description: "Test capability for Skill Server Adapter deserialization and wiring"

--- a/src/test/resources/tool-handler-with-mustache-capability.yaml
+++ b/src/test/resources/tool-handler-with-mustache-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/naftiko-schema.json
 ---
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 
 capability:
   consumes:

--- a/src/test/resources/xml-capability.yaml
+++ b/src/test/resources/xml-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/naftiko-schema.json
 ---
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 info:
   label: "XML Test Capability"
   description: "Test capability for XML parsing from API responses"
@@ -48,7 +48,7 @@ capability:
       inputParameters:
         - name: "User-Agent"
           in: "header"
-          value: "Naftiko/1.0.0-alpha1"
+          value: "Naftiko/1.0.0-alpha2"
 
       resources:
         - path: "api/users"

--- a/src/test/resources/yaml-capability.yaml
+++ b/src/test/resources/yaml-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/naftiko-schema.json
 ---
-naftiko: "1.0.0-alpha1"
+naftiko: "1.0.0-alpha2"
 info:
   label: "YAML Test Capability"
   description: "Test capability for YAML parsing from API responses"
@@ -48,7 +48,7 @@ capability:
       inputParameters:
         - name: "User-Agent"
           in: "header"
-          value: "Naftiko/1.0.0-alpha1"
+          value: "Naftiko/1.0.0-2"
 
       resources:
         - path: "api/users"


### PR DESCRIPTION
…ty template

## Related Issue

Closes #176 

---

## What does this PR do?

Don't be afraid! The majority of modified files are just an update from 1.0.0-alpha1 to 1.0.0-alpha2.

Real updates are:
- Add a maven filtering configuration in pom.xml to allow feeding a new resource file: version.properties (with the value of the pom.xml version)
- Modify the CLI to use this version.properties to inject into the mustache template for capability.

---

## Tests

Update all existing tests with the version number of the pom.xml.

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main`
- [ ] Small and focused — one concern per PR
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

<!-- If this PR was created or assisted by an AI agent, provide metadata below (YAML) -->

```yaml
# agent_name:
# llm:
# tool:
# confidence:          # low | medium | high
# source_event:
# discovery_method:    # runtime_observation | code_review | test_failure | user_report
# review_focus:        # e.g. ClassName.java:line-range
```
