### PR TITLE
Fix/apikey placement npe

### DIFF
--- a/src/main/java/io/naftiko/engine/consumes/http/HttpClientAdapter.java
+++ b/src/main/java/io/naftiko/engine/consumes/http/HttpClientAdapter.java
@@ -133,6 +133,11 @@ public class HttpClientAdapter extends ClientAdapter {
                             Resolver.resolveMustacheTemplate(apiKeyAuth.getValue(), parameters);
                     String placement = apiKeyAuth.getPlacement();
 
+                    if (placement == null) {
+                        throw new IllegalArgumentException(
+                                "Placement is required for apikey authentication (expected: header or query)");
+                    }
+
                     if (placement.equals("header")) {
                         clientRequest.getHeaders().add(key, value);
                     } else if (placement.equals("query")) {

--- a/src/test/java/io/naftiko/engine/consumes/http/HttpClientAdapterTest.java
+++ b/src/test/java/io/naftiko/engine/consumes/http/HttpClientAdapterTest.java
@@ -129,7 +129,7 @@ public class HttpClientAdapterTest {
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
                 () -> adapter.setChallengeResponse(null, clientRequest,
                         clientRequest.getResourceRef().toString(), Map.of()));
-        assertEquals("placement is required for apikey authentication (expected: header or query)",
+        assertEquals("Placement is required for apikey authentication (expected: header or query)",
                 ex.getMessage());
     }
 }

--- a/src/test/java/io/naftiko/engine/consumes/http/HttpClientAdapterTest.java
+++ b/src/test/java/io/naftiko/engine/consumes/http/HttpClientAdapterTest.java
@@ -15,6 +15,7 @@ package io.naftiko.engine.consumes.http;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.junit.jupiter.api.Test;
@@ -111,5 +112,24 @@ public class HttpClientAdapterTest {
         assertEquals("bob", clientRequest.getChallengeResponse().getIdentifier());
         assertEquals("forwarded-secret",
                 String.valueOf(clientRequest.getChallengeResponse().getSecret()));
+    }
+
+    @Test
+    public void setChallengeResponseShouldThrowWhenApiKeyPlacementIsMissing() {
+        HttpClientSpec spec = new HttpClientSpec("apikey", "https://api.example.com", null);
+        ApiKeyAuthenticationSpec authentication = new ApiKeyAuthenticationSpec();
+        authentication.setType("apikey");
+        authentication.setKey("X-Dock-Key");
+        authentication.setValue("MY_API_KEY");
+        spec.setAuthentication(authentication);
+
+        HttpClientAdapter adapter = new HttpClientAdapter(null, spec);
+        Request clientRequest = new Request(Method.GET, "https://api.example.com/v1/items");
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> adapter.setChallengeResponse(null, clientRequest,
+                        clientRequest.getResourceRef().toString(), Map.of()));
+        assertEquals("placement is required for apikey authentication (expected: header or query)",
+                ex.getMessage());
     }
 }


### PR DESCRIPTION
## Related Issue

Closes #212

---

## What does this PR do?

When an `apikey` authentication spec omits the `placement` field, `HttpClientAdapter.setChallengeResponse()` threw a `NullPointerException` on `placement.equals("header")`.

This PR adds a null guard that throws a clear `IllegalArgumentException` with the message `"placement is required for apikey authentication (expected: header or query)"`.

---

## Tests

Added `setChallengeResponseShouldThrowWhenApiKeyPlacementIsMissing` in `HttpClientAdapterTest` — verifies the exception type and message when `placement` is omitted.

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: claude-opus-4-5
tool: VS Code Chat
confidence: high
source_event: "#212"
discovery_method: user_report
review_focus: HttpClientAdapter.java:136-140