### PR TITLE
fix: patching the workflow t oskip gpg signing for github packages

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -16,6 +16,6 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
       - name: Publish snapshot
-        run: mvn --batch-mode deploy
+        run: mvn --batch-mode -Dgpg.skip=true deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Related Issue

No related Issue

---

## What does this PR do?

Since GitHub Packages doesn't force usage of GPG sign, we opted to skip it for now and configure it for maven central publish. 

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
