### PR TITLE
feat: configuring dual publish of mvn to ghcr and sonatype

### DIFF
--- a/.github/workflows/publish-mvn-release-ghcr.yml
+++ b/.github/workflows/publish-mvn-release-ghcr.yml
@@ -1,7 +1,7 @@
-name: Publish Snapshot to GitHub Packages
+name: Publish MVN Release to GitHub Packages
 on:
-  push:
-    branches: [main]
+  release:
+    types: [created]
 
 jobs:
   publish:
@@ -15,7 +15,9 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-      - name: Publish snapshot
-        run: mvn --batch-mode -Dgpg.skip=true deploy
+      - name: Strip SNAPSHOT from version
+        run: mvn versions:set -DremoveSnapshot -DgenerateBackupPoms=false
+      - name: Publish release
+        run: mvn --batch-mode deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-mvn-releases-sonatype.yml
+++ b/.github/workflows/publish-mvn-releases-sonatype.yml
@@ -1,0 +1,46 @@
+name: Publish MVN Release to Maven Central
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*' 
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout Source Code
+        uses: actions/checkout@v5
+
+      - name: Configure Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Configure Maven Credentials for Central
+        run: ./src/main/resources/scripts/builder.sh config_maven_central
+        env:
+          CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
+
+      - name: Configure GPG Key
+        run: ./src/main/resources/scripts/builder.sh config_gpg
+        env:
+          GPG_SIGNING_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Publish to Maven Central
+        run: ./src/main/resources/scripts/builder.sh central
+        env:
+          CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Cleanup sensitive files
+        if: always()
+        run: |
+          rm -rf ~/.gnupg
+          rm -f ~/.m2/settings.xml

--- a/.github/workflows/publish-mvn-snapshot-ghcr.yml
+++ b/.github/workflows/publish-mvn-snapshot-ghcr.yml
@@ -1,7 +1,7 @@
-name: Publish Release to GitHub Packages
+name: Publish MVN Snapshot to GitHub Packages
 on:
-  release:
-    types: [created]
+  push:
+    branches: [main]
 
 jobs:
   publish:
@@ -15,9 +15,7 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-      - name: Strip SNAPSHOT from version
-        run: mvn versions:set -DremoveSnapshot -DgenerateBackupPoms=false
-      - name: Publish release
-        run: mvn --batch-mode deploy
+      - name: Publish snapshot
+        run: mvn --batch-mode -Dgpg.skip=true deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -225,19 +225,6 @@
             </resource>
         </resources>
         <plugins>
-            <!-- Central Publishing Plugin -->
-            <plugin>
-                <groupId>org.sonatype.central</groupId>
-                <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.10.0</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <publishingServerId>central</publishingServerId>
-                    <autoPublish>true</autoPublish>
-                    <waitUntil>published</waitUntil>
-                </configuration>
-            </plugin>
-
             <!-- Source Plugin - generates source JAR -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -271,22 +258,6 @@
                     <doclint>none</doclint>
                     <source>21</source>
                 </configuration>
-            </plugin>
-
-            <!-- GPG Plugin - signs artifacts -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>3.1.0</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
                      
             <plugin>
@@ -403,8 +374,8 @@
         </plugins>
     </build>
 
-    <!-- Profile for GraalVM native build -->
     <profiles>
+        <!-- Profile for GraalVM native build -->
         <profile>
             <id>native</id>
             <build>
@@ -426,6 +397,47 @@
                                     <buildArgs>
                                         <buildArg>-H:+ReportExceptionStackTraces</buildArg>
                                     </buildArgs>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>central</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.10.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
+                        </configuration>
+                    </plugin>
+
+                    <!-- GPG Plugin - signs artifacts -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
                                 </configuration>
                             </execution>
                         </executions>

--- a/src/main/resources/scripts/builder.sh
+++ b/src/main/resources/scripts/builder.sh
@@ -1,0 +1,175 @@
+#!/bin/sh 
+cd "$(dirname "$0")/../../../.." || exit 1
+
+# FUNCTIONS
+print(){ printf "%s" "$*"; }
+println(){ printf "%s\n" "$*"; }
+
+build(){
+  mvn clean package --no-transfer-progress 
+}
+
+deploy_local(){
+  mvn clean install -DskipTests=true --no-transfer-progress
+}
+
+deploy_github(){
+  println "Deploying to GitHub Packages..."
+  mvn clean deploy -DskipTests=true --no-transfer-progress
+}
+
+deploy_central(){
+  println "Deploying to Maven Central..."
+  mvn clean deploy -P central -DskipTests=true --no-transfer-progress
+}
+
+deploy_remote(){
+  deploy_central
+}
+
+config_gpg(){
+  if [ "$GPG_SIGNING_KEY" = "" ]; then
+    println "ERROR: No GPG_SIGNING_KEY defined"
+    exit 200
+  fi
+
+  mkdir -p ~/.gnupg/
+  chmod 700 ~/.gnupg/
+  
+  print "${GPG_SIGNING_KEY}" | base64 --decode > ~/.gnupg/private.key
+  chmod 600 ~/.gnupg/private.key
+  gpg --batch --import ~/.gnupg/private.key
+  
+  cat <<EOF > ~/.gnupg/gpg.conf
+use-agent
+pinentry-mode loopback
+EOF
+
+  cat <<EOF > ~/.gnupg/gpg-agent.conf
+allow-loopback-pinentry
+EOF
+
+  gpgconf --kill gpg-agent || true
+  gpg-agent --daemon --allow-loopback-pinentry || true
+  
+  println "✓ GPG configured"
+}
+
+config_maven_github(){
+  if [ "$GITHUB_TOKEN" = "" ]; then
+    println "ERROR: Variable GITHUB_TOKEN not defined"
+    exit 202
+  fi
+
+  mkdir -p ~/.m2
+  
+  cat <<EOF> ~/.m2/settings.xml
+<settings>
+  <servers>
+    <server>
+      <id>github</id>
+      <username>\${env.GITHUB_ACTOR}</username>
+      <password>\${env.GITHUB_TOKEN}</password>
+    </server>
+  </servers>
+</settings>
+EOF
+  
+  println "✓ Maven configured for GitHub Packages"
+}
+
+config_maven_central(){
+  if [ "$CENTRAL_USERNAME" = "" ] || [ "$CENTRAL_PASSWORD" = "" ]; then
+    println "ERROR: Variables CENTRAL_USERNAME or CENTRAL_PASSWORD not defined"
+    println "Get your credentials on: https://central.sonatype.com/account"
+    exit 201
+  fi
+
+  mkdir -p ~/.m2
+  
+  cat <<EOF> ~/.m2/settings.xml
+<settings>
+  <servers>
+    <server>
+      <id>central</id>
+      <username>\${env.CENTRAL_USERNAME}</username>
+      <password>\${env.CENTRAL_PASSWORD}</password>
+    </server>
+  </servers>
+</settings>
+EOF
+  
+  println "✓ Maven configured for Maven Central"
+}
+
+config_maven_all(){
+  if [ "$GITHUB_TOKEN" = "" ]; then
+    println "WARNING: GITHUB_TOKEN not defined, skipping GitHub config"
+  fi
+  
+  if [ "$CENTRAL_USERNAME" = "" ] || [ "$CENTRAL_PASSWORD" = "" ]; then
+    println "WARNING: CENTRAL_USERNAME or CENTRAL_PASSWORD not defined, skipping Central config"
+  fi
+
+  mkdir -p ~/.m2
+  
+  cat <<EOF> ~/.m2/settings.xml
+<settings>
+  <servers>
+    <server>
+      <id>github</id>
+      <username>\${env.GITHUB_ACTOR}</username>
+      <password>\${env.GITHUB_TOKEN}</password>
+    </server>
+    <server>
+      <id>central</id>
+      <username>\${env.CENTRAL_USERNAME}</username>
+      <password>\${env.CENTRAL_PASSWORD}</password>
+    </server>
+  </servers>
+</settings>
+EOF
+  
+  println "✓ Maven configured for GitHub Packages AND Maven Central"
+}
+
+# MAIN
+case "$1" in
+  "build") build ;;
+  "deploy_local"|"local") deploy_local ;;
+  "deploy_github"|"github") deploy_github ;;
+  "deploy_central"|"central") deploy_central ;;
+  "deploy"|"remote") deploy_remote ;;
+  "config_maven_github") config_maven_github ;;
+  "config_maven_central"|"config_maven") config_maven_central ;;
+  "config_maven_all") config_maven_all ;;
+  "config_gpg") config_gpg ;;
+  *)
+    cat <<EOF | sed 's/^[ \t]*//'
+      Usage: $0 <OPTION>
+
+      Where OPTION is one of the following:
+      
+      Build:
+      - build                    
+      - local / deploy_local     
+      
+      Deploy:
+      - github / deploy_github   
+      - central / deploy_central 
+      - deploy / remote          
+      
+      Configuration:
+      - config_maven_github      
+      - config_maven_central     
+      - config_maven / config_maven_all 
+      - config_gpg               
+
+      Examples:
+      - Publish snapshot to GitHub: $0 github
+      - Publish release to Maven Central: $0 central
+
+EOF
+    exit 1
+  ;;
+esac


### PR DESCRIPTION
## Related Issue

Closes https://github.com/naftiko/framework/issues/312

---

## What does this PR do?

Adding the capacity to also publish mvn release to Maven Central.
Why?
-GitHub Packages for rapid dev and snapshots, Maven Central for official public distribution.

so now : 

w/o profile → GitHub Packages (default)
mvn deploy  

w/ central profile → Maven Central
mvn deploy -P central

**was inspired by this ref**
https://github.com/Skullabs/injector/

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

