### PR TITLE
feat: add distributed tracing with optional OpenTelemetry SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
         <json-smart.version>2.5.2</json-smart.version>
         <junit.jupiter.version>5.12.2</junit.jupiter.version>
         <jacoco.version>0.8.13</jacoco.version>
+        <slf4j.version>2.0.17</slf4j.version>
         <opentelemetry.version>1.48.0</opentelemetry.version>
     </properties>
 
@@ -121,14 +122,21 @@
             <version>${restlet.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>1.5.18</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jul-to-slf4j</artifactId>
-            <version>2.0.17</version>
+            <version>${slf4j.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
         <json-smart.version>2.5.2</json-smart.version>
         <junit.jupiter.version>5.12.2</junit.jupiter.version>
         <jacoco.version>0.8.13</jacoco.version>
+        <opentelemetry.version>1.48.0</opentelemetry.version>
     </properties>
 
     <distributionManagement>
@@ -128,6 +129,35 @@
             <groupId>org.slf4j</groupId>
             <artifactId>jul-to-slf4j</artifactId>
             <version>2.0.17</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <version>${opentelemetry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+            <version>${opentelemetry.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+            <version>${opentelemetry.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+            <version>${opentelemetry.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-logback-appender-1.0</artifactId>
+            <version>2.14.0-alpha</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
@@ -227,6 +257,12 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+            <version>${opentelemetry.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/naftiko/Capability.java
+++ b/src/main/java/io/naftiko/Capability.java
@@ -25,6 +25,7 @@ import io.naftiko.engine.aggregates.Aggregate;
 import io.naftiko.engine.aggregates.AggregateFunction;
 import io.naftiko.engine.aggregates.AggregateRefResolver;
 import io.naftiko.engine.exposes.OperationStepExecutor;
+import io.naftiko.engine.telemetry.TelemetryBootstrap;
 import io.naftiko.spec.aggregates.AggregateSpec;
 import io.naftiko.spec.util.ExecutionContext;
 import io.naftiko.engine.consumes.ClientAdapter;
@@ -231,6 +232,12 @@ public class Capability {
                 // Ignore unknown properties to handle potential Restlet framework classes
                 mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
                 NaftikoSpec spec = mapper.readValue(file, NaftikoSpec.class);
+                // Initialize OpenTelemetry with service name from spec
+                String serviceName = "naftiko";
+                if (spec.getInfo() != null && spec.getInfo().getLabel() != null) {
+                    serviceName = "naftiko-" + spec.getInfo().getLabel();
+                }
+                TelemetryBootstrap.init(serviceName);
                 // Pass the capability directory for bind file resolution
                 String capabilityDir = file.getParent();
                 Capability capability = new Capability(spec, capabilityDir);

--- a/src/main/java/io/naftiko/engine/aggregates/AggregateFunction.java
+++ b/src/main/java/io/naftiko/engine/aggregates/AggregateFunction.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.naftiko.engine.exposes.OperationStepExecutor;
+import io.naftiko.engine.telemetry.TelemetryBootstrap;
 import io.naftiko.engine.util.Resolver;
 import io.naftiko.spec.aggregates.AggregateFunctionSpec;
 import io.naftiko.spec.InputParameterSpec;
@@ -27,6 +28,8 @@ import io.naftiko.spec.aggregates.SemanticsSpec;
 import io.naftiko.spec.exposes.OperationStepSpec;
 import io.naftiko.spec.exposes.ServerCallSpec;
 import io.naftiko.spec.exposes.StepOutputMappingSpec;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Scope;
 
 /**
  * Runtime-executable wrapper around an {@link AggregateFunctionSpec}.
@@ -98,6 +101,19 @@ public class AggregateFunction {
      * @return a transport-neutral {@link FunctionResult}
      */
     public FunctionResult execute(Map<String, Object> parameters) throws Exception {
+        String ref = namespace + "." + spec.getName();
+        Span span = TelemetryBootstrap.get().startAggregateFunctionSpan(ref);
+        try (Scope scope = span.makeCurrent()) {
+            return doExecute(parameters);
+        } catch (Exception e) {
+            TelemetryBootstrap.recordError(span, e);
+            throw e;
+        } finally {
+            TelemetryBootstrap.endSpan(span);
+        }
+    }
+
+    FunctionResult doExecute(Map<String, Object> parameters) throws Exception {
         Map<String, Object> merged = new HashMap<>();
         if (parameters != null) {
             merged.putAll(parameters);

--- a/src/main/java/io/naftiko/engine/exposes/OperationStepExecutor.java
+++ b/src/main/java/io/naftiko/engine/exposes/OperationStepExecutor.java
@@ -739,7 +739,7 @@ public class OperationStepExecutor {
         public Request clientRequest;
         public Response clientResponse;
 
-        @SuppressWarnings("null")
+        @SuppressWarnings("null") // OTel SDK interop
         public void handle() {
             TelemetryBootstrap telemetry = TelemetryBootstrap.get();
 

--- a/src/main/java/io/naftiko/engine/exposes/OperationStepExecutor.java
+++ b/src/main/java/io/naftiko/engine/exposes/OperationStepExecutor.java
@@ -739,6 +739,7 @@ public class OperationStepExecutor {
         public Request clientRequest;
         public Response clientResponse;
 
+        @SuppressWarnings("null")
         public void handle() {
             TelemetryBootstrap telemetry = TelemetryBootstrap.get();
 

--- a/src/main/java/io/naftiko/engine/exposes/OperationStepExecutor.java
+++ b/src/main/java/io/naftiko/engine/exposes/OperationStepExecutor.java
@@ -740,11 +740,7 @@ public class OperationStepExecutor {
         public Response clientResponse;
 
         public void handle() {
-            // Inject W3C trace context into outbound request headers
             TelemetryBootstrap telemetry = TelemetryBootstrap.get();
-            telemetry.getOpenTelemetry().getPropagators().getTextMapPropagator()
-                    .inject(io.opentelemetry.context.Context.current(), clientRequest,
-                            RestletHeaderSetter.INSTANCE);
 
             String method = clientRequest.getMethod() != null
                     ? clientRequest.getMethod().getName() : "UNKNOWN";
@@ -753,6 +749,12 @@ public class OperationStepExecutor {
 
             Span span = telemetry.startClientSpan(method, url);
             try (Scope scope = span.makeCurrent()) {
+                // Inject W3C trace context after the client span is current
+                // so downstream services see this span as the parent
+                telemetry.getOpenTelemetry().getPropagators().getTextMapPropagator()
+                        .inject(io.opentelemetry.context.Context.current(), clientRequest,
+                                RestletHeaderSetter.INSTANCE);
+
                 clientAdapter.getHttpClient().handle(clientRequest, clientResponse);
 
                 if (clientResponse != null && clientResponse.getStatus() != null) {

--- a/src/main/java/io/naftiko/engine/exposes/OperationStepExecutor.java
+++ b/src/main/java/io/naftiko/engine/exposes/OperationStepExecutor.java
@@ -32,6 +32,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.naftiko.Capability;
 import io.naftiko.engine.consumes.ClientAdapter;
 import io.naftiko.engine.consumes.http.HttpClientAdapter;
+import io.naftiko.engine.telemetry.RestletHeaderSetter;
+import io.naftiko.engine.telemetry.TelemetryBootstrap;
 import io.naftiko.engine.util.LookupExecutor;
 import io.naftiko.engine.util.Resolver;
 import io.naftiko.engine.util.StepExecutionContext;
@@ -46,6 +48,8 @@ import io.naftiko.spec.exposes.OperationStepSpec;
 import io.naftiko.spec.exposes.OperationStepCallSpec;
 import io.naftiko.spec.exposes.OperationStepLookupSpec;
 import io.naftiko.spec.exposes.StepOutputMappingSpec;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Scope;
 
 /**
  * Executor for orchestrated operation steps.
@@ -163,85 +167,109 @@ public class OperationStepExecutor {
             return new StepExecutionResult(lastContext, stepContext);
         }
 
-        for (OperationStepSpec step : steps) {
+        for (int stepIndex = 0; stepIndex < steps.size(); stepIndex++) {
+            OperationStepSpec step = steps.get(stepIndex);
             switch (step) {
                 case OperationStepCallSpec callStep -> {
-                    lastContext = executeCallStep(callStep, runtimeParameters);
+                    Span stepSpan = TelemetryBootstrap.get()
+                            .startStepCallSpan(stepIndex, callStep.getCall());
+                    try (Scope stepScope = stepSpan.makeCurrent()) {
+                        lastContext = executeCallStep(callStep, runtimeParameters);
 
-                    if (lastContext == null) {
-                        throw new IllegalArgumentException("Invalid call format: "
-                                + (callStep.getCall() != null ? callStep.getCall() : "null"));
-                    }
-
-                    try {
-                        lastContext.handle();
-                    } catch (Exception e) {
-                        throw new RuntimeException("Error while handling an HTTP client call", e);
-                    }
-
-                    // Store call output for lookup references when response is valid JSON
-                    if (lastContext.clientResponse != null
-                            && lastContext.clientResponse.getEntity() != null) {
-                        try {
-                            if (!(lastContext.clientResponse
-                                    .getEntity() instanceof StringRepresentation)) {
-                                lastContext.clientResponse.setEntity(new StringRepresentation(
-                                        lastContext.clientResponse.getEntity().getText(),
-                                        lastContext.clientResponse.getEntity().getMediaType()));
-                            }
-
-                            JsonNode rawOutput = mapper
-                                    .readTree(lastContext.clientResponse.getEntity().getReader());
-                            JsonNode stepOutput = resolveStepOutput(lastContext, rawOutput);
-                            stepContext.storeStepOutput(callStep.getName(), stepOutput);
-                            addStepOutputToParameters(runtimeParameters, callStep.getName(),
-                                    stepOutput);
-                        } catch (Exception ignoreJsonParseError) {
-                            // Ignore non-JSON call output for lookup indexing
+                        if (lastContext == null) {
+                            throw new IllegalArgumentException("Invalid call format: "
+                                    + (callStep.getCall() != null ? callStep.getCall() : "null"));
                         }
+
+                        try {
+                            lastContext.handle();
+                        } catch (Exception e) {
+                            throw new RuntimeException(
+                                    "Error while handling an HTTP client call", e);
+                        }
+
+                        // Store call output for lookup references when response is valid JSON
+                        if (lastContext.clientResponse != null
+                                && lastContext.clientResponse.getEntity() != null) {
+                            try {
+                                if (!(lastContext.clientResponse
+                                        .getEntity() instanceof StringRepresentation)) {
+                                    lastContext.clientResponse
+                                            .setEntity(new StringRepresentation(
+                                                    lastContext.clientResponse.getEntity()
+                                                            .getText(),
+                                                    lastContext.clientResponse.getEntity()
+                                                            .getMediaType()));
+                                }
+
+                                JsonNode rawOutput = mapper.readTree(
+                                        lastContext.clientResponse.getEntity().getReader());
+                                JsonNode stepOutput =
+                                        resolveStepOutput(lastContext, rawOutput);
+                                stepContext.storeStepOutput(callStep.getName(), stepOutput);
+                                addStepOutputToParameters(runtimeParameters,
+                                        callStep.getName(), stepOutput);
+                            } catch (Exception ignoreJsonParseError) {
+                                // Ignore non-JSON call output for lookup indexing
+                            }
+                        }
+                    } catch (Exception e) {
+                        TelemetryBootstrap.recordError(stepSpan, e);
+                        throw e;
+                    } finally {
+                        TelemetryBootstrap.endSpan(stepSpan);
                     }
                 }
                 case OperationStepLookupSpec lookupStep -> {
-                    JsonNode indexData = stepContext.getStepOutput(lookupStep.getIndex());
+                    Span stepSpan = TelemetryBootstrap.get()
+                            .startStepLookupSpan(stepIndex, lookupStep.getMatch());
+                    try (Scope stepScope = stepSpan.makeCurrent()) {
+                        JsonNode indexData = stepContext.getStepOutput(lookupStep.getIndex());
 
-                    if (indexData == null) {
-                        throw new IllegalArgumentException(
-                                "Lookup step references non-existent step: "
-                                        + lookupStep.getIndex());
-                    }
-
-                    String resolvedLookupValue = Resolver.resolveMustacheTemplate(
-                            lookupStep.getLookupValue(), runtimeParameters);
-
-                    // Resolve lookup value from step context (JsonPath) when applicable
-                    JsonNode lookupValueNode = resolveJsonPathFromStepContext(
-                            lookupStep.getLookupValue(), stepContext);
-
-                    JsonNode lookupResult;
-                    if (lookupValueNode != null && lookupValueNode.isArray()) {
-                        // Multi-value lookup: collect results into an array
-                        ArrayNode resultArray = mapper.createArrayNode();
-                        for (JsonNode item : lookupValueNode) {
-                            JsonNode match = LookupExecutor.executeLookup(indexData,
-                                    lookupStep.getMatch(), item.asText(),
-                                    lookupStep.getOutputParameters());
-                            if (match != null) {
-                                resultArray.add(match);
-                            }
+                        if (indexData == null) {
+                            throw new IllegalArgumentException(
+                                    "Lookup step references non-existent step: "
+                                            + lookupStep.getIndex());
                         }
-                        lookupResult = resultArray.isEmpty() ? null : resultArray;
-                    } else if (lookupValueNode != null) {
-                        lookupResult = LookupExecutor.executeLookup(indexData,
-                                lookupStep.getMatch(), lookupValueNode.asText(),
-                                lookupStep.getOutputParameters());
-                    } else {
-                        lookupResult = LookupExecutor.executeLookup(indexData,
-                                lookupStep.getMatch(), resolvedLookupValue,
-                                lookupStep.getOutputParameters());
-                    }
 
-                    if (lookupResult != null) {
-                        stepContext.storeStepOutput(lookupStep.getName(), lookupResult);
+                        String resolvedLookupValue = Resolver.resolveMustacheTemplate(
+                                lookupStep.getLookupValue(), runtimeParameters);
+
+                        // Resolve lookup value from step context (JsonPath) when applicable
+                        JsonNode lookupValueNode = resolveJsonPathFromStepContext(
+                                lookupStep.getLookupValue(), stepContext);
+
+                        JsonNode lookupResult;
+                        if (lookupValueNode != null && lookupValueNode.isArray()) {
+                            // Multi-value lookup: collect results into an array
+                            ArrayNode resultArray = mapper.createArrayNode();
+                            for (JsonNode item : lookupValueNode) {
+                                JsonNode match = LookupExecutor.executeLookup(indexData,
+                                        lookupStep.getMatch(), item.asText(),
+                                        lookupStep.getOutputParameters());
+                                if (match != null) {
+                                    resultArray.add(match);
+                                }
+                            }
+                            lookupResult = resultArray.isEmpty() ? null : resultArray;
+                        } else if (lookupValueNode != null) {
+                            lookupResult = LookupExecutor.executeLookup(indexData,
+                                    lookupStep.getMatch(), lookupValueNode.asText(),
+                                    lookupStep.getOutputParameters());
+                        } else {
+                            lookupResult = LookupExecutor.executeLookup(indexData,
+                                    lookupStep.getMatch(), resolvedLookupValue,
+                                    lookupStep.getOutputParameters());
+                        }
+
+                        if (lookupResult != null) {
+                            stepContext.storeStepOutput(lookupStep.getName(), lookupResult);
+                        }
+                    } catch (Exception e) {
+                        TelemetryBootstrap.recordError(stepSpan, e);
+                        throw e;
+                    } finally {
+                        TelemetryBootstrap.endSpan(stepSpan);
                     }
                 }
                 default -> {
@@ -712,7 +740,35 @@ public class OperationStepExecutor {
         public Response clientResponse;
 
         public void handle() {
-            clientAdapter.getHttpClient().handle(clientRequest, clientResponse);
+            // Inject W3C trace context into outbound request headers
+            TelemetryBootstrap telemetry = TelemetryBootstrap.get();
+            telemetry.getOpenTelemetry().getPropagators().getTextMapPropagator()
+                    .inject(io.opentelemetry.context.Context.current(), clientRequest,
+                            RestletHeaderSetter.INSTANCE);
+
+            String method = clientRequest.getMethod() != null
+                    ? clientRequest.getMethod().getName() : "UNKNOWN";
+            String url = clientRequest.getResourceRef() != null
+                    ? clientRequest.getResourceRef().toString() : "unknown";
+
+            Span span = telemetry.startClientSpan(method, url);
+            try (Scope scope = span.makeCurrent()) {
+                clientAdapter.getHttpClient().handle(clientRequest, clientResponse);
+
+                if (clientResponse != null && clientResponse.getStatus() != null) {
+                    int statusCode = clientResponse.getStatus().getCode();
+                    span.setAttribute(TelemetryBootstrap.ATTR_HTTP_STATUS_CODE, statusCode);
+                    if (statusCode >= 500) {
+                        span.setStatus(io.opentelemetry.api.trace.StatusCode.ERROR,
+                                "HTTP " + statusCode);
+                    }
+                }
+            } catch (Exception e) {
+                TelemetryBootstrap.recordError(span, e);
+                throw e;
+            } finally {
+                TelemetryBootstrap.endSpan(span);
+            }
         }
     }
 

--- a/src/main/java/io/naftiko/engine/exposes/OperationStepExecutor.java
+++ b/src/main/java/io/naftiko/engine/exposes/OperationStepExecutor.java
@@ -172,7 +172,7 @@ public class OperationStepExecutor {
             switch (step) {
                 case OperationStepCallSpec callStep -> {
                     Span stepSpan = TelemetryBootstrap.get()
-                            .startStepCallSpan(stepIndex, callStep.getCall());
+                            .startStepCallSpan(stepIndex, callStep.getCall(), exposeNamespace);
                     try (Scope stepScope = stepSpan.makeCurrent()) {
                         lastContext = executeCallStep(callStep, runtimeParameters);
 
@@ -747,8 +747,9 @@ public class OperationStepExecutor {
                     ? clientRequest.getMethod().getName() : "UNKNOWN";
             String url = clientRequest.getResourceRef() != null
                     ? clientRequest.getResourceRef().toString() : "unknown";
+            String namespace = clientAdapter.getHttpClientSpec().getNamespace();
 
-            Span span = telemetry.startClientSpan(method, url);
+            Span span = telemetry.startClientSpan(method, url, namespace);
             try (Scope scope = span.makeCurrent()) {
                 // Inject W3C trace context after the client span is current
                 // so downstream services see this span as the parent

--- a/src/main/java/io/naftiko/engine/exposes/mcp/McpServerAdapter.java
+++ b/src/main/java/io/naftiko/engine/exposes/mcp/McpServerAdapter.java
@@ -100,6 +100,11 @@ public class McpServerAdapter extends ServerAdapter {
         Context context = new Context();
         context.getAttributes().put("dispatcher", dispatcher);
         context.getAttributes().put("activeSessions", activeSessions);
+        if (getCapability().getSpec().getInfo() != null
+                && getCapability().getSpec().getInfo().getLabel() != null) {
+            context.getAttributes().put("capabilityName",
+                    getCapability().getSpec().getInfo().getLabel());
+        }
 
         Router router = new Router(context);
         router.attachDefault(McpServerResource.class);

--- a/src/main/java/io/naftiko/engine/exposes/mcp/McpServerResource.java
+++ b/src/main/java/io/naftiko/engine/exposes/mcp/McpServerResource.java
@@ -26,6 +26,7 @@ import org.restlet.resource.Post;
 import org.restlet.resource.ServerResource;
 import io.naftiko.engine.telemetry.RestletHeaderGetter;
 import io.naftiko.engine.telemetry.TelemetryBootstrap;
+import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Scope;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -64,12 +65,13 @@ public class McpServerResource extends ServerResource {
                         RestletHeaderGetter.INSTANCE);
 
         try (Scope ignored = extractedContext.makeCurrent()) {
-            return dispatchWithTraceContext(dispatcher, mapper, entity);
+            return dispatchWithTraceContext(dispatcher, mapper, entity, extractedContext);
         }
     }
 
     private Representation dispatchWithTraceContext(ProtocolDispatcher dispatcher,
-            ObjectMapper mapper, Representation entity) {
+            ObjectMapper mapper, Representation entity,
+            io.opentelemetry.context.Context extractedContext) {
         try {
             String body = (entity != null) ? entity.getText() : null;
 
@@ -97,15 +99,26 @@ public class McpServerResource extends ServerResource {
                 return new StringRepresentation("");
             }
 
-            // Delegate to the shared protocol dispatcher
-            ObjectNode result = dispatcher.dispatch(root);
+            // Create a SERVER span for the inbound MCP request
+            String capabilityName = (String) getContext().getAttributes().get("capabilityName");
+            Span span = TelemetryBootstrap.get().startServerSpan("mcp", rpcMethod,
+                    extractedContext, null, capabilityName);
+            try (Scope scope = span.makeCurrent()) {
+                // Delegate to the shared protocol dispatcher
+                ObjectNode result = dispatcher.dispatch(root);
 
-            if (result != null) {
-                return toJsonRepresentation(mapper, result);
-            } else {
-                // Notification — no response body
-                setStatus(Status.SUCCESS_ACCEPTED);
-                return new StringRepresentation("");
+                if (result != null) {
+                    return toJsonRepresentation(mapper, result);
+                } else {
+                    // Notification — no response body
+                    setStatus(Status.SUCCESS_ACCEPTED);
+                    return new StringRepresentation("");
+                }
+            } catch (Exception e) {
+                TelemetryBootstrap.recordError(span, e);
+                throw e;
+            } finally {
+                TelemetryBootstrap.endSpan(span);
             }
 
         } catch (JsonProcessingException e) {

--- a/src/main/java/io/naftiko/engine/exposes/mcp/McpServerResource.java
+++ b/src/main/java/io/naftiko/engine/exposes/mcp/McpServerResource.java
@@ -24,6 +24,9 @@ import org.restlet.resource.Delete;
 import org.restlet.resource.Get;
 import org.restlet.resource.Post;
 import org.restlet.resource.ServerResource;
+import io.naftiko.engine.telemetry.RestletHeaderGetter;
+import io.naftiko.engine.telemetry.TelemetryBootstrap;
+import io.opentelemetry.context.Scope;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -51,6 +54,21 @@ public class McpServerResource extends ServerResource {
         ProtocolDispatcher dispatcher = getDispatcher();
         ObjectMapper mapper = dispatcher.getMapper();
 
+        // Extract W3C trace context from incoming HTTP headers so downstream
+        // spans (tools/call) are linked to the caller's trace.
+        TelemetryBootstrap telemetry = TelemetryBootstrap.get();
+        io.opentelemetry.context.Context extractedContext = telemetry.getOpenTelemetry()
+                .getPropagators().getTextMapPropagator()
+                .extract(io.opentelemetry.context.Context.current(), getRequest(),
+                        RestletHeaderGetter.INSTANCE);
+
+        try (Scope ignored = extractedContext.makeCurrent()) {
+            return dispatchWithTraceContext(dispatcher, mapper, entity);
+        }
+    }
+
+    private Representation dispatchWithTraceContext(ProtocolDispatcher dispatcher,
+            ObjectMapper mapper, Representation entity) {
         try {
             String body = (entity != null) ? entity.getText() : null;
 

--- a/src/main/java/io/naftiko/engine/exposes/mcp/McpServerResource.java
+++ b/src/main/java/io/naftiko/engine/exposes/mcp/McpServerResource.java
@@ -51,7 +51,7 @@ public class McpServerResource extends ServerResource {
     private static final String HEADER_MCP_SESSION_ID = "Mcp-Session-Id";
 
     @Post("json")
-    @SuppressWarnings("null")
+    @SuppressWarnings("null") // OTel SDK interop
     public Representation handlePost(Representation entity) {
         ProtocolDispatcher dispatcher = getDispatcher();
         ObjectMapper mapper = dispatcher.getMapper();
@@ -59,10 +59,11 @@ public class McpServerResource extends ServerResource {
         // Extract W3C trace context from incoming HTTP headers so downstream
         // spans (tools/call) are linked to the caller's trace.
         TelemetryBootstrap telemetry = TelemetryBootstrap.get();
-        io.opentelemetry.context.Context extractedContext = telemetry.getOpenTelemetry()
-                .getPropagators().getTextMapPropagator()
-                .extract(io.opentelemetry.context.Context.current(), getRequest(),
-                        RestletHeaderGetter.INSTANCE);
+        io.opentelemetry.context.Context extractedContext = java.util.Objects.requireNonNull(
+                telemetry.getOpenTelemetry()
+                        .getPropagators().getTextMapPropagator()
+                        .extract(io.opentelemetry.context.Context.current(), getRequest(),
+                                RestletHeaderGetter.INSTANCE));
 
         try (Scope ignored = extractedContext.makeCurrent()) {
             return dispatchWithTraceContext(dispatcher, mapper, entity, extractedContext);

--- a/src/main/java/io/naftiko/engine/exposes/mcp/McpServerResource.java
+++ b/src/main/java/io/naftiko/engine/exposes/mcp/McpServerResource.java
@@ -50,6 +50,7 @@ public class McpServerResource extends ServerResource {
     private static final String HEADER_MCP_SESSION_ID = "Mcp-Session-Id";
 
     @Post("json")
+    @SuppressWarnings("null")
     public Representation handlePost(Representation entity) {
         ProtocolDispatcher dispatcher = getDispatcher();
         ObjectMapper mapper = dispatcher.getMapper();

--- a/src/main/java/io/naftiko/engine/exposes/mcp/ResourceHandler.java
+++ b/src/main/java/io/naftiko/engine/exposes/mcp/ResourceHandler.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Logger;
 import org.restlet.Context;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -43,8 +42,6 @@ import io.naftiko.spec.exposes.McpServerResourceSpec;
  * validation to prevent directory traversal.</p>
  */
 public class ResourceHandler {
-
-    private static final Logger logger = Context.getCurrentLogger();
 
     /** Allowed path segment characters — no {@code ..}, no special characters. */
     private static final Pattern SAFE_SEGMENT = Pattern.compile("^[a-zA-Z0-9._-]+$");
@@ -223,7 +220,7 @@ public class ResourceHandler {
                         entries.add(entry);
                     });
         } catch (IOException e) {
-            logger.warning("Cannot list static resource directory for '" + spec.getName()
+            Context.getCurrentLogger().warning("Cannot list static resource directory for '" + spec.getName()
                     + "': " + e.getMessage());
         }
         return entries;

--- a/src/main/java/io/naftiko/engine/exposes/mcp/ToolHandler.java
+++ b/src/main/java/io/naftiko/engine/exposes/mcp/ToolHandler.java
@@ -18,7 +18,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Logger;
 import org.restlet.Context;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.naftiko.Capability;
@@ -42,7 +41,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class ToolHandler {
 
-    private static final Logger logger = Context.getCurrentLogger();
     private final Capability capability;
     private final Map<String, McpServerToolSpec> toolSpecs;
     private final OperationStepExecutor stepExecutor;
@@ -154,7 +152,7 @@ public class ToolHandler {
         } catch (IllegalArgumentException e) {
             throw e;
         } catch (Exception e) {
-            logger.warning("Error during HTTP client call for tool '" + toolName + "': " + e);
+            Context.getCurrentLogger().warning("Error during HTTP client call for tool '" + toolName + "': " + e);
             return new McpSchema.CallToolResult(
                     List.of(new McpSchema.TextContent(
                             "Error during HTTP client call: " + e.getMessage())),
@@ -193,7 +191,7 @@ public class ToolHandler {
         } catch (IllegalArgumentException e) {
             throw e;
         } catch (Exception e) {
-            logger.warning("Error during aggregate function call for tool '" + toolName + "': "
+            Context.getCurrentLogger().warning("Error during aggregate function call for tool '" + toolName + "': "
                     + e);
             return new McpSchema.CallToolResult(
                     List.of(new McpSchema.TextContent(

--- a/src/main/java/io/naftiko/engine/exposes/mcp/ToolHandler.java
+++ b/src/main/java/io/naftiko/engine/exposes/mcp/ToolHandler.java
@@ -72,7 +72,8 @@ public class ToolHandler {
     public McpSchema.CallToolResult handleToolCall(String toolName, Map<String, Object> arguments)
             throws Exception {
 
-        Span span = TelemetryBootstrap.get().startServerSpan("mcp", toolName);
+        Span span = TelemetryBootstrap.get().startServerSpan("mcp", toolName,
+                io.opentelemetry.context.Context.current(), null);
         try (Scope scope = span.makeCurrent()) {
             return doHandleToolCall(toolName, arguments);
         } catch (Exception e) {

--- a/src/main/java/io/naftiko/engine/exposes/mcp/ToolHandler.java
+++ b/src/main/java/io/naftiko/engine/exposes/mcp/ToolHandler.java
@@ -72,8 +72,7 @@ public class ToolHandler {
     public McpSchema.CallToolResult handleToolCall(String toolName, Map<String, Object> arguments)
             throws Exception {
 
-        Span span = TelemetryBootstrap.get().startServerSpan("mcp", toolName,
-                io.opentelemetry.context.Context.current(), null);
+        Span span = TelemetryBootstrap.get().startToolHandlerSpan(toolName);
         try (Scope scope = span.makeCurrent()) {
             return doHandleToolCall(toolName, arguments);
         } catch (Exception e) {

--- a/src/main/java/io/naftiko/engine/exposes/mcp/ToolHandler.java
+++ b/src/main/java/io/naftiko/engine/exposes/mcp/ToolHandler.java
@@ -25,8 +25,11 @@ import io.naftiko.Capability;
 import io.naftiko.engine.aggregates.AggregateFunction;
 import io.naftiko.engine.aggregates.FunctionResult;
 import io.naftiko.engine.exposes.OperationStepExecutor;
+import io.naftiko.engine.telemetry.TelemetryBootstrap;
 import io.naftiko.engine.util.Resolver;
 import io.naftiko.spec.exposes.McpServerToolSpec;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Scope;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -69,6 +72,20 @@ public class ToolHandler {
      * @return the tool result
      */
     public McpSchema.CallToolResult handleToolCall(String toolName, Map<String, Object> arguments)
+            throws Exception {
+
+        Span span = TelemetryBootstrap.get().startServerSpan("mcp", toolName);
+        try (Scope scope = span.makeCurrent()) {
+            return doHandleToolCall(toolName, arguments);
+        } catch (Exception e) {
+            TelemetryBootstrap.recordError(span, e);
+            throw e;
+        } finally {
+            TelemetryBootstrap.endSpan(span);
+        }
+    }
+
+    McpSchema.CallToolResult doHandleToolCall(String toolName, Map<String, Object> arguments)
             throws Exception {
 
         McpServerToolSpec toolSpec = toolSpecs.get(toolName);

--- a/src/main/java/io/naftiko/engine/exposes/rest/ResourceRestlet.java
+++ b/src/main/java/io/naftiko/engine/exposes/rest/ResourceRestlet.java
@@ -62,14 +62,15 @@ public class ResourceRestlet extends Restlet {
     }
 
     @Override
-    @SuppressWarnings("null")
+    @SuppressWarnings("null") // OTel SDK interop
     public void handle(Request request, Response response) {
         // Extract W3C traceparent from inbound headers
         TelemetryBootstrap telemetry = TelemetryBootstrap.get();
-        io.opentelemetry.context.Context extractedContext = telemetry.getOpenTelemetry()
-                .getPropagators().getTextMapPropagator()
-                .extract(io.opentelemetry.context.Context.current(), request,
-                        RestletHeaderGetter.INSTANCE);
+        io.opentelemetry.context.Context extractedContext = java.util.Objects.requireNonNull(
+                telemetry.getOpenTelemetry()
+                        .getPropagators().getTextMapPropagator()
+                        .extract(io.opentelemetry.context.Context.current(), request,
+                                RestletHeaderGetter.INSTANCE));
 
         String operationId = resourceSpec.getPath() + " " + request.getMethod().getName();
         String capabilityName = capability.getSpec().getInfo() != null

--- a/src/main/java/io/naftiko/engine/exposes/rest/ResourceRestlet.java
+++ b/src/main/java/io/naftiko/engine/exposes/rest/ResourceRestlet.java
@@ -25,6 +25,8 @@ import io.naftiko.engine.aggregates.FunctionResult;
 import io.naftiko.engine.consumes.ClientAdapter;
 import io.naftiko.engine.consumes.http.HttpClientAdapter;
 import io.naftiko.engine.exposes.OperationStepExecutor;
+import io.naftiko.engine.telemetry.RestletHeaderGetter;
+import io.naftiko.engine.telemetry.TelemetryBootstrap;
 import io.naftiko.engine.util.Converter;
 import io.naftiko.engine.util.Resolver;
 import io.naftiko.spec.OutputParameterSpec;
@@ -32,6 +34,8 @@ import io.naftiko.spec.exposes.RestServerForwardSpec;
 import io.naftiko.spec.exposes.RestServerOperationSpec;
 import io.naftiko.spec.exposes.RestServerResourceSpec;
 import io.naftiko.spec.exposes.RestServerSpec;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Scope;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.NullNode;
@@ -59,17 +63,40 @@ public class ResourceRestlet extends Restlet {
 
     @Override
     public void handle(Request request, Response response) {
-        boolean handled = handleFromOperationSpec(request, response);
+        // Extract W3C traceparent from inbound headers
+        TelemetryBootstrap telemetry = TelemetryBootstrap.get();
+        io.opentelemetry.context.Context extractedContext = telemetry.getOpenTelemetry()
+                .getPropagators().getTextMapPropagator()
+                .extract(io.opentelemetry.context.Context.current(), request,
+                        RestletHeaderGetter.INSTANCE);
 
-        if (!handled && getResourceSpec().getForward() != null) {
-            handled = handleFromForwardSpec(request, response);
-        }
+        String operationId = resourceSpec.getPath() + " " + request.getMethod().getName();
+        Span span = telemetry.getTracer().spanBuilder("rest.request")
+                .setSpanKind(io.opentelemetry.api.trace.SpanKind.SERVER)
+                .setParent(extractedContext)
+                .setAttribute(TelemetryBootstrap.ATTR_ADAPTER_TYPE, "rest")
+                .setAttribute(TelemetryBootstrap.ATTR_OPERATION_ID, operationId)
+                .setAttribute(TelemetryBootstrap.ATTR_HTTP_METHOD, request.getMethod().getName())
+                .startSpan();
 
-        if (!handled) {
-            response.setStatus(Status.CLIENT_ERROR_NOT_FOUND);
-            response.setEntity(
-                    "Unable to handle the request. Please check the capability specification.",
-                    MediaType.TEXT_PLAIN);
+        try (Scope scope = span.makeCurrent()) {
+            boolean handled = handleFromOperationSpec(request, response);
+
+            if (!handled && getResourceSpec().getForward() != null) {
+                handled = handleFromForwardSpec(request, response);
+            }
+
+            if (!handled) {
+                response.setStatus(Status.CLIENT_ERROR_NOT_FOUND);
+                response.setEntity(
+                        "Unable to handle the request. Please check the capability specification.",
+                        MediaType.TEXT_PLAIN);
+            }
+        } catch (Exception e) {
+            TelemetryBootstrap.recordError(span, e);
+            throw e;
+        } finally {
+            TelemetryBootstrap.endSpan(span);
         }
     }
 

--- a/src/main/java/io/naftiko/engine/exposes/rest/ResourceRestlet.java
+++ b/src/main/java/io/naftiko/engine/exposes/rest/ResourceRestlet.java
@@ -72,8 +72,10 @@ public class ResourceRestlet extends Restlet {
                         RestletHeaderGetter.INSTANCE);
 
         String operationId = resourceSpec.getPath() + " " + request.getMethod().getName();
+        String capabilityName = capability.getSpec().getInfo() != null
+                ? capability.getSpec().getInfo().getLabel() : null;
         Span span = telemetry.startServerSpan("rest", operationId, extractedContext,
-                request.getMethod().getName());
+                request.getMethod().getName(), capabilityName);
 
         try (Scope scope = span.makeCurrent()) {
             boolean handled = handleFromOperationSpec(request, response);

--- a/src/main/java/io/naftiko/engine/exposes/rest/ResourceRestlet.java
+++ b/src/main/java/io/naftiko/engine/exposes/rest/ResourceRestlet.java
@@ -62,6 +62,7 @@ public class ResourceRestlet extends Restlet {
     }
 
     @Override
+    @SuppressWarnings("null")
     public void handle(Request request, Response response) {
         // Extract W3C traceparent from inbound headers
         TelemetryBootstrap telemetry = TelemetryBootstrap.get();
@@ -71,13 +72,8 @@ public class ResourceRestlet extends Restlet {
                         RestletHeaderGetter.INSTANCE);
 
         String operationId = resourceSpec.getPath() + " " + request.getMethod().getName();
-        Span span = telemetry.getTracer().spanBuilder("rest.request")
-                .setSpanKind(io.opentelemetry.api.trace.SpanKind.SERVER)
-                .setParent(extractedContext)
-                .setAttribute(TelemetryBootstrap.ATTR_ADAPTER_TYPE, "rest")
-                .setAttribute(TelemetryBootstrap.ATTR_OPERATION_ID, operationId)
-                .setAttribute(TelemetryBootstrap.ATTR_HTTP_METHOD, request.getMethod().getName())
-                .startSpan();
+        Span span = telemetry.startServerSpan("rest", operationId, extractedContext,
+                request.getMethod().getName());
 
         try (Scope scope = span.makeCurrent()) {
             boolean handled = handleFromOperationSpec(request, response);

--- a/src/main/java/io/naftiko/engine/exposes/skill/SkillServerAdapter.java
+++ b/src/main/java/io/naftiko/engine/exposes/skill/SkillServerAdapter.java
@@ -60,6 +60,11 @@ public class SkillServerAdapter extends ServerAdapter {
         Context context = new Context();
         context.getAttributes().put("skillServerSpec", serverSpec);
         context.getAttributes().put("namespaceMode", namespaceMode);
+        if (getCapability().getSpec().getInfo() != null
+                && getCapability().getSpec().getInfo().getLabel() != null) {
+            context.getAttributes().put("capabilityName",
+                    getCapability().getSpec().getInfo().getLabel());
+        }
 
         Router router = new Router(context);
         router.attach("/skills", CatalogResource.class);

--- a/src/main/java/io/naftiko/engine/exposes/skill/SkillServerResource.java
+++ b/src/main/java/io/naftiko/engine/exposes/skill/SkillServerResource.java
@@ -28,7 +28,6 @@ import io.naftiko.engine.telemetry.TelemetryBootstrap;
 import io.naftiko.spec.exposes.ExposedSkillSpec;
 import io.naftiko.spec.exposes.SkillServerSpec;
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Scope;
 
 /**
@@ -63,14 +62,8 @@ abstract class SkillServerResource extends ServerResource {
 
         String operationId = getRequest().getResourceRef() != null
                 ? getRequest().getResourceRef().getPath() : "unknown";
-        Span span = telemetry.getTracer().spanBuilder("skill.request")
-                .setSpanKind(SpanKind.SERVER)
-                .setParent(extractedContext)
-                .setAttribute(TelemetryBootstrap.ATTR_ADAPTER_TYPE, "skill")
-                .setAttribute(TelemetryBootstrap.ATTR_OPERATION_ID, operationId)
-                .setAttribute(TelemetryBootstrap.ATTR_HTTP_METHOD,
-                        getRequest().getMethod().getName())
-                .startSpan();
+        Span span = telemetry.startServerSpan("skill", operationId, extractedContext,
+                getRequest().getMethod().getName());
 
         try (Scope scope = span.makeCurrent()) {
             return super.handle();

--- a/src/main/java/io/naftiko/engine/exposes/skill/SkillServerResource.java
+++ b/src/main/java/io/naftiko/engine/exposes/skill/SkillServerResource.java
@@ -20,10 +20,16 @@ import java.util.Map;
 import java.util.regex.Pattern;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.restlet.data.MediaType;
+import org.restlet.representation.Representation;
 import org.restlet.resource.ServerResource;
 import org.restlet.service.MetadataService;
+import io.naftiko.engine.telemetry.RestletHeaderGetter;
+import io.naftiko.engine.telemetry.TelemetryBootstrap;
 import io.naftiko.spec.exposes.ExposedSkillSpec;
 import io.naftiko.spec.exposes.SkillServerSpec;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Scope;
 
 /**
  * Abstract base for all skill server handler resources.
@@ -44,6 +50,35 @@ abstract class SkillServerResource extends ServerResource {
 
     public ObjectMapper getMapper() {
         return mapper;
+    }
+
+    @Override
+    public Representation handle() {
+        TelemetryBootstrap telemetry = TelemetryBootstrap.get();
+        io.opentelemetry.context.Context extractedContext = telemetry.getOpenTelemetry()
+                .getPropagators().getTextMapPropagator()
+                .extract(io.opentelemetry.context.Context.current(), getRequest(),
+                        RestletHeaderGetter.INSTANCE);
+
+        String operationId = getRequest().getResourceRef() != null
+                ? getRequest().getResourceRef().getPath() : "unknown";
+        Span span = telemetry.getTracer().spanBuilder("skill.request")
+                .setSpanKind(SpanKind.SERVER)
+                .setParent(extractedContext)
+                .setAttribute(TelemetryBootstrap.ATTR_ADAPTER_TYPE, "skill")
+                .setAttribute(TelemetryBootstrap.ATTR_OPERATION_ID, operationId)
+                .setAttribute(TelemetryBootstrap.ATTR_HTTP_METHOD,
+                        getRequest().getMethod().getName())
+                .startSpan();
+
+        try (Scope scope = span.makeCurrent()) {
+            return super.handle();
+        } catch (Exception e) {
+            TelemetryBootstrap.recordError(span, e);
+            throw e;
+        } finally {
+            TelemetryBootstrap.endSpan(span);
+        }
     }
 
     protected SkillServerSpec getSkillServerSpec() {

--- a/src/main/java/io/naftiko/engine/exposes/skill/SkillServerResource.java
+++ b/src/main/java/io/naftiko/engine/exposes/skill/SkillServerResource.java
@@ -62,8 +62,9 @@ abstract class SkillServerResource extends ServerResource {
 
         String operationId = getRequest().getResourceRef() != null
                 ? getRequest().getResourceRef().getPath() : "unknown";
+        String capabilityName = (String) getContext().getAttributes().get("capabilityName");
         Span span = telemetry.startServerSpan("skill", operationId, extractedContext,
-                getRequest().getMethod().getName());
+                getRequest().getMethod().getName(), capabilityName);
 
         try (Scope scope = span.makeCurrent()) {
             return super.handle();

--- a/src/main/java/io/naftiko/engine/exposes/skill/SkillServerResource.java
+++ b/src/main/java/io/naftiko/engine/exposes/skill/SkillServerResource.java
@@ -53,6 +53,7 @@ abstract class SkillServerResource extends ServerResource {
     }
 
     @Override
+    @SuppressWarnings("null")
     public Representation handle() {
         TelemetryBootstrap telemetry = TelemetryBootstrap.get();
         io.opentelemetry.context.Context extractedContext = telemetry.getOpenTelemetry()

--- a/src/main/java/io/naftiko/engine/exposes/skill/SkillServerResource.java
+++ b/src/main/java/io/naftiko/engine/exposes/skill/SkillServerResource.java
@@ -52,13 +52,14 @@ abstract class SkillServerResource extends ServerResource {
     }
 
     @Override
-    @SuppressWarnings("null")
+    @SuppressWarnings("null") // OTel SDK interop
     public Representation handle() {
         TelemetryBootstrap telemetry = TelemetryBootstrap.get();
-        io.opentelemetry.context.Context extractedContext = telemetry.getOpenTelemetry()
-                .getPropagators().getTextMapPropagator()
-                .extract(io.opentelemetry.context.Context.current(), getRequest(),
-                        RestletHeaderGetter.INSTANCE);
+        io.opentelemetry.context.Context extractedContext = java.util.Objects.requireNonNull(
+                telemetry.getOpenTelemetry()
+                        .getPropagators().getTextMapPropagator()
+                        .extract(io.opentelemetry.context.Context.current(), getRequest(),
+                                RestletHeaderGetter.INSTANCE));
 
         String operationId = getRequest().getResourceRef() != null
                 ? getRequest().getResourceRef().getPath() : "unknown";

--- a/src/main/java/io/naftiko/engine/telemetry/RestletHeaderGetter.java
+++ b/src/main/java/io/naftiko/engine/telemetry/RestletHeaderGetter.java
@@ -22,6 +22,7 @@ import java.util.Collections;
  *
  * <p>Used by server adapters (REST, MCP HTTP) to continue an upstream trace.</p>
  */
+@SuppressWarnings("null")
 public class RestletHeaderGetter implements TextMapGetter<Request> {
 
     public static final RestletHeaderGetter INSTANCE = new RestletHeaderGetter();

--- a/src/main/java/io/naftiko/engine/telemetry/RestletHeaderGetter.java
+++ b/src/main/java/io/naftiko/engine/telemetry/RestletHeaderGetter.java
@@ -14,6 +14,8 @@
 package io.naftiko.engine.telemetry;
 
 import io.opentelemetry.context.propagation.TextMapGetter;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.restlet.Request;
 import java.util.Collections;
 
@@ -22,13 +24,12 @@ import java.util.Collections;
  *
  * <p>Used by server adapters (REST, MCP HTTP) to continue an upstream trace.</p>
  */
-@SuppressWarnings("null")
 public class RestletHeaderGetter implements TextMapGetter<Request> {
 
     public static final RestletHeaderGetter INSTANCE = new RestletHeaderGetter();
 
     @Override
-    public Iterable<String> keys(Request request) {
+    public Iterable<String> keys(@Nullable Request request) {
         if (request == null || request.getHeaders() == null) {
             return Collections.emptyList();
         }
@@ -36,7 +37,8 @@ public class RestletHeaderGetter implements TextMapGetter<Request> {
     }
 
     @Override
-    public String get(Request request, String key) {
+    @Nullable
+    public String get(@Nullable Request request, @Nonnull String key) {
         if (request == null || request.getHeaders() == null || key == null) {
             return null;
         }

--- a/src/main/java/io/naftiko/engine/telemetry/RestletHeaderGetter.java
+++ b/src/main/java/io/naftiko/engine/telemetry/RestletHeaderGetter.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.naftiko.engine.telemetry;
+
+import io.opentelemetry.context.propagation.TextMapGetter;
+import org.restlet.Request;
+import java.util.Collections;
+
+/**
+ * Extracts W3C trace context headers from an inbound Restlet {@link Request}.
+ *
+ * <p>Used by server adapters (REST, MCP HTTP) to continue an upstream trace.</p>
+ */
+public class RestletHeaderGetter implements TextMapGetter<Request> {
+
+    public static final RestletHeaderGetter INSTANCE = new RestletHeaderGetter();
+
+    @Override
+    public Iterable<String> keys(Request request) {
+        if (request == null || request.getHeaders() == null) {
+            return Collections.emptyList();
+        }
+        return request.getHeaders().getNames();
+    }
+
+    @Override
+    public String get(Request request, String key) {
+        if (request == null || request.getHeaders() == null || key == null) {
+            return null;
+        }
+        return request.getHeaders().getFirstValue(key, true);
+    }
+}

--- a/src/main/java/io/naftiko/engine/telemetry/RestletHeaderSetter.java
+++ b/src/main/java/io/naftiko/engine/telemetry/RestletHeaderSetter.java
@@ -21,6 +21,7 @@ import org.restlet.Request;
  *
  * <p>Used by the HTTP client adapter to propagate trace context to consumed APIs.</p>
  */
+@SuppressWarnings("null")
 public class RestletHeaderSetter implements TextMapSetter<Request> {
 
     public static final RestletHeaderSetter INSTANCE = new RestletHeaderSetter();

--- a/src/main/java/io/naftiko/engine/telemetry/RestletHeaderSetter.java
+++ b/src/main/java/io/naftiko/engine/telemetry/RestletHeaderSetter.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.naftiko.engine.telemetry;
+
+import io.opentelemetry.context.propagation.TextMapSetter;
+import org.restlet.Request;
+
+/**
+ * Injects W3C trace context headers into an outbound Restlet {@link Request}.
+ *
+ * <p>Used by the HTTP client adapter to propagate trace context to consumed APIs.</p>
+ */
+public class RestletHeaderSetter implements TextMapSetter<Request> {
+
+    public static final RestletHeaderSetter INSTANCE = new RestletHeaderSetter();
+
+    @Override
+    public void set(Request request, String key, String value) {
+        if (request != null && key != null && value != null) {
+            request.getHeaders().set(key, value);
+        }
+    }
+}

--- a/src/main/java/io/naftiko/engine/telemetry/RestletHeaderSetter.java
+++ b/src/main/java/io/naftiko/engine/telemetry/RestletHeaderSetter.java
@@ -14,6 +14,8 @@
 package io.naftiko.engine.telemetry;
 
 import io.opentelemetry.context.propagation.TextMapSetter;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.restlet.Request;
 
 /**
@@ -21,13 +23,12 @@ import org.restlet.Request;
  *
  * <p>Used by the HTTP client adapter to propagate trace context to consumed APIs.</p>
  */
-@SuppressWarnings("null")
 public class RestletHeaderSetter implements TextMapSetter<Request> {
 
     public static final RestletHeaderSetter INSTANCE = new RestletHeaderSetter();
 
     @Override
-    public void set(Request request, String key, String value) {
+    public void set(@Nullable Request request, @Nonnull String key, @Nonnull String value) {
         if (request != null && key != null && value != null) {
             request.getHeaders().set(key, value);
         }

--- a/src/main/java/io/naftiko/engine/telemetry/TelemetryBootstrap.java
+++ b/src/main/java/io/naftiko/engine/telemetry/TelemetryBootstrap.java
@@ -32,7 +32,7 @@ import java.util.logging.Logger;
  *
  * <p>Provides a singleton {@link Tracer} for span creation across the engine.</p>
  */
-@SuppressWarnings("null")
+@SuppressWarnings("null") // OTel SDK AttributeKey constants lack @Nonnull — safe at this boundary
 public class TelemetryBootstrap {
 
     static final String INSTRUMENTATION_NAME = "io.naftiko.engine";

--- a/src/main/java/io/naftiko/engine/telemetry/TelemetryBootstrap.java
+++ b/src/main/java/io/naftiko/engine/telemetry/TelemetryBootstrap.java
@@ -15,6 +15,7 @@ package io.naftiko.engine.telemetry;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
@@ -43,9 +44,9 @@ public class TelemetryBootstrap {
     public static final AttributeKey<Long> ATTR_STEP_INDEX = AttributeKey.longKey("naftiko.step.index");
     public static final AttributeKey<String> ATTR_STEP_CALL = AttributeKey.stringKey("naftiko.step.call");
     public static final AttributeKey<String> ATTR_STEP_MATCH = AttributeKey.stringKey("naftiko.step.match");
-    public static final AttributeKey<String> ATTR_HTTP_METHOD = AttributeKey.stringKey("http.method");
-    public static final AttributeKey<String> ATTR_HTTP_URL = AttributeKey.stringKey("http.url");
-    public static final AttributeKey<Long> ATTR_HTTP_STATUS_CODE = AttributeKey.longKey("http.status_code");
+    public static final AttributeKey<String> ATTR_HTTP_METHOD = AttributeKey.stringKey("http.request.method");
+    public static final AttributeKey<String> ATTR_HTTP_URL = AttributeKey.stringKey("url.full");
+    public static final AttributeKey<Long> ATTR_HTTP_STATUS_CODE = AttributeKey.longKey("http.response.status_code");
     public static final AttributeKey<String> ATTR_AGGREGATE_REF = AttributeKey.stringKey("naftiko.aggregate.ref");
 
     private static final TelemetryBootstrap NOOP = new TelemetryBootstrap(OpenTelemetry.noop());
@@ -118,7 +119,7 @@ public class TelemetryBootstrap {
     }
 
     /**
-     * Reset the global instance (for testing).
+     * Reset the global instance. <strong>Test-only</strong> — do not call from production code.
      */
     public static void reset() {
         instance = null;
@@ -141,6 +142,24 @@ public class TelemetryBootstrap {
                 .setAttribute(ATTR_ADAPTER_TYPE, adapterType)
                 .setAttribute(ATTR_OPERATION_ID, operationId != null ? operationId : "unknown")
                 .startSpan();
+    }
+
+    /**
+     * Start a SERVER span for an inbound adapter request with parent context and HTTP method.
+     */
+    public Span startServerSpan(String adapterType, String operationId,
+            io.opentelemetry.context.Context parentContext, String httpMethod) {
+        SpanBuilder builder = tracer.spanBuilder(adapterType + ".request")
+                .setSpanKind(SpanKind.SERVER)
+                .setAttribute(ATTR_ADAPTER_TYPE, adapterType)
+                .setAttribute(ATTR_OPERATION_ID, operationId != null ? operationId : "unknown");
+        if (parentContext != null) {
+            builder.setParent(parentContext);
+        }
+        if (httpMethod != null) {
+            builder.setAttribute(ATTR_HTTP_METHOD, httpMethod);
+        }
+        return builder.startSpan();
     }
 
     /**

--- a/src/main/java/io/naftiko/engine/telemetry/TelemetryBootstrap.java
+++ b/src/main/java/io/naftiko/engine/telemetry/TelemetryBootstrap.java
@@ -1,0 +1,203 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.naftiko.engine.telemetry;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import java.util.logging.Logger;
+
+/**
+ * Bootstraps the OpenTelemetry SDK for the Naftiko engine.
+ *
+ * <p>Initialized once in {@code Capability} during startup. Uses OTel autoconfigure
+ * ({@code OTEL_EXPORTER_*} env vars) for zero-config in Docker/K8s, with a fallback
+ * to sensible defaults.</p>
+ *
+ * <p>Provides a singleton {@link Tracer} for span creation across the engine.</p>
+ */
+public class TelemetryBootstrap {
+
+    static final String INSTRUMENTATION_NAME = "io.naftiko.engine";
+
+    public static final AttributeKey<String> ATTR_ADAPTER_TYPE = AttributeKey.stringKey("naftiko.adapter.type");
+    public static final AttributeKey<String> ATTR_CAPABILITY = AttributeKey.stringKey("naftiko.capability");
+    public static final AttributeKey<String> ATTR_OPERATION_ID = AttributeKey.stringKey("naftiko.operation.id");
+    public static final AttributeKey<String> ATTR_NAMESPACE = AttributeKey.stringKey("naftiko.namespace");
+    public static final AttributeKey<Long> ATTR_STEP_INDEX = AttributeKey.longKey("naftiko.step.index");
+    public static final AttributeKey<String> ATTR_STEP_CALL = AttributeKey.stringKey("naftiko.step.call");
+    public static final AttributeKey<String> ATTR_STEP_MATCH = AttributeKey.stringKey("naftiko.step.match");
+    public static final AttributeKey<String> ATTR_HTTP_METHOD = AttributeKey.stringKey("http.method");
+    public static final AttributeKey<String> ATTR_HTTP_URL = AttributeKey.stringKey("http.url");
+    public static final AttributeKey<Long> ATTR_HTTP_STATUS_CODE = AttributeKey.longKey("http.status_code");
+    public static final AttributeKey<String> ATTR_AGGREGATE_REF = AttributeKey.stringKey("naftiko.aggregate.ref");
+
+    private static volatile TelemetryBootstrap instance;
+
+    private final OpenTelemetry openTelemetry;
+    private final Tracer tracer;
+
+    private static final Logger logger = Logger.getLogger(TelemetryBootstrap.class.getName());
+
+    private static final String AUTOCONFIGURE_CLASS =
+            "io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk";
+
+    TelemetryBootstrap(OpenTelemetry openTelemetry) {
+        this.openTelemetry = openTelemetry;
+        this.tracer = openTelemetry.getTracer(INSTRUMENTATION_NAME);
+    }
+
+    /**
+     * Initialize the global TelemetryBootstrap instance with auto-configured SDK.
+     *
+     * <p>If the OTel SDK is not on the classpath (e.g. when Naftiko is embedded as a library),
+     * falls back to a no-op instance so all span calls become zero-cost.</p>
+     */
+    public static TelemetryBootstrap init(String serviceName) {
+        try {
+            Class.forName(AUTOCONFIGURE_CLASS);
+            instance = new TelemetryBootstrap(buildAutoConfigured(serviceName));
+        } catch (ClassNotFoundException e) {
+            logger.info("OpenTelemetry SDK not on classpath — telemetry disabled");
+            instance = new TelemetryBootstrap(OpenTelemetry.noop());
+        }
+        return instance;
+    }
+
+    /**
+     * Builds an auto-configured OpenTelemetry SDK instance.
+     * Extracted into a separate method so the class reference to AutoConfiguredOpenTelemetrySdk
+     * is only resolved when the class is confirmed present on the classpath.
+     */
+    private static OpenTelemetry buildAutoConfigured(String serviceName) {
+        var builder = io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk.builder();
+        return builder
+                .addResourceCustomizer((resource, config) ->
+                        resource.merge(io.opentelemetry.sdk.resources.Resource.create(
+                                Attributes.of(AttributeKey.stringKey("service.name"), serviceName))))
+                .build()
+                .getOpenTelemetrySdk();
+    }
+
+    /**
+     * Initialize with a provided OpenTelemetry instance (for testing).
+     */
+    public static TelemetryBootstrap init(OpenTelemetry openTelemetry) {
+        instance = new TelemetryBootstrap(openTelemetry);
+        return instance;
+    }
+
+    /**
+     * Get the global instance, or a no-op instance if not initialized.
+     */
+    public static TelemetryBootstrap get() {
+        TelemetryBootstrap current = instance;
+        if (current != null) {
+            return current;
+        }
+        return new TelemetryBootstrap(OpenTelemetry.noop());
+    }
+
+    /**
+     * Reset the global instance (for testing).
+     */
+    public static void reset() {
+        instance = null;
+    }
+
+    public OpenTelemetry getOpenTelemetry() {
+        return openTelemetry;
+    }
+
+    public Tracer getTracer() {
+        return tracer;
+    }
+
+    /**
+     * Start a SERVER span for an inbound adapter request.
+     */
+    public Span startServerSpan(String adapterType, String operationId) {
+        return tracer.spanBuilder(adapterType + ".request")
+                .setSpanKind(SpanKind.SERVER)
+                .setAttribute(ATTR_ADAPTER_TYPE, adapterType)
+                .setAttribute(ATTR_OPERATION_ID, operationId != null ? operationId : "unknown")
+                .startSpan();
+    }
+
+    /**
+     * Start an INTERNAL span for a call step.
+     */
+    public Span startStepCallSpan(int stepIndex, String call) {
+        return tracer.spanBuilder("step.call")
+                .setSpanKind(SpanKind.INTERNAL)
+                .setAttribute(ATTR_STEP_INDEX, stepIndex)
+                .setAttribute(ATTR_STEP_CALL, call != null ? call : "unknown")
+                .startSpan();
+    }
+
+    /**
+     * Start an INTERNAL span for a lookup step.
+     */
+    public Span startStepLookupSpan(int stepIndex, String match) {
+        return tracer.spanBuilder("step.lookup")
+                .setSpanKind(SpanKind.INTERNAL)
+                .setAttribute(ATTR_STEP_INDEX, stepIndex)
+                .setAttribute(ATTR_STEP_MATCH, match != null ? match : "unknown")
+                .startSpan();
+    }
+
+    /**
+     * Start an INTERNAL span for an aggregate function execution.
+     */
+    public Span startAggregateFunctionSpan(String ref) {
+        return tracer.spanBuilder("aggregate.function")
+                .setSpanKind(SpanKind.INTERNAL)
+                .setAttribute(ATTR_AGGREGATE_REF, ref != null ? ref : "unknown")
+                .startSpan();
+    }
+
+    /**
+     * Start a CLIENT span for an outbound HTTP call.
+     */
+    public Span startClientSpan(String method, String url) {
+        return tracer.spanBuilder("http.client." + (method != null ? method : "UNKNOWN"))
+                .setSpanKind(SpanKind.CLIENT)
+                .setAttribute(ATTR_HTTP_METHOD, method != null ? method : "UNKNOWN")
+                .setAttribute(ATTR_HTTP_URL, url != null ? url : "unknown")
+                .startSpan();
+    }
+
+    /**
+     * Record an error on a span.
+     */
+    public static void recordError(Span span, Throwable error) {
+        if (span != null && error != null) {
+            span.recordException(error);
+            span.setStatus(StatusCode.ERROR, error.getMessage());
+        }
+    }
+
+    /**
+     * End a span safely.
+     */
+    public static void endSpan(Span span) {
+        if (span != null) {
+            span.end();
+        }
+    }
+}

--- a/src/main/java/io/naftiko/engine/telemetry/TelemetryBootstrap.java
+++ b/src/main/java/io/naftiko/engine/telemetry/TelemetryBootstrap.java
@@ -134,23 +134,22 @@ public class TelemetryBootstrap {
     }
 
     /**
-     * Start a SERVER span for an inbound adapter request.
-     */
-    public Span startServerSpan(String adapterType, String operationId) {
-        return tracer.spanBuilder(adapterType + ".request")
-                .setSpanKind(SpanKind.SERVER)
-                .setAttribute(ATTR_ADAPTER_TYPE, adapterType)
-                .setAttribute(ATTR_OPERATION_ID, operationId != null ? operationId : "unknown")
-                .startSpan();
-    }
-
-    /**
-     * Start a SERVER span for an inbound adapter request with parent context and HTTP method.
+     * Start a span for an inbound adapter request with parent context and HTTP method.
+     *
+     * <p>When the extracted context carries a valid remote parent (i.e. the inbound request
+     * contained a {@code traceparent} header), the span is INTERNAL because the true SERVER
+     * span lives in the upstream caller.  Otherwise this is the entry point and the span
+     * is SERVER.</p>
      */
     public Span startServerSpan(String adapterType, String operationId,
-            io.opentelemetry.context.Context parentContext, String httpMethod) {
+            io.opentelemetry.context.Context parentContext, String httpMethod,
+            String capabilityName) {
+        boolean hasRemoteParent = parentContext != null
+                && Span.fromContext(parentContext).getSpanContext().isValid()
+                && Span.fromContext(parentContext).getSpanContext().isRemote();
+        SpanKind kind = hasRemoteParent ? SpanKind.INTERNAL : SpanKind.SERVER;
         SpanBuilder builder = tracer.spanBuilder(adapterType + ".request")
-                .setSpanKind(SpanKind.SERVER)
+                .setSpanKind(kind)
                 .setAttribute(ATTR_ADAPTER_TYPE, adapterType)
                 .setAttribute(ATTR_OPERATION_ID, operationId != null ? operationId : "unknown");
         if (parentContext != null) {
@@ -159,18 +158,24 @@ public class TelemetryBootstrap {
         if (httpMethod != null) {
             builder.setAttribute(ATTR_HTTP_METHOD, httpMethod);
         }
+        if (capabilityName != null) {
+            builder.setAttribute(ATTR_CAPABILITY, capabilityName);
+        }
         return builder.startSpan();
     }
 
     /**
      * Start an INTERNAL span for a call step.
      */
-    public Span startStepCallSpan(int stepIndex, String call) {
-        return tracer.spanBuilder("step.call")
+    public Span startStepCallSpan(int stepIndex, String call, String namespace) {
+        SpanBuilder builder = tracer.spanBuilder("step.call")
                 .setSpanKind(SpanKind.INTERNAL)
                 .setAttribute(ATTR_STEP_INDEX, stepIndex)
-                .setAttribute(ATTR_STEP_CALL, call != null ? call : "unknown")
-                .startSpan();
+                .setAttribute(ATTR_STEP_CALL, call != null ? call : "unknown");
+        if (namespace != null) {
+            builder.setAttribute(ATTR_NAMESPACE, namespace);
+        }
+        return builder.startSpan();
     }
 
     /**
@@ -195,14 +200,31 @@ public class TelemetryBootstrap {
     }
 
     /**
+     * Start an INTERNAL span for MCP tool handling.
+     *
+     * <p>ToolHandler is not a network entry point — the SERVER span belongs
+     * to McpServerResource.  This span captures the tool-dispatch logic.</p>
+     */
+    public Span startToolHandlerSpan(String toolName) {
+        return tracer.spanBuilder("mcp.tool")
+                .setSpanKind(SpanKind.INTERNAL)
+                .setAttribute(ATTR_ADAPTER_TYPE, "mcp")
+                .setAttribute(ATTR_OPERATION_ID, toolName != null ? toolName : "unknown")
+                .startSpan();
+    }
+
+    /**
      * Start a CLIENT span for an outbound HTTP call.
      */
-    public Span startClientSpan(String method, String url) {
-        return tracer.spanBuilder("http.client." + (method != null ? method : "UNKNOWN"))
+    public Span startClientSpan(String method, String url, String namespace) {
+        SpanBuilder builder = tracer.spanBuilder("http.client." + (method != null ? method : "UNKNOWN"))
                 .setSpanKind(SpanKind.CLIENT)
                 .setAttribute(ATTR_HTTP_METHOD, method != null ? method : "UNKNOWN")
-                .setAttribute(ATTR_HTTP_URL, url != null ? url : "unknown")
-                .startSpan();
+                .setAttribute(ATTR_HTTP_URL, url != null ? url : "unknown");
+        if (namespace != null) {
+            builder.setAttribute(ATTR_NAMESPACE, namespace);
+        }
+        return builder.startSpan();
     }
 
     /**

--- a/src/main/java/io/naftiko/engine/telemetry/TelemetryBootstrap.java
+++ b/src/main/java/io/naftiko/engine/telemetry/TelemetryBootstrap.java
@@ -47,6 +47,8 @@ public class TelemetryBootstrap {
     public static final AttributeKey<Long> ATTR_HTTP_STATUS_CODE = AttributeKey.longKey("http.status_code");
     public static final AttributeKey<String> ATTR_AGGREGATE_REF = AttributeKey.stringKey("naftiko.aggregate.ref");
 
+    private static final TelemetryBootstrap NOOP = new TelemetryBootstrap(OpenTelemetry.noop());
+
     private static volatile TelemetryBootstrap instance;
 
     private final OpenTelemetry openTelemetry;
@@ -74,7 +76,11 @@ public class TelemetryBootstrap {
             instance = new TelemetryBootstrap(buildAutoConfigured(serviceName));
         } catch (ClassNotFoundException e) {
             logger.info("OpenTelemetry SDK not on classpath — telemetry disabled");
-            instance = new TelemetryBootstrap(OpenTelemetry.noop());
+            instance = NOOP;
+        } catch (LinkageError | RuntimeException e) {
+            logger.warning("OpenTelemetry SDK initialization failed \u2014 telemetry disabled: "
+                    + e.getMessage());
+            instance = NOOP;
         }
         return instance;
     }
@@ -107,10 +113,7 @@ public class TelemetryBootstrap {
      */
     public static TelemetryBootstrap get() {
         TelemetryBootstrap current = instance;
-        if (current != null) {
-            return current;
-        }
-        return new TelemetryBootstrap(OpenTelemetry.noop());
+        return current != null ? current : NOOP;
     }
 
     /**

--- a/src/main/java/io/naftiko/engine/telemetry/TelemetryBootstrap.java
+++ b/src/main/java/io/naftiko/engine/telemetry/TelemetryBootstrap.java
@@ -31,6 +31,7 @@ import java.util.logging.Logger;
  *
  * <p>Provides a singleton {@link Tracer} for span creation across the engine.</p>
  */
+@SuppressWarnings("null")
 public class TelemetryBootstrap {
 
     static final String INSTRUMENTATION_NAME = "io.naftiko.engine";

--- a/src/main/resources/blueprints/control-port.md
+++ b/src/main/resources/blueprints/control-port.md
@@ -1,0 +1,934 @@
+# Control Port
+## A Dedicated Management Adapter for Development, Operations, and Governance
+
+**Status**: Proposal  
+**Date**: April 16, 2026  
+**Spec Version**: `1.0.0-alpha2`  
+**Key Concept**: Introduce a new `type: "control"` exposed adapter that provides a single management surface for every capability — health checks, Prometheus metrics, runtime configuration, diagnostic endpoints, and governance hooks — isolated from business traffic on a dedicated port.
+
+---
+
+## Table of Contents
+
+1. [Executive Summary](#executive-summary)
+2. [Goals and Non-Goals](#goals-and-non-goals)
+3. [Terminology](#terminology)
+4. [Design Analogy](#design-analogy)
+5. [Architecture Overview](#architecture-overview)
+6. [Core Concepts](#core-concepts)
+7. [Specification and Schema Changes](#specification-and-schema-changes)
+8. [Capability YAML Examples](#capability-yaml-examples)
+9. [Endpoint Catalog](#endpoint-catalog)
+10. [Runtime Design](#runtime-design)
+11. [Relationship with OpenTelemetry Observability Blueprint](#relationship-with-opentelemetry-observability-blueprint)
+12. [Security Considerations](#security-considerations)
+13. [Testing Strategy](#testing-strategy)
+14. [Implementation Roadmap](#implementation-roadmap)
+15. [Risks and Mitigations](#risks-and-mitigations)
+16. [Acceptance Criteria](#acceptance-criteria)
+
+---
+
+## Executive Summary
+
+### What This Proposes
+
+Add a new `type: "control"` server adapter in `capability.exposes` that provides a **management plane** for every Naftiko capability. The control port is not a business adapter — it does not expose tools, operations, or skills. Instead, it exposes a fixed set of **engine-provided endpoints** grouped into three domains:
+
+| Domain | Purpose | Example Endpoints |
+|---|---|---|
+| **Development** | Runtime introspection and configuration for capability authors | Configuration reload, spec introspection, remote debugging hooks |
+| **Operations** | Production readiness signals for infrastructure and SRE teams | Health/readiness/liveness probes, Prometheus `/metrics`, runtime info |
+| **Governance** | Policy enforcement and audit for platform teams | Capability metadata, dependency inventory, compliance labels |
+
+The control port runs on a **dedicated port**, isolated from business traffic, and is managed by the engine — capability authors declare it but do not define its endpoints.
+
+### Why This Fits Naftiko
+
+Naftiko capabilities are declarative YAML documents that wire consumed APIs to exposed adapters. Today, there is no standard way to:
+
+- Check if a running capability is healthy
+- Scrape Prometheus metrics without conflicting with business ports
+- Reload configuration without restarting the process
+- Inspect the resolved capability spec at runtime
+- Expose governance metadata for platform cataloging
+
+Every production-grade framework solves this with a management port (Spring Boot Actuator on `:8081`, Quarkus management interface, Kubernetes sidecar patterns). The control port brings this to Naftiko while preserving its declarative philosophy: declare `type: "control"` in YAML, get a full management surface with zero code.
+
+### Why a Separate Adapter (Not Embedded in Business Adapters)
+
+1. **Port isolation** — Infrastructure tools (Prometheus, Kubernetes probes, service mesh sidecars) expect management endpoints on a dedicated port. Mixing them with business traffic creates routing complexity, security risks, and port conflicts.
+2. **Independent lifecycle** — The control port must respond to health probes even when business adapters are overloaded, restarting, or misconfigured.
+3. **Unified surface** — A capability may expose multiple business adapters (REST on `:8080`, MCP on `:3000`). The control port provides a single address for all management concerns, regardless of how many business adapters are running.
+4. **Security boundary** — Management endpoints (config reload, debug info) should never be accidentally exposed on a public-facing business port. A separate adapter makes this explicit.
+
+### Value
+
+| Benefit | Impact |
+|---|---|
+| **Kubernetes-native** | Standard `/health/live` and `/health/ready` endpoints for probe configuration |
+| **Prometheus integration** | `/metrics` on a dedicated port — no conflict with business adapters |
+| **Zero-downtime config** | Reload capability configuration without process restart |
+| **Spec introspection** | Query the resolved capability spec at runtime for debugging and cataloging |
+| **Governance metadata** | Expose dependency inventory and compliance labels for platform teams |
+| **Consistent across adapters** | Same management surface whether the capability exposes REST, MCP, Skill, or all three |
+
+### Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Config reload causes runtime inconsistency | Medium | High | Atomic swap with validation; reject invalid specs |
+| Management port exposed to public internet | Medium | High | Bind to `localhost` by default; document network policy |
+| Debug endpoints leak sensitive data | Low | High | Redact secrets from introspection; auth required for debug |
+| Port conflict with business adapters | Low | Low | Schema validation rejects duplicate ports |
+| Feature creep — control port becomes a second REST API | Low | Medium | Endpoints are engine-provided, not user-defined |
+
+---
+
+## Goals and Non-Goals
+
+### Goals
+
+1. Introduce `control` as a new exposed adapter type, joining `rest`, `mcp`, `skill`.
+2. Provide built-in health, readiness, and liveness endpoints for Kubernetes probe integration.
+3. Host the Prometheus `/metrics` scrape endpoint — absorbing Phase 2 of the [OpenTelemetry Observability](opentelemetry-observability.md) blueprint.
+4. Support runtime configuration reload (hot reload of capability YAML without process restart).
+5. Expose a read-only spec introspection endpoint for debugging and catalog integration.
+6. Expose governance metadata (dependency inventory, adapter summary, compliance labels).
+7. Keep the control port engine-managed — capability authors declare it, the engine provides the endpoints.
+8. Bind to `localhost` by default for security; allow override via `address`.
+
+### Non-Goals (This Proposal)
+
+1. User-defined endpoints on the control port — it is not a second REST API.
+2. Full APM or profiling — those belong in the [OpenTelemetry Observability](opentelemetry-observability.md) blueprint.
+3. Cluster-wide orchestration or service discovery — the control port is per-capability.
+4. Authentication/authorization for the control port in Phase 1 — added in a later phase.
+5. WebSocket or streaming management connections.
+6. Write operations on governance metadata — the control port is read-only for governance; mutations go through the spec.
+
+---
+
+## Terminology
+
+| Term | Definition |
+|---|---|
+| **Control port** | A dedicated HTTP port for management traffic, isolated from business adapters |
+| **Health probe** | An HTTP endpoint that reports the operational status of the capability (`UP`, `DOWN`, `DEGRADED`) |
+| **Liveness probe** | Kubernetes concept — indicates the process is alive and not deadlocked; failure triggers a restart |
+| **Readiness probe** | Kubernetes concept — indicates the capability is ready to serve traffic; failure removes it from the load balancer |
+| **Hot reload** | Replacing the active capability spec at runtime without stopping the process |
+| **Spec introspection** | Querying the resolved (post-merge, post-bind) capability specification at runtime |
+| **Governance metadata** | Structured information about a capability's dependencies, adapters, and compliance posture — consumed by platform catalogs |
+| **RED metrics** | Rate, Errors, Duration — the standard SRE metric set, exposed via Prometheus |
+
+---
+
+## Design Analogy
+
+### How the control port relates to existing adapters
+
+```
+REST Adapter           MCP Adapter            Skill Adapter          Control Adapter (proposed)
+────────────           ───────────            ─────────────          ─────────────────────────
+ExposesRest            ExposesMcp             ExposesSkill           ExposesControl
+├─ namespace           ├─ namespace           ├─ namespace           ├─ (no namespace — singleton)
+├─ port                ├─ port                ├─ port                ├─ port
+├─ address             ├─ address             ├─ address             ├─ address (default: localhost)
+├─ authentication      ├─ transport           ├─ authentication      ├─ (no authentication in phase 1)
+│                      │                      │                      │
+├─ resources[]         ├─ tools[]             ├─ skills[]            ├─ (no user-defined constructs)
+│  └─ operations[]     │  └─ call/steps       │  └─ tools[]          │
+│     └─ call/steps    │                      │     └─ call/steps    ├─ Engine-provided endpoints:
+│                      ├─ resources[]         │                      │  ├─ /health/live
+│                      │                      │                      │  ├─ /health/ready
+│                      ├─ prompts[]           │                      │  ├─ /metrics
+│                      │                      │                      │  ├─ /info
+│                      │                      │                      │  ├─ /spec
+│                      │                      │                      │  ├─ /config/reload
+│                      │                      │                      │  └─ /governance
+```
+
+### Key difference from business adapters
+
+Business adapters expose **user-defined constructs** (tools, operations, skills) backed by orchestration steps. The control adapter exposes **engine-defined endpoints** backed by the engine's own internal state. Capability authors control *whether* the control port is enabled and *where* it listens — not *what* it serves.
+
+### Analogy to established frameworks
+
+| Framework | Management Surface | Default Port |
+|---|---|---|
+| Spring Boot | Actuator (`/actuator/*`) | `management.server.port` (separate from app) |
+| Quarkus | Management interface (`/q/*`) | `quarkus.management.port` (9000) |
+| Envoy | Admin interface (`/`) | `admin.address` (typically 15000) |
+| **Naftiko** | **Control adapter (`/`)** | **`exposes[type=control].port`** |
+
+---
+
+## Architecture Overview
+
+### Current State
+
+```
+Capability
+├─ exposes:
+│  ├─ type: rest   (port 8080)   ← business traffic
+│  ├─ type: mcp    (port 3000)   ← business traffic
+│  └─ type: skill  (port 4000)   ← business traffic
+│
+├─ No health endpoints
+├─ No metrics endpoint (Prometheus has nothing to scrape)
+├─ No config reload (must restart)
+├─ No spec introspection
+└─ No governance metadata
+```
+
+### Proposed State
+
+```
+Capability
+├─ exposes:
+│  ├─ type: rest    (port 8080)  ← business traffic
+│  ├─ type: mcp     (port 3000)  ← business traffic
+│  ├─ type: skill   (port 4000)  ← business traffic
+│  └─ type: control (port 9090)  ← management traffic
+│     ├─ GET /health/live         → { "status": "UP" }
+│     ├─ GET /health/ready        → { "status": "UP" } or 503
+│     ├─ GET /metrics             → Prometheus exposition format
+│     ├─ GET /info                → capability name, version, uptime, adapters
+│     ├─ GET /spec                → resolved capability spec (redacted)
+│     ├─ POST /config/reload      → trigger hot reload
+│     └─ GET /governance          → dependency inventory, compliance labels
+│
+├─ Kubernetes probes point to :9090/health/*
+├─ Prometheus scrapes :9090/metrics
+└─ Platform catalog reads :9090/governance
+```
+
+### Traffic Isolation
+
+```
+                    ┌─────────────────┐
+  Business traffic  │                 │  Management traffic
+  ─────────────────►│   Capability    │◄───────────────────
+   :8080 (REST)     │                 │   :9090 (Control)
+   :3000 (MCP)      │  ┌───────────┐  │
+   :4000 (Skill)    │  │  Engine    │  │   Kubernetes probes
+                    │  │  State     │  │   Prometheus scraper
+                    │  └───────────┘  │   Platform catalog
+                    └─────────────────┘   Config reload API
+```
+
+---
+
+## Core Concepts
+
+### 1. Engine-Provided Endpoints
+
+Unlike business adapters where the user declares tools/operations/resources, the control port's endpoints are **provided by the engine**. The set of available endpoints is determined by:
+
+- **Always present**: `/health/live`, `/health/ready`, `/info`
+- **When OTel is active**: `/metrics` (Prometheus scrape)
+- **When enabled in spec**: `/config/reload`, `/spec`, `/governance`
+
+Capability authors do not define routes, parameters, or output mappings on the control port.
+
+### 2. Health Model
+
+The health model distinguishes between three states:
+
+| State | Liveness | Readiness | Meaning |
+|---|---|---|---|
+| `UP` | 200 | 200 | All adapters started, all consumed APIs reachable |
+| `DEGRADED` | 200 | 503 | Process is alive but one or more adapters failed to start or a consumed API is unreachable |
+| `DOWN` | 503 | 503 | Critical failure — process should be restarted |
+
+**Liveness** answers: "Is the process alive?" — returns 200 unless the JVM is deadlocked or the control port itself is broken (which would mean no response at all).
+
+**Readiness** answers: "Is the capability ready to serve business traffic?" — checks that all declared business adapters are started and listening.
+
+### 3. Hot Reload
+
+`POST /config/reload` triggers a re-read of the capability YAML file and an atomic swap of the internal spec. The reload follows these rules:
+
+1. **Parse** the YAML file from disk (same path as the original load).
+2. **Validate** the new spec against the JSON schema and Naftiko rules.
+3. **Diff** the new spec against the current spec to determine what changed.
+4. **Reject** if structural changes require a restart (e.g., adding/removing adapters, changing ports).
+5. **Apply** safe changes atomically (e.g., updated operation parameters, new steps, modified output mappings).
+6. **Report** the result in the response: `{ "status": "applied", "changes": [...] }` or `{ "status": "rejected", "reason": "..." }`.
+
+Changes that always require a restart (rejected by reload):
+- Adding or removing an `exposes` adapter
+- Changing an adapter's `port` or `address`
+- Adding or removing a `consumes` adapter
+- Changing `capability.info.name`
+
+Changes that are safe to hot-reload:
+- Modified `steps` in an operation/tool/procedure
+- Updated `outputParameters` mappings
+- Changed `inputParameters` (name, type, description, required)
+- Updated `aggregates` function definitions
+- Modified `authentication` credentials (re-bind)
+
+### 4. Spec Introspection
+
+`GET /spec` returns the **resolved** capability specification — after aggregate ref resolution, bind substitution, and import merging. This is the spec as the engine sees it at runtime.
+
+**Security**: Secrets referenced via `binds` are **redacted** in the response (replaced with `"***"`). The introspection endpoint never exposes raw credentials.
+
+### 5. Governance Metadata
+
+`GET /governance` returns a structured summary for platform catalog integration:
+
+```json
+{
+  "capability": {
+    "name": "weather-service",
+    "version": "1.0.0",
+    "specVersion": "1.0.0-alpha2"
+  },
+  "adapters": [
+    { "type": "rest", "port": 8080 },
+    { "type": "mcp", "port": 3000, "transport": "http" },
+    { "type": "control", "port": 9090 }
+  ],
+  "dependencies": [
+    {
+      "namespace": "weather-api",
+      "baseUri": "https://api.weather.gov",
+      "authentication": "none"
+    }
+  ],
+  "aggregates": [
+    {
+      "namespace": "forecast",
+      "functions": ["get-forecast", "get-alerts"],
+      "semantics": { "safe": true, "cacheable": true }
+    }
+  ],
+  "labels": {}
+}
+```
+
+The `labels` field is a free-form key-value map that capability authors can populate for compliance tagging (e.g., `"data-classification": "public"`, `"team": "platform"`).
+
+---
+
+## Specification and Schema Changes
+
+### New `ExposesControl` Definition
+
+```json
+"ExposesControl": {
+  "type": "object",
+  "properties": {
+    "type": {
+      "const": "control"
+    },
+    "address": {
+      "type": "string",
+      "default": "localhost",
+      "description": "Bind address for the control port. Defaults to localhost for security."
+    },
+    "port": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 65535,
+      "description": "TCP port for the control adapter."
+    },
+    "endpoints": {
+      "$ref": "#/$defs/ControlEndpointsSpec"
+    },
+    "labels": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "description": "Free-form key-value labels for governance and catalog integration."
+    }
+  },
+  "required": ["type", "port"],
+  "unevaluatedProperties": false
+}
+```
+
+### `ControlEndpointsSpec` — Granular Endpoint Toggle
+
+```json
+"ControlEndpointsSpec": {
+  "type": "object",
+  "description": "Toggle individual control port endpoint groups. All default to true when the control adapter is declared.",
+  "properties": {
+    "health": {
+      "type": "boolean",
+      "default": true,
+      "description": "Enable /health/live and /health/ready endpoints."
+    },
+    "metrics": {
+      "type": "boolean",
+      "default": true,
+      "description": "Enable /metrics (Prometheus scrape). Requires OTel observability to be active."
+    },
+    "info": {
+      "type": "boolean",
+      "default": true,
+      "description": "Enable /info endpoint."
+    },
+    "spec": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable /spec introspection endpoint. Disabled by default — contains resolved spec details."
+    },
+    "reload": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable POST /config/reload. Disabled by default — mutates runtime state."
+    },
+    "governance": {
+      "type": "boolean",
+      "default": true,
+      "description": "Enable /governance metadata endpoint."
+    }
+  },
+  "unevaluatedProperties": false
+}
+```
+
+### Update `ServerSpec` Discriminator
+
+Add `control` to the `oneOf` in the `exposes` array:
+
+```json
+"exposes": {
+  "type": "array",
+  "items": {
+    "oneOf": [
+      { "$ref": "#/$defs/ExposesRest" },
+      { "$ref": "#/$defs/ExposesMcp" },
+      { "$ref": "#/$defs/ExposesSkill" },
+      { "$ref": "#/$defs/ExposesControl" }
+    ]
+  }
+}
+```
+
+### Validation Rules
+
+Add to `naftiko-rules.yml`:
+
+| Rule | Description |
+|---|---|
+| `control-port-singleton` | At most one `type: "control"` adapter per capability |
+| `control-port-unique` | Control port must not conflict with any business adapter port |
+| `control-address-localhost-warning` | Warn if `address` is not `localhost` or `127.0.0.1` (security) |
+
+---
+
+## Capability YAML Examples
+
+### Minimal Control Port
+
+```yaml
+capability:
+  info:
+    name: weather-service
+    specVersion: 1.0.0-alpha2
+  consumes:
+    - type: http
+      namespace: weather-api
+      baseUri: https://api.weather.gov
+      operations:
+        - id: get-forecast
+          method: GET
+          path: /points/{lat},{lon}/forecast
+  exposes:
+    - type: mcp
+      namespace: weather
+      port: 3000
+      tools:
+        - name: get-forecast
+          description: Get weather forecast for a location.
+          inputParameters:
+            - name: lat
+              type: number
+              description: Latitude
+              required: true
+            - name: lon
+              type: number
+              description: Longitude
+              required: true
+          call: weather-api.get-forecast
+          with:
+            lat: "{{lat}}"
+            lon: "{{lon}}"
+    - type: control
+      port: 9090
+```
+
+This gives you `/health/live`, `/health/ready`, `/metrics`, `/info`, and `/governance` on `:9090` with zero additional configuration.
+
+### Full Control Port with All Options
+
+```yaml
+capability:
+  info:
+    name: payment-gateway
+    specVersion: 1.0.0-alpha2
+  exposes:
+    - type: rest
+      namespace: payments
+      port: 8080
+      resources:
+        - path: /payments
+          name: payments
+          operations:
+            - id: create-payment
+              method: POST
+              call: stripe-api.create-charge
+              with:
+                amount: "{{amount}}"
+    - type: control
+      port: 9090
+      address: 0.0.0.0
+      endpoints:
+        health: true
+        metrics: true
+        info: true
+        spec: true
+        reload: true
+        governance: true
+      labels:
+        team: payments
+        data-classification: pci
+        environment: production
+```
+
+### Control Port with Governance Labels Only
+
+```yaml
+  exposes:
+    - type: control
+      port: 9090
+      endpoints:
+        health: true
+        metrics: false
+        info: true
+        spec: false
+        reload: false
+        governance: true
+      labels:
+        cost-center: engineering
+        owner: platform-team
+```
+
+---
+
+## Endpoint Catalog
+
+### Development Endpoints
+
+| Method | Path | Default | Description |
+|---|---|---|---|
+| `GET` | `/spec` | Disabled | Returns the resolved capability spec with secrets redacted. Useful for debugging ref resolution, bind substitution, and import merging. |
+| `POST` | `/config/reload` | Disabled | Triggers a hot reload of the capability YAML. Returns a diff of applied changes or a rejection reason. |
+
+**Future development endpoints** (not in this proposal):
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/debug/threads` | Thread dump for deadlock diagnosis |
+| `GET` | `/debug/steps/{operation-id}` | Step execution trace for a specific operation (dry run) |
+| `POST` | `/debug/evaluate` | Evaluate a Mustache template against sample input (template playground) |
+| `GET` | `/debug/binds` | List all `binds` references and their resolution status (values redacted) |
+
+### Operations Endpoints
+
+| Method | Path | Default | Description |
+|---|---|---|---|
+| `GET` | `/health/live` | Enabled | Liveness probe. Returns `200 {"status":"UP"}` if the process is alive. |
+| `GET` | `/health/ready` | Enabled | Readiness probe. Returns `200` when all business adapters are started, `503` otherwise. |
+| `GET` | `/metrics` | Enabled | Prometheus exposition format. Serves OTel-collected metrics (see [OpenTelemetry Observability](opentelemetry-observability.md) Phase 2). |
+| `GET` | `/info` | Enabled | Returns capability name, spec version, engine version, uptime, and adapter summary. |
+
+**Future operations endpoints**:
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/health/dependencies` | Per-dependency health status (consumed API reachability) |
+| `POST` | `/drain` | Graceful shutdown — stop accepting new requests, finish in-flight, then stop |
+| `GET` | `/metrics/json` | Metrics in JSON format (for non-Prometheus consumers) |
+
+### Governance Endpoints
+
+| Method | Path | Default | Description |
+|---|---|---|---|
+| `GET` | `/governance` | Enabled | Returns structured metadata: adapters, dependencies, aggregates, labels. |
+
+**Future governance endpoints**:
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/governance/sbom` | Software Bill of Materials (dependency tree, license info) |
+| `GET` | `/governance/policy` | Policy compliance status (evaluated against external policy engine) |
+| `POST` | `/governance/audit` | Emit an audit event to the configured audit sink |
+
+---
+
+## Runtime Design
+
+### Java Class Hierarchy
+
+```
+ServerAdapter (existing abstract base)
+  ├── RestServerAdapter
+  ├── McpServerAdapter
+  ├── SkillServerAdapter
+  └── ControlServerAdapter (new)
+        ├── HealthRestlet          → /health/live, /health/ready
+        ├── MetricsRestlet         → /metrics
+        ├── InfoRestlet            → /info
+        ├── SpecIntrospectionRestlet → /spec
+        ├── ConfigReloadRestlet    → /config/reload
+        └── GovernanceRestlet      → /governance
+```
+
+### `ControlServerAdapter`
+
+```java
+class ControlServerAdapter extends ServerAdapter {
+
+    ControlServerAdapter(Capability capability, ControlServerSpec spec) {
+        super(capability, spec);
+
+        Router router = new Router(getContext());
+
+        if (spec.getEndpoints().isHealth()) {
+            router.attach("/health/live", new HealthLiveRestlet(capability));
+            router.attach("/health/ready", new HealthReadyRestlet(capability));
+        }
+        if (spec.getEndpoints().isMetrics()) {
+            router.attach("/metrics", new MetricsRestlet(capability));
+        }
+        if (spec.getEndpoints().isInfo()) {
+            router.attach("/info", new InfoRestlet(capability));
+        }
+        if (spec.getEndpoints().isSpec()) {
+            router.attach("/spec", new SpecIntrospectionRestlet(capability));
+        }
+        if (spec.getEndpoints().isReload()) {
+            router.attach("/config/reload", new ConfigReloadRestlet(capability));
+        }
+        if (spec.getEndpoints().isGovernance()) {
+            router.attach("/governance", new GovernanceRestlet(capability));
+        }
+
+        initServer(spec.getAddress(), spec.getPort(), router);
+    }
+}
+```
+
+### Health Check Implementation
+
+```java
+class HealthReadyRestlet extends Restlet {
+
+    private final Capability capability;
+
+    @Override
+    public void handle(Request request, Response response) {
+        boolean allAdaptersReady = capability.getServerAdapters().stream()
+            .filter(a -> !(a instanceof ControlServerAdapter))
+            .allMatch(ServerAdapter::isStarted);
+
+        if (allAdaptersReady) {
+            response.setStatus(Status.SUCCESS_OK);
+            response.setEntity("{\"status\":\"UP\"}", MediaType.APPLICATION_JSON);
+        } else {
+            response.setStatus(Status.SERVER_ERROR_SERVICE_UNAVAILABLE);
+            response.setEntity("{\"status\":\"DEGRADED\"}", MediaType.APPLICATION_JSON);
+        }
+    }
+}
+```
+
+### Prometheus Metrics Integration
+
+The `/metrics` endpoint on the control port **replaces** the standalone Prometheus exporter server proposed in [OpenTelemetry Observability Phase 2](opentelemetry-observability.md#phase-2--metrics). Instead of OTel spinning up its own HTTP server on a separate port, the control adapter hosts the Prometheus scrape endpoint directly:
+
+```java
+class MetricsRestlet extends Restlet {
+
+    private final PrometheusHttpServer prometheusServer; // OTel Prometheus bridge
+
+    @Override
+    public void handle(Request request, Response response) {
+        // Delegate to OTel's Prometheus exposition format writer
+        String metrics = prometheusServer.collectMetrics();
+        response.setStatus(Status.SUCCESS_OK);
+        response.setEntity(metrics, MediaType.TEXT_PLAIN);
+    }
+}
+```
+
+This consolidation means:
+- **One management port** instead of two (no separate `:9464` for Prometheus)
+- Prometheus scrape config points to `<host>:<control-port>/metrics`
+- The OTel SDK still records metrics via `Meter`; the control port simply serves them
+
+### Info Endpoint Response
+
+```json
+{
+  "capability": {
+    "name": "weather-service",
+    "specVersion": "1.0.0-alpha2"
+  },
+  "engine": {
+    "version": "1.0.0-alpha2",
+    "java": "21.0.3",
+    "nativeImage": false
+  },
+  "uptime": "PT2H34M12S",
+  "startedAt": "2026-04-16T10:00:00Z",
+  "adapters": [
+    { "type": "mcp", "port": 3000, "status": "started" },
+    { "type": "control", "port": 9090, "status": "started" }
+  ]
+}
+```
+
+### Config Reload Flow
+
+```
+POST /config/reload
+       │
+       ▼
+┌─────────────────┐     ┌──────────────┐     ┌─────────────┐
+│ Read YAML from  │────►│ Validate vs  │────►│ Diff against │
+│ original path   │     │ JSON Schema  │     │ current spec │
+└─────────────────┘     │ + Rules      │     └──────┬───────┘
+                        └──────────────┘            │
+                                              ┌─────┴──────┐
+                                              │ Structural │
+                                         ┌────┤ change?    ├────┐
+                                         │ No └────────────┘Yes │
+                                         ▼                      ▼
+                                ┌────────────────┐    ┌──────────────┐
+                                │ Atomic swap    │    │ Reject with  │
+                                │ spec + rebuild │    │ reason       │
+                                │ step executors │    └──────────────┘
+                                └────────────────┘
+                                         │
+                                         ▼
+                              { "status": "applied",
+                                "changes": [...] }
+```
+
+---
+
+## Relationship with OpenTelemetry Observability Blueprint
+
+The control port absorbs and refines specific proposals from the [OpenTelemetry Observability](opentelemetry-observability.md) blueprint:
+
+| OTel Blueprint Item | Control Port Approach |
+|---|---|
+| **Phase 2 — Prometheus `/metrics` endpoint** (standalone OTel HTTP server on `:9464`) | **Absorbed** — Prometheus metrics are served by the control adapter on `/metrics`. No standalone OTel metrics server needed. |
+| **Phase 3 — `observability.metrics.port`** (schema field for Prometheus port) | **Superseded** — The control adapter's `port` determines where `/metrics` is served. No separate metrics port config. |
+| **Phase 1 — Tracing, Phase 0 — Logging** | **Unchanged** — These phases are independent of the control port. The OTel SDK records spans and logs regardless of whether a control adapter is declared. |
+| **Phase 3 — `observability` YAML block** | **Complementary** — The `observability` block configures OTel SDK behavior (sampling, exporters). The control port configures *where* the engine-side endpoints are served. |
+
+### When No Control Port Is Declared
+
+If a capability does not declare `type: "control"`:
+- Health, info, and governance endpoints are **not available** (no management surface).
+- Prometheus metrics fall back to OTel's default standalone exporter (if configured via `OTEL_EXPORTER_PROMETHEUS_PORT`).
+- Config reload is not available (restart required).
+
+This preserves backward compatibility — existing capabilities work unchanged.
+
+---
+
+## Security Considerations
+
+### Default-Secure Posture
+
+1. **`address` defaults to `localhost`** — the control port is not network-accessible unless explicitly configured with `0.0.0.0` or a specific interface.
+2. **Sensitive endpoints disabled by default** — `/spec` and `/config/reload` are opt-in. Authors must explicitly enable them.
+3. **Secret redaction** — `/spec` replaces all `binds`-referenced values with `"***"`. No raw credentials are ever returned.
+4. **No write operations on governance** — `/governance` is read-only. Labels are set in YAML, not via the API.
+
+### Phase 2: Authentication (Future)
+
+A later phase adds optional authentication to the control port:
+
+```yaml
+  - type: control
+    port: 9090
+    authentication:
+      type: bearer
+      token:
+        externalRef: CONTROL_TOKEN
+```
+
+This reuses the existing `authentication` model from REST adapters.
+
+### Network Policy Recommendations
+
+For Kubernetes deployments:
+
+```yaml
+# NetworkPolicy: only allow Prometheus and kubelet to reach the control port
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: control-port-access
+spec:
+  podSelector:
+    matchLabels:
+      app: weather-service
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: monitoring
+      ports:
+        - port: 9090
+```
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+| Test Class | Package | Purpose |
+|---|---|---|
+| `HealthLiveRestletTest` | `io.naftiko.engine.exposes.control` | Returns 200 when capability is running |
+| `HealthReadyRestletTest` | `io.naftiko.engine.exposes.control` | Returns 200 when all adapters started, 503 when degraded |
+| `InfoRestletTest` | `io.naftiko.engine.exposes.control` | Returns correct capability metadata and uptime |
+| `GovernanceRestletTest` | `io.naftiko.engine.exposes.control` | Returns dependency inventory, adapter list, labels |
+| `SpecIntrospectionRestletTest` | `io.naftiko.engine.exposes.control` | Returns resolved spec with secrets redacted |
+| `ConfigReloadRestletTest` | `io.naftiko.engine.exposes.control` | Accepts safe changes, rejects structural changes |
+| `ControlServerSpecTest` | `io.naftiko.spec.exposes` | Deserialization of `ExposesControl` from YAML |
+
+### Integration Tests
+
+| Test Class | Package | Purpose |
+|---|---|---|
+| `ControlPortIntegrationTest` | `io.naftiko.engine.exposes.control` | Full lifecycle: start capability with control port, hit all endpoints, verify responses |
+| `ControlPortMetricsIntegrationTest` | `io.naftiko.engine.exposes.control` | Prometheus `/metrics` returns OTel-recorded metrics |
+| `ControlPortReloadIntegrationTest` | `io.naftiko.engine.exposes.control` | Hot reload: modify YAML, call `/config/reload`, verify new spec is active |
+| `ControlPortSingletonRuleTest` | `io.naftiko.engine.exposes.control` | Reject capabilities declaring more than one control adapter |
+
+### Test Fixtures
+
+| Fixture | Location | Description |
+|---|---|---|
+| `control-port-capability.yaml` | `src/test/resources/` | Capability with all control endpoints enabled |
+| `control-port-minimal-capability.yaml` | `src/test/resources/` | Capability with default control port (no `endpoints` block) |
+| `control-port-reload-before.yaml` | `src/test/resources/` | Original spec for hot reload test |
+| `control-port-reload-after.yaml` | `src/test/resources/` | Modified spec for hot reload test (safe changes) |
+| `control-port-reload-structural.yaml` | `src/test/resources/` | Modified spec with structural changes (should be rejected) |
+
+---
+
+## Implementation Roadmap
+
+### Phase 1 — Health and Info (Foundation)
+
+| Task | Component | Description |
+|---|---|---|
+| 1.1 | Schema | Add `ExposesControl` and `ControlEndpointsSpec` to `naftiko-schema.json` |
+| 1.2 | Spec classes | Create `ControlServerSpec`, `ControlEndpointsSpec` in `io.naftiko.spec.exposes` |
+| 1.3 | Discriminator | Add `control` to `ServerSpec` Jackson subtypes and schema `oneOf` |
+| 1.4 | Adapter | Implement `ControlServerAdapter` extending `ServerAdapter` |
+| 1.5 | Health | Implement `HealthLiveRestlet` and `HealthReadyRestlet` |
+| 1.6 | Info | Implement `InfoRestlet` with capability metadata and uptime |
+| 1.7 | Rules | Add `control-port-singleton` and `control-port-unique` validation rules |
+| 1.8 | Tests | Unit + integration tests for health and info endpoints |
+
+### Phase 2 — Metrics and Governance
+
+| Task | Component | Description |
+|---|---|---|
+| 2.1 | Metrics | Implement `MetricsRestlet` bridging OTel Prometheus exporter |
+| 2.2 | Governance | Implement `GovernanceRestlet` with adapter/dependency/label summary |
+| 2.3 | Labels | Wire `labels` from spec into governance response |
+| 2.4 | OTel integration | Update [OpenTelemetry Observability](opentelemetry-observability.md) Phase 2 to use control port instead of standalone Prometheus server |
+| 2.5 | Tests | Unit + integration tests for metrics and governance endpoints |
+
+### Phase 3 — Development Endpoints
+
+| Task | Component | Description |
+|---|---|---|
+| 3.1 | Spec introspection | Implement `SpecIntrospectionRestlet` with secret redaction |
+| 3.2 | Config reload | Implement `ConfigReloadRestlet` with validation, diffing, and atomic swap |
+| 3.3 | Reload safety | Implement structural change detection and rejection logic |
+| 3.4 | Tests | Unit + integration tests for introspection and reload |
+
+### Phase 4 — Authentication and Advanced Endpoints
+
+| Task | Component | Description |
+|---|---|---|
+| 4.1 | Authentication | Add optional `authentication` support to `ExposesControl` |
+| 4.2 | Dependency health | Implement `/health/dependencies` with per-consumed-API status |
+| 4.3 | Graceful drain | Implement `POST /drain` for graceful shutdown |
+| 4.4 | Debug endpoints | Implement `/debug/threads`, `/debug/binds` |
+| 4.5 | Tests | Full test coverage for authenticated and advanced endpoints |
+
+### Implementation Order and Rationale
+
+| Order | Phase | Effort | Value | Rationale |
+|---|---|---|---|---|
+| 1st | **Phase 1** (Health + Info) | Low | **Highest** | Kubernetes probe integration is the most immediate operational need; foundation for all other phases |
+| 2nd | **Phase 2** (Metrics + Governance) | Medium | High | Prometheus scrape consolidation + platform catalog integration |
+| 3rd | **Phase 3** (Dev endpoints) | Medium | Medium | Config reload and spec introspection improve the development loop |
+| 4th | **Phase 4** (Auth + Advanced) | Medium | Medium | Hardening for production environments |
+
+---
+
+## Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| **Config reload causes inconsistent state** | Medium | High | Atomic swap with full validation before apply; reject structural changes |
+| **Control port exposed to internet** | Medium | High | Default `address: localhost`; warn when `0.0.0.0`; auth in Phase 4 |
+| **Spec introspection leaks secrets** | Low | High | All `binds`-referenced values redacted; endpoint disabled by default |
+| **Port conflict with business adapters** | Low | Low | Schema validation rule rejects duplicate ports |
+| **Metrics endpoint unavailable without OTel** | Low | Low | Return `503` with message when OTel SDK is not initialized |
+| **Health probe returns false positive** | Low | Medium | Readiness checks actual adapter `isStarted()` state, not just port binding |
+| **Hot reload complexity grows with engine features** | Medium | Medium | Clearly define safe vs structural changes; reject unknown diffs |
+
+---
+
+## Acceptance Criteria
+
+### Phase 1 — Health and Info
+
+1. `ExposesControl` is accepted in capability YAML and deserialized correctly.
+2. At most one `type: "control"` adapter is allowed per capability (validated by rule).
+3. Control port binds to `localhost` by default; explicit `address` overrides it.
+4. `GET /health/live` returns `200 {"status":"UP"}` when the capability is running.
+5. `GET /health/ready` returns `200` when all business adapters are started, `503` when any is not.
+6. `GET /info` returns capability name, spec version, engine version, uptime, and adapter summary.
+7. All existing tests pass — zero regressions.
+
+### Phase 2 — Metrics and Governance
+
+1. `GET /metrics` returns Prometheus exposition format with OTel-recorded metrics.
+2. `GET /governance` returns adapter list, dependency inventory, aggregate summary, and labels.
+3. Labels declared in YAML appear in the governance response.
+4. When OTel is not active, `/metrics` returns `503` with an explanatory message.
+
+### Phase 3 — Development Endpoints
+
+1. `GET /spec` returns the resolved capability spec with all `binds` values replaced by `"***"`.
+2. `POST /config/reload` re-reads, validates, diffs, and applies safe changes.
+3. Structural changes (add/remove adapter, change port) are rejected with a descriptive reason.
+4. After a successful reload, subsequent requests use the new spec.
+5. Both endpoints are disabled by default and require explicit `endpoints.spec: true` / `endpoints.reload: true`.
+
+### Phase 4 — Authentication and Advanced
+
+1. Optional `authentication` on the control port restricts access to authorized callers.
+2. `GET /health/dependencies` returns per-consumed-API reachability status.
+3. `POST /drain` stops accepting new requests and shuts down after in-flight requests complete.
+4. Debug endpoints return diagnostic information with secrets redacted.

--- a/src/main/resources/blueprints/opentelemetry-observability.md
+++ b/src/main/resources/blueprints/opentelemetry-observability.md
@@ -2,7 +2,7 @@
 ## Distributed Tracing, Metrics, and Structured Logging for the Naftiko Engine
 
 **Status**: Proposal  
-**Date**: April 10, 2026  
+**Date**: April 17, 2026  
 **Spec Version**: `1.0.0-alpha2`  
 **Key Concept**: Add OpenTelemetry-based observability to the Naftiko engine — distributed tracing, Prometheus-compatible metrics, and structured logging — feeding Prometheus and Datadog as primary backends, with zero changes to existing logging call sites thanks to Restlet's SLF4J extension.
 
@@ -36,7 +36,7 @@
 Add OpenTelemetry (OTel) instrumentation to the Naftiko engine, covering the three pillars of observability:
 
 1. **Traces** — Distributed spans across the full request lifecycle: server adapter → step execution → HTTP client calls to consumed APIs.
-2. **Metrics** — RED metrics (Rate, Errors, Duration) for server adapters, step execution, and HTTP client calls, exposed via Prometheus scrape endpoint and OTLP push.
+2. **Metrics** — RED metrics (Rate, Errors, Duration) for server adapters, step execution, and HTTP client calls, exposed via the [Control Port](control-port.md)'s Prometheus scrape endpoint (`/metrics`) and OTLP push.
 3. **Logs** — Structured logging through SLF4J, correlated with trace IDs for end-to-end debugging.
 
 **Prometheus alone is not enough** for this initiative: it is excellent for scrape-based metrics, but it does not model the per-request lifecycle (end-to-end span context, parent/child causality, and cross-service correlation). **OpenTelemetry fills that gap** by instrumenting the full request lifecycle (tracing) and providing **context propagation** (W3C `traceparent`) across adapter → steps → consumed HTTP calls. From there, we can export **metrics to Prometheus** (scrape) and **traces + metrics to Datadog** (OTLP ingestion) using a single OTel SDK — no vendor-specific SDKs required.
@@ -63,16 +63,17 @@ This proposal fills that gap while preserving Naftiko's zero-code philosophy: ob
 | **Zero-code instrumentation** | Existing capabilities gain observability without YAML changes |
 | **Dual backend** | Single OTel SDK feeds both Prometheus and Datadog |
 | **Context propagation** | W3C `traceparent` injected into outgoing HTTP calls — correlate with downstream services |
+| **Library-safe embedding** | OTel SDK is optional — only `opentelemetry-api` (~200 KB) is required; when SDK JARs are absent, all spans become zero-cost no-ops. Embedders (e.g. Langchain4j) can pass their own `OpenTelemetry` instance or exclude telemetry entirely |
 | **Clear stdio limitation** | For MCP stdio, there's no header/metadata carrier for parent extraction, so each tool call starts a **new root span** (new trace) — documented and explicit |
 
 ### Risk Assessment
 
 | Risk | Likelihood | Impact | Mitigation |
 |---|---|---|---|
-| OTel SDK jar size (~3 MB) | Medium | Low | Shade unused exporters; optional Maven profile if needed |
+| OTel SDK jar size (~3 MB) | Medium | Low | SDK deps are `<optional>true</optional>` — embedders only pull `opentelemetry-api` (~200 KB); standalone deployment includes all JARs via shade plugin |
 | Restlet request model lacks OTel Context carrier | Medium | Medium | Wrap with `Context.current().with(span)` at handler entry; pass via `Request.getAttributes()` |
 | Stdio transport has no HTTP headers for propagation | High | Low | Start new root span; document limitation |
-| Prometheus port conflicts with adapter ports | Low | Low | Separate metrics port with schema-level configuration |
+| Prometheus port conflicts with adapter ports | Low | Low | Metrics served via [Control Port](control-port.md) — dedicated management port, isolated from business traffic |
 | Performance overhead on hot paths | Low | Medium | Sampling via `traces.sampling` in spec or `OTEL_TRACES_SAMPLER_ARG` env var |
 
 ---
@@ -87,9 +88,10 @@ This proposal fills that gap while preserving Naftiko's zero-code philosophy: ob
     - Extract inbound `traceparent`/`tracestate` from request headers (so Naftiko continues the caller's trace tree)
     - Inject outbound `traceparent`/`tracestate` into HTTP calls to consumed APIs (so downstream services can join the same trace)
 4. For MCP stdio transport, start a **new root span** per tool call (no header/metadata carrier available for parent extraction) and document the limitation.
-5. Expose RED metrics via a Prometheus-compatible scrape endpoint and OTLP push to Datadog.
+5. Expose RED metrics via the [Control Port](control-port.md)'s Prometheus scrape endpoint (`/metrics`) and OTLP push to Datadog. The Control Port blueprint defines the hosting surface; this blueprint defines what metrics are recorded and how.
 6. Support zero-config operation via OTel environment variables (`OTEL_EXPORTER_*`) for containerized deployments.
 7. Optionally allow capability authors to tune observability settings in YAML.
+8. Support library embedding (e.g. Langchain4j): OTel SDK dependencies are optional — when absent, `TelemetryBootstrap` falls back to `OpenTelemetry.noop()` with zero overhead. Embedders can also pass their own `OpenTelemetry` instance via `TelemetryBootstrap.init(OpenTelemetry)`.
 
 ### Non-Goals (This Proposal)
 
@@ -168,7 +170,10 @@ Naftiko Engine
   │
   ├── OTel SDK (traces + metrics + logs bridge)
   │     ├── OTLP Exporter ──→ Datadog Agent (OTLP endpoint)
-  │     └── Prometheus Exporter ──→ Prometheus scrape (/metrics)
+  │     └── Prometheus MetricReader ──→ Control Port /metrics
+  │
+  ├── Control Port (type: "control" adapter)
+  │     └── GET /metrics ──→ Prometheus scrape endpoint
   │
   ├── SLF4J + Logback (structured JSON logs)
   │     └── OTel Logback Appender ──→ trace-correlated logs
@@ -176,7 +181,7 @@ Naftiko Engine
   └── jul-to-slf4j bridge (catches any stray JUL usage)
 ```
 
-Datadog natively supports [OTLP ingestion](https://docs.datadoghq.com/opentelemetry/otlp_ingest_in_the_agent/) — no vendor-specific SDK needed. Prometheus is scraped from an OTel-provided HTTP endpoint. A single OTel SDK covers both backends.
+Datadog natively supports [OTLP ingestion](https://docs.datadoghq.com/opentelemetry/otlp_ingest_in_the_agent/) — no vendor-specific SDK needed. Prometheus scrapes the `/metrics` endpoint on the [Control Port](control-port.md) — a dedicated management adapter isolated from business traffic. A single OTel SDK covers both backends.
 
 ---
 
@@ -296,30 +301,47 @@ The `trace_id` and `span_id` MDC fields are populated automatically by the OTel 
 
 Create `io.naftiko.engine.telemetry.TelemetryBootstrap`:
 
-- Initialized once in `Capability.java` during startup (next to adapter init)
+- Initialized once in `Capability.java` during startup (after spec parsing, before adapter init)
 - Uses OTel autoconfigure (`OTEL_EXPORTER_*` env vars) for zero-config in Docker/K8s
-- Fallback to programmatic config with sensible defaults
-- Service name: `naftiko-<capability.info.name>` (derived from YAML spec)
-- Exposes `Tracer` and `Meter` singletons for the engine
+- **Classpath-guarded**: checks for `AutoConfiguredOpenTelemetrySdk` via `Class.forName()` — if the SDK JARs are absent (library embedding), falls back to `OpenTelemetry.noop()` automatically
+- Service name: `naftiko-<capability.info.label>` (derived from YAML spec)
+- Singleton `Tracer` via `get()` — returns no-op instance when `init()` was never called
+- Three initialization paths:
+  1. `init(String serviceName)` — standalone mode, autoconfigure with classpath guard
+  2. `init(OpenTelemetry)` — embedder passes their own instance (or used in tests with `InMemorySpanExporter`)
+  3. Never called — `get()` returns no-op, all span calls are zero-cost
 
 ```java
-class TelemetryBootstrap {
+public class TelemetryBootstrap {
 
+    private static volatile TelemetryBootstrap instance;
     private final OpenTelemetry openTelemetry;
     private final Tracer tracer;
-    private final Meter meter;
 
-    TelemetryBootstrap(String serviceName) {
-        this.openTelemetry = AutoConfiguredOpenTelemetrySdk.builder()
-            .addResourceCustomizer((resource, config) ->
-                resource.merge(Resource.builder()
-                    .put(ServiceAttributes.SERVICE_NAME, serviceName)
-                    .build()))
-            .build()
-            .getOpenTelemetrySdk();
-
+    TelemetryBootstrap(OpenTelemetry openTelemetry) {
+        this.openTelemetry = openTelemetry;
         this.tracer = openTelemetry.getTracer("io.naftiko.engine");
-        this.meter = openTelemetry.getMeter("io.naftiko.engine");
+    }
+
+    public static TelemetryBootstrap init(String serviceName) {
+        try {
+            Class.forName("io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk");
+            instance = new TelemetryBootstrap(buildAutoConfigured(serviceName));
+        } catch (ClassNotFoundException e) {
+            logger.info("OpenTelemetry SDK not on classpath — telemetry disabled");
+            instance = new TelemetryBootstrap(OpenTelemetry.noop());
+        }
+        return instance;
+    }
+
+    public static TelemetryBootstrap init(OpenTelemetry openTelemetry) {
+        instance = new TelemetryBootstrap(openTelemetry);
+        return instance;
+    }
+
+    public static TelemetryBootstrap get() {
+        TelemetryBootstrap current = instance;
+        return current != null ? current : new TelemetryBootstrap(OpenTelemetry.noop());
     }
 }
 ```
@@ -462,22 +484,27 @@ Existing `catch` blocks in `ResourceRestlet`, `ToolHandler`, and `ProtocolDispat
 
 ## Phase 2 — Metrics
 
-**Goal**: Expose RED metrics (Rate, Errors, Duration) plus business metrics via Prometheus scrape endpoint and OTLP push to Datadog.
+**Goal**: Record RED metrics (Rate, Errors, Duration) plus business metrics via the OTel SDK, served through the [Control Port](control-port.md)'s `/metrics` endpoint and pushed via OTLP to Datadog.
 
-### Prometheus `/metrics` Endpoint
+**Dependency**: This phase requires the [Control Port](control-port.md) blueprint's Phase 2 (Metrics and Governance), which provides the `MetricsRestlet` on the `type: "control"` adapter. The OTel SDK records metrics internally; the Control Port serves them to Prometheus.
 
-- `opentelemetry-exporter-prometheus` spins up a lightweight HTTP server
+### How Metrics Reach Prometheus (via Control Port)
 
-**What "exporter" means here:** Prometheus can only scrape metrics that are exposed in the **Prometheus text exposition format** (the `/metrics` format it understands). The OpenTelemetry SDK records metrics using OTel's internal data model; the **Prometheus exporter** is the component that:
+The OTel SDK records metrics using its internal `Meter` API. The **Prometheus metric reader** (`opentelemetry-exporter-prometheus`) collects those metrics and translates them into Prometheus text exposition format. Instead of spinning up a standalone HTTP server (as the OTel library does by default), the Control Port's `MetricsRestlet` calls the reader directly and writes the exposition-format output to the response:
 
-- Collects those OTel metrics from the SDK's `Meter`
-- Translates them into Prometheus' exposition format (names, labels, types)
-- Exposes them over HTTP at `/metrics`, so Prometheus can **pull** (scrape) them on an interval
+```
+OTel Meter API                Control Port                       Prometheus
+────────────                  ────────────                       ──────────
+counter.add(1, labels)  ──►  GET /metrics                  ──►  scrape interval
+histogram.record(0.3s)  ──►    └── PrometheusMetricReader  ──►  pull :9090/metrics
+                                     └── exposition format
+```
 
-Without this exporter, Prometheus has nothing to scrape — the service may be recording metrics internally, but they are not available in a Prometheus-compatible format/endpoint.
-
-- Binds to a separate configurable port (default `9464`) — isolated from adapter traffic
-- Prometheus scrapes this endpoint at its configured interval
+This consolidation means:
+- **One management port** — no separate `:9464` for Prometheus. Metrics live alongside health, info, and governance on the Control Port.
+- **Prometheus scrape config** points to `<host>:<control-port>/metrics`.
+- The OTel SDK still records metrics via `Meter`; the Control Port simply serves them.
+- When no Control Port is declared, metrics fall back to OTel's default standalone exporter (if configured via `OTEL_EXPORTER_PROMETHEUS_PORT` env var).
 
 ### Metric Definitions
 
@@ -524,15 +551,18 @@ capability:
     name: my-capability
   observability:
     enabled: true
-    metrics:
-      port: 9464
     traces:
       sampling: 0.1        # 10% sampling rate (default: 1.0 = all)
       propagation: w3c      # w3c | b3 (default: w3c)
     exporters:
       otlp:
         endpoint: "{{OTEL_EXPORTER_OTLP_ENDPOINT}}"
+  exposes:
+    - type: control
+      port: 9090            # Prometheus /metrics served here
 ```
+
+> **Note**: The `observability.metrics.port` field from earlier drafts has been **removed**. The Prometheus scrape endpoint is now hosted by the [Control Port](control-port.md) adapter — its port is determined by `exposes[type=control].port`, not by an observability-level setting. This avoids having two competing port configurations for the same endpoint.
 
 ### Design Principles
 
@@ -540,6 +570,7 @@ capability:
 - `binds` integration: exporter endpoints can reference bound secrets (e.g., `{{DD_API_KEY}}`)
 - When `observability` is absent, telemetry is still active if OTel env vars are set (zero-config for containerized deployments)
 - When `observability.enabled` is `false`, telemetry is disabled entirely (no SDK init, no overhead)
+- Prometheus metrics port is **not** configured here — it is determined by the [Control Port](control-port.md) adapter's `port` field. If no Control Port is declared, metrics fall back to OTel's standalone exporter via `OTEL_EXPORTER_PROMETHEUS_PORT`.
 
 ### Schema Definition
 
@@ -552,26 +583,11 @@ capability:
       "default": true,
       "description": "Enable or disable observability. Defaults to true."
     },
-    "metrics": {
-      "$ref": "#/$defs/ObservabilityMetricsSpec"
-    },
     "traces": {
       "$ref": "#/$defs/ObservabilityTracesSpec"
     },
     "exporters": {
       "$ref": "#/$defs/ObservabilityExportersSpec"
-    }
-  },
-  "unevaluatedProperties": false
-}
-
-"ObservabilityMetricsSpec": {
-  "type": "object",
-  "properties": {
-    "port": {
-      "type": "integer",
-      "default": 9464,
-      "description": "Port for the Prometheus scrape endpoint."
     }
   },
   "unevaluatedProperties": false
@@ -625,7 +641,6 @@ capability:
 | Class | Package | Description |
 |---|---|---|
 | `ObservabilitySpec` | `io.naftiko.spec` | Root observability configuration |
-| `ObservabilityMetricsSpec` | `io.naftiko.spec` | Metrics port configuration |
 | `ObservabilityTracesSpec` | `io.naftiko.spec` | Sampling rate and propagation format |
 | `ObservabilityExportersSpec` | `io.naftiko.spec` | Exporter configuration container |
 | `ObservabilityOtlpExporterSpec` | `io.naftiko.spec` | OTLP endpoint configuration |
@@ -644,6 +659,8 @@ capability:
 | Prometheus alerting rules | `demo/observability/alerts.yml` | High error rate, latency P99 thresholds |
 
 ### Docker Compose Dev Stack
+
+> **Note**: Prometheus scrapes the Control Port's `/metrics` endpoint. The `prometheus.yml` target should point to `<capability-host>:<control-port>/metrics` (e.g., `host.docker.internal:9090/metrics`).
 
 ```yaml
 services:
@@ -702,57 +719,55 @@ services:
 </dependency>
 ```
 
-### Phase 1 — Tracing + Metrics
+### Phase 1 — Tracing
 
 ```xml
-<!-- BOM for consistent versions -->
-<dependencyManagement>
-    <dependency>
-        <groupId>io.opentelemetry</groupId>
-        <artifactId>opentelemetry-bom</artifactId>
-        <version>1.48.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-    </dependency>
-</dependencyManagement>
-
-<!-- Core SDK -->
+<!-- Required — the only mandatory OTel dependency (~200 KB).
+     Provides the API surface (Tracer, Span, Context) and OpenTelemetry.noop() fallback.
+     Versions managed via ${opentelemetry.version} property (1.48.0). -->
 <dependency>
     <groupId>io.opentelemetry</groupId>
     <artifactId>opentelemetry-api</artifactId>
+    <version>${opentelemetry.version}</version>
 </dependency>
+
+<!-- Optional — SDK + autoconfigure + exporter + log appender.
+     Pulled automatically in standalone deployment (shade plugin).
+     Embedders can exclude these — TelemetryBootstrap falls back to OpenTelemetry.noop(). -->
 <dependency>
     <groupId>io.opentelemetry</groupId>
     <artifactId>opentelemetry-sdk</artifactId>
+    <version>${opentelemetry.version}</version>
+    <optional>true</optional>
 </dependency>
 <dependency>
     <groupId>io.opentelemetry</groupId>
     <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+    <version>${opentelemetry.version}</version>
+    <optional>true</optional>
 </dependency>
-
-<!-- Exporters -->
 <dependency>
     <groupId>io.opentelemetry</groupId>
     <artifactId>opentelemetry-exporter-otlp</artifactId>
+    <version>${opentelemetry.version}</version>
+    <optional>true</optional>
 </dependency>
-
-<!-- Context propagation -->
-<dependency>
-    <groupId>io.opentelemetry</groupId>
-    <artifactId>opentelemetry-context</artifactId>
-</dependency>
-
-<!-- Log-trace correlation -->
 <dependency>
     <groupId>io.opentelemetry.instrumentation</groupId>
     <artifactId>opentelemetry-logback-appender-1.0</artifactId>
     <version>2.14.0-alpha</version>
+    <optional>true</optional>
 </dependency>
 ```
 
-### Phase 2 — Prometheus Exporter
+**Embedding note:** When Naftiko is used as a library (e.g. inside Langchain4j), only `opentelemetry-api` is transitively required. The optional SDK JARs are not pulled. `TelemetryBootstrap.init(String)` detects the SDK absence via `Class.forName()` and falls back to `OpenTelemetry.noop()`. Embedders can also call `TelemetryBootstrap.init(OpenTelemetry)` to supply their own instance.
+
+### Phase 2 — Prometheus Metric Reader (served by Control Port)
 
 ```xml
+<!-- Prometheus metric reader — translates OTel metrics to Prometheus exposition format.
+     The Control Port's MetricsRestlet calls this reader to serve /metrics.
+     No standalone HTTP server is spun up — the Control Port hosts the endpoint. -->
 <dependency>
     <groupId>io.opentelemetry</groupId>
     <artifactId>opentelemetry-exporter-prometheus</artifactId>
@@ -761,16 +776,18 @@ services:
 
 ### JAR Size Impact
 
-| Dependency | Approximate Size |
-|---|---|
-| `org.restlet.ext.slf4j` | ~50 KB |
-| `logback-classic` + `logback-core` | ~1.2 MB |
-| `jul-to-slf4j` | ~10 KB |
-| OTel SDK + API + autoconfigure | ~3 MB |
-| OTel OTLP exporter (HTTP/protobuf) | ~1.5 MB |
-| OTel Prometheus exporter | ~500 KB |
-| OTel Logback appender | ~100 KB |
-| **Total** | **~6.4 MB** |
+| Dependency | Approximate Size | Required? |
+|---|---|---|
+| `org.restlet.ext.slf4j` | ~50 KB | Yes |
+| `logback-classic` + `logback-core` | ~1.2 MB | Yes |
+| `jul-to-slf4j` | ~10 KB | Yes |
+| `opentelemetry-api` | ~200 KB | **Yes** (only mandatory OTel dep) |
+| OTel SDK + autoconfigure | ~2.8 MB | Optional |
+| OTel OTLP exporter (HTTP/protobuf) | ~1.5 MB | Optional |
+| OTel Prometheus exporter | ~500 KB | Optional |
+| OTel Logback appender | ~100 KB | Optional |
+| **Total (standalone)** | **~6.4 MB** | |
+| **Total (embedded, no SDK)** | **~1.5 MB** | |
 
 ---
 
@@ -851,8 +868,8 @@ All tests use OTel's `InMemorySpanExporter` and `InMemoryMetricReader` — no ex
 
 | Task | Component | Description |
 |---|---|---|
-| 1.1 | Dependencies | Add OTel BOM, SDK, OTLP exporter, context, Logback appender |
-| 1.2 | Bootstrap | Create `TelemetryBootstrap` — OTel SDK init, `Tracer`/`Meter` singletons |
+| 1.1 | Dependencies | Add `opentelemetry-api` (required) + SDK, autoconfigure, OTLP exporter, Logback appender as `<optional>true</optional>` |
+| 1.2 | Bootstrap | Create `TelemetryBootstrap` — classpath-guarded SDK init via `Class.forName()`, no-op fallback, `init(OpenTelemetry)` for embedders |
 | 1.3 | Server spans | Instrument `ResourceRestlet.handle()`, `ToolHandler.handleToolCall()`, `SkillServerResource.handle()` with `SERVER` spans |
 | 1.4 | Step spans | Instrument `OperationStepExecutor.executeStep()` with `INTERNAL` spans per step type |
 | 1.5 | Client spans | Instrument `HttpClientAdapter.handle()` with `CLIENT` spans |
@@ -865,20 +882,21 @@ All tests use OTel's `InMemorySpanExporter` and `InMemoryMetricReader` — no ex
 
 | Task | Component | Description |
 |---|---|---|
-| 2.1 | Dependencies | Add `opentelemetry-exporter-prometheus` |
+| 2.1 | Dependencies | Add `opentelemetry-exporter-prometheus` (metric reader only — no standalone server) |
 | 2.2 | Metrics registry | Define counters and histograms in `TelemetryBootstrap` |
 | 2.3 | Server metrics | Record `naftiko.request.total`, `naftiko.request.duration`, `naftiko.request.errors` in adapter handlers |
 | 2.4 | Step metrics | Record `naftiko.step.duration` in `OperationStepExecutor` |
 | 2.5 | Client metrics | Record `naftiko.http.client.total`, `naftiko.http.client.duration` in `HttpClientAdapter` |
-| 2.6 | Prometheus endpoint | Configure Prometheus exporter on separate port |
-| 2.7 | Tests | Verify metric registration and recording with in-memory reader |
+| 2.6 | Control Port integration | Wire `PrometheusMetricReader` into the [Control Port](control-port.md)'s `MetricsRestlet` — no standalone Prometheus HTTP server |
+| 2.7 | Fallback | When no Control Port is declared, fall back to OTel standalone exporter via `OTEL_EXPORTER_PROMETHEUS_PORT` env var |
+| 2.8 | Tests | Verify metric registration and recording with in-memory reader; integration test via Control Port `/metrics` |
 
 ### Phase 3 — Spec-Driven Configuration
 
 | Task | Component | Description |
 |---|---|---|
-| 3.1 | Schema | Add `ObservabilitySpec` and related definitions to `naftiko-schema.json` |
-| 3.2 | Spec classes | Create `ObservabilitySpec`, `ObservabilityMetricsSpec`, `ObservabilityTracesSpec`, `ObservabilityExportersSpec` |
+| 3.1 | Schema | Add `ObservabilitySpec` and related definitions to `naftiko-schema.json` (no `metrics.port` — superseded by Control Port) |
+| 3.2 | Spec classes | Create `ObservabilitySpec`, `ObservabilityTracesSpec`, `ObservabilityExportersSpec` |
 | 3.3 | Bootstrap | Wire spec-level config into `TelemetryBootstrap` (sampling, propagation, endpoint) |
 | 3.4 | Tests | Deserialization tests + integration tests with different configurations |
 
@@ -897,7 +915,7 @@ All tests use OTel's `InMemorySpanExporter` and `InMemoryMetricReader` — no ex
 |---|---|---|---|---|
 | 1st | **Phase 0** (Logging) | Low | Medium | Foundation for everything else; unblocks log-trace correlation; zero risk |
 | 2nd | **Phase 1** (Tracing) | Medium | **Highest** | Distributed traces provide immediate debugging value; Datadog APM lights up; context propagation enables cross-service correlation |
-| 3rd | **Phase 2** (Metrics) | Medium | High | RED metrics + Prometheus scrape enable SRE dashboards and alerting |
+| 3rd | **Phase 2** (Metrics) | Medium | High | RED metrics + Prometheus scrape via [Control Port](control-port.md) enable SRE dashboards and alerting |
 | 4th | **Phase 3** (Spec config) | Low | Medium | Declarative config aligns with Naftiko philosophy but OTel env vars already cover most needs |
 | 5th | **Phase 4** (Dashboards) | Low | Medium | Not engine code — can be contributed incrementally |
 
@@ -935,10 +953,10 @@ Yes — this proposal should explicitly include a mechanism to **avoid exporting
 
 | Risk | Likelihood | Impact | Mitigation |
 |---|---|---|---|
-| **OTel SDK jar size** (~6.4 MB total) | Medium | Low | Acceptable for a server-side framework; optional Maven profile if native binary size is a concern |
+| **OTel SDK jar size** (~6.4 MB total) | Medium | Low | SDK deps are `<optional>true</optional>` — only `opentelemetry-api` (~200 KB) is mandatory; `TelemetryBootstrap` classpath-guards the autoconfigure call and falls back to no-op. Standalone deployment shades all JARs |
 | **Restlet's request model doesn't carry OTel `Context`** | Medium | Medium | Wrap with `Context.current().with(span)` at handler entry; pass via `Request.getAttributes()` or `ThreadLocal` |
 | **Stdio transport has no HTTP headers for propagation** | High | Low | Start new root span; document limitation; explore MCP `_meta` extension |
-| **Prometheus port conflicts with adapter ports** | Low | Low | Separate metrics port with schema-level `observability.metrics.port` configuration |
+| **Prometheus port conflicts with adapter ports** | Low | Low | **Eliminated** — Prometheus metrics are served by the [Control Port](control-port.md) on its dedicated management port; no separate metrics port to conflict |
 | **Performance overhead on hot paths** | Low | Medium | Sampling via `traces.sampling` in spec or `OTEL_TRACES_SAMPLER_ARG` env var; benchmark before/after |
 | **GraalVM native-image compatibility** | Medium | Medium | Prefer HTTP/protobuf OTLP over gRPC; add `reflect-config.json`; test with native profile |
 | **Logback conflicts with existing JUL config** | Low | Low | `Slf4jLoggerFacade` takes priority; `SLF4JBridgeHandler` catches remaining JUL |
@@ -965,13 +983,16 @@ Yes — this proposal should explicitly include a mechanism to **avoid exporting
 6. Failed operations set `StatusCode.ERROR` and record exceptions on spans.
 7. Log entries carry `trace_id` and `span_id` via MDC.
 8. All tests pass with `InMemorySpanExporter`.
+9. When OTel SDK JARs are absent from the classpath, `TelemetryBootstrap.init(String)` falls back to `OpenTelemetry.noop()` — zero overhead, no `ClassNotFoundException`.
+10. Embedders can supply their own `OpenTelemetry` instance via `TelemetryBootstrap.init(OpenTelemetry)` and all engine spans participate in the host application's traces.
 
 ### Phase 2
 
-1. Prometheus `/metrics` endpoint serves all defined metrics.
+1. Prometheus `/metrics` endpoint on the [Control Port](control-port.md) serves all defined metrics in exposition format.
 2. Metrics are recorded with correct labels on every request.
 3. OTLP push exports metrics to configured endpoint.
 4. `naftiko.capability.active` increments on start and decrements on stop.
+5. When no Control Port is declared, metrics fall back to OTel standalone exporter via `OTEL_EXPORTER_PROMETHEUS_PORT`.
 
 ### Phase 3
 
@@ -980,6 +1001,7 @@ Yes — this proposal should explicitly include a mechanism to **avoid exporting
 3. `observability.traces.sampling` controls the sampling rate.
 4. `observability.exporters.otlp.endpoint` supports Mustache expressions for binds.
 5. Absent `observability` block defaults to OTel env var configuration.
+6. No `observability.metrics.port` field — Prometheus port is determined by the Control Port adapter.
 
 ### Phase 4
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -4,11 +4,7 @@
       <pattern>%d{ISO8601} [%thread] %-5level %logger{36} - traceId=%X{trace_id} spanId=%X{span_id} - %msg%n</pattern>
     </encoder>
   </appender>
-  <appender name="OTEL" class="io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender">
-    <captureExperimentalAttributes>true</captureExperimentalAttributes>
-  </appender>
   <root level="INFO">
     <appender-ref ref="CONSOLE" />
-    <appender-ref ref="OTEL" />
   </root>
 </configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -4,7 +4,11 @@
       <pattern>%d{ISO8601} [%thread] %-5level %logger{36} - traceId=%X{trace_id} spanId=%X{span_id} - %msg%n</pattern>
     </encoder>
   </appender>
+  <appender name="OTEL" class="io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender">
+    <captureExperimentalAttributes>true</captureExperimentalAttributes>
+  </appender>
   <root level="INFO">
     <appender-ref ref="CONSOLE" />
+    <appender-ref ref="OTEL" />
   </root>
 </configuration>

--- a/src/test/java/io/naftiko/engine/exposes/mcp/ObservabilityMcpIntegrationTest.java
+++ b/src/test/java/io/naftiko/engine/exposes/mcp/ObservabilityMcpIntegrationTest.java
@@ -41,6 +41,7 @@ import java.util.Map;
  * Integration tests verifying that MCP tool calls produce the expected OTel span hierarchy.
  * Uses an aggregate-based mock capability so no real HTTP calls are needed.
  */
+@SuppressWarnings("null")
 public class ObservabilityMcpIntegrationTest {
 
     private final InMemorySpanExporter exporter = InMemorySpanExporter.create();

--- a/src/test/java/io/naftiko/engine/exposes/mcp/ObservabilityMcpIntegrationTest.java
+++ b/src/test/java/io/naftiko/engine/exposes/mcp/ObservabilityMcpIntegrationTest.java
@@ -71,7 +71,7 @@ public class ObservabilityMcpIntegrationTest {
     }
 
     @Test
-    void mcpToolCallShouldProduceServerSpan() throws Exception {
+    void mcpToolCallShouldProduceToolHandlerSpan() throws Exception {
         McpServerAdapter adapter = (McpServerAdapter) capability.getServerAdapters().get(0);
         ToolHandler handler = adapter.getToolHandler();
 
@@ -83,19 +83,19 @@ public class ObservabilityMcpIntegrationTest {
         assertNotNull(result);
 
         List<SpanData> spans = exporter.getFinishedSpanItems();
-        assertTrue(spans.size() >= 2, "Should produce at least 2 spans (server + aggregate)");
+        assertTrue(spans.size() >= 2, "Should produce at least 2 spans (tool handler + aggregate)");
 
-        // Find the server span
-        SpanData serverSpan = spans.stream()
-                .filter(s -> s.getName().equals("mcp.request"))
+        // Find the tool handler span (INTERNAL — the SERVER span lives in McpServerResource)
+        SpanData toolSpan = spans.stream()
+                .filter(s -> s.getName().equals("mcp.tool"))
                 .findFirst()
-                .orElseThrow(() -> new AssertionError("Missing mcp.request span"));
+                .orElseThrow(() -> new AssertionError("Missing mcp.tool span"));
 
-        assertEquals(SpanKind.SERVER, serverSpan.getKind());
+        assertEquals(SpanKind.INTERNAL, toolSpan.getKind());
         assertEquals("mcp",
-                serverSpan.getAttributes().get(TelemetryBootstrap.ATTR_ADAPTER_TYPE));
+                toolSpan.getAttributes().get(TelemetryBootstrap.ATTR_ADAPTER_TYPE));
         assertEquals("get-forecast",
-                serverSpan.getAttributes().get(TelemetryBootstrap.ATTR_OPERATION_ID));
+                toolSpan.getAttributes().get(TelemetryBootstrap.ATTR_OPERATION_ID));
     }
 
     @Test
@@ -120,14 +120,14 @@ public class ObservabilityMcpIntegrationTest {
         assertEquals("forecast.get-forecast",
                 aggregateSpan.getAttributes().get(TelemetryBootstrap.ATTR_AGGREGATE_REF));
 
-        // Aggregate span should be a child of the server span
-        SpanData serverSpan = spans.stream()
-                .filter(s -> s.getName().equals("mcp.request"))
+        // Aggregate span should be a child of the tool handler span
+        SpanData toolSpan = spans.stream()
+                .filter(s -> s.getName().equals("mcp.tool"))
                 .findFirst().orElseThrow();
 
-        assertEquals(serverSpan.getSpanId(), aggregateSpan.getParentSpanId(),
-                "aggregate.function should be a child of mcp.request");
-        assertEquals(serverSpan.getTraceId(), aggregateSpan.getTraceId(),
+        assertEquals(toolSpan.getSpanId(), aggregateSpan.getParentSpanId(),
+                "aggregate.function should be a child of mcp.tool");
+        assertEquals(toolSpan.getTraceId(), aggregateSpan.getTraceId(),
                 "Both spans should share the same trace");
     }
 
@@ -142,11 +142,11 @@ public class ObservabilityMcpIntegrationTest {
         List<SpanData> spans = exporter.getFinishedSpanItems();
         assertFalse(spans.isEmpty(), "Should produce a span even on error");
 
-        SpanData serverSpan = spans.stream()
-                .filter(s -> s.getName().equals("mcp.request"))
+        SpanData toolSpan = spans.stream()
+                .filter(s -> s.getName().equals("mcp.tool"))
                 .findFirst().orElseThrow();
 
         assertEquals(io.opentelemetry.api.trace.StatusCode.ERROR,
-                serverSpan.getStatus().getStatusCode());
+                toolSpan.getStatus().getStatusCode());
     }
 }

--- a/src/test/java/io/naftiko/engine/exposes/mcp/ObservabilityMcpIntegrationTest.java
+++ b/src/test/java/io/naftiko/engine/exposes/mcp/ObservabilityMcpIntegrationTest.java
@@ -41,7 +41,7 @@ import java.util.Map;
  * Integration tests verifying that MCP tool calls produce the expected OTel span hierarchy.
  * Uses an aggregate-based mock capability so no real HTTP calls are needed.
  */
-@SuppressWarnings("null")
+@SuppressWarnings("null") // OTel SDK types lack @Nonnull annotations
 public class ObservabilityMcpIntegrationTest {
 
     private final InMemorySpanExporter exporter = InMemorySpanExporter.create();

--- a/src/test/java/io/naftiko/engine/exposes/mcp/ObservabilityMcpIntegrationTest.java
+++ b/src/test/java/io/naftiko/engine/exposes/mcp/ObservabilityMcpIntegrationTest.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.naftiko.engine.exposes.mcp;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import io.naftiko.Capability;
+import io.naftiko.engine.telemetry.TelemetryBootstrap;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.naftiko.spec.NaftikoSpec;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Integration tests verifying that MCP tool calls produce the expected OTel span hierarchy.
+ * Uses an aggregate-based mock capability so no real HTTP calls are needed.
+ */
+public class ObservabilityMcpIntegrationTest {
+
+    private final InMemorySpanExporter exporter = InMemorySpanExporter.create();
+    private Capability capability;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        OpenTelemetrySdk sdk = OpenTelemetrySdk.builder()
+                .setTracerProvider(SdkTracerProvider.builder()
+                        .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                        .build())
+                .build();
+        TelemetryBootstrap.init(sdk);
+
+        File file = new File("src/test/resources/aggregates/aggregate-basic.yaml");
+        assertTrue(file.exists());
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        NaftikoSpec spec = mapper.readValue(file, NaftikoSpec.class);
+        capability = new Capability(spec);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TelemetryBootstrap.reset();
+        exporter.reset();
+    }
+
+    @Test
+    void mcpToolCallShouldProduceServerSpan() throws Exception {
+        McpServerAdapter adapter = (McpServerAdapter) capability.getServerAdapters().get(0);
+        ToolHandler handler = adapter.getToolHandler();
+
+        Map<String, Object> args = new HashMap<>();
+        args.put("location", "Paris");
+
+        // get-forecast uses a mock aggregate (no HTTP call, no steps → mock mode)
+        McpSchema.CallToolResult result = handler.handleToolCall("get-forecast", args);
+        assertNotNull(result);
+
+        List<SpanData> spans = exporter.getFinishedSpanItems();
+        assertTrue(spans.size() >= 2, "Should produce at least 2 spans (server + aggregate)");
+
+        // Find the server span
+        SpanData serverSpan = spans.stream()
+                .filter(s -> s.getName().equals("mcp.request"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Missing mcp.request span"));
+
+        assertEquals(SpanKind.SERVER, serverSpan.getKind());
+        assertEquals("mcp",
+                serverSpan.getAttributes().get(TelemetryBootstrap.ATTR_ADAPTER_TYPE));
+        assertEquals("get-forecast",
+                serverSpan.getAttributes().get(TelemetryBootstrap.ATTR_OPERATION_ID));
+    }
+
+    @Test
+    void mcpToolCallWithAggregateShouldProduceAggregateFunctionSpan() throws Exception {
+        McpServerAdapter adapter = (McpServerAdapter) capability.getServerAdapters().get(0);
+        ToolHandler handler = adapter.getToolHandler();
+
+        Map<String, Object> args = new HashMap<>();
+        args.put("location", "London");
+
+        handler.handleToolCall("get-forecast", args);
+
+        List<SpanData> spans = exporter.getFinishedSpanItems();
+
+        // Find aggregate.function span
+        SpanData aggregateSpan = spans.stream()
+                .filter(s -> s.getName().equals("aggregate.function"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Missing aggregate.function span"));
+
+        assertEquals(SpanKind.INTERNAL, aggregateSpan.getKind());
+        assertEquals("forecast.get-forecast",
+                aggregateSpan.getAttributes().get(TelemetryBootstrap.ATTR_AGGREGATE_REF));
+
+        // Aggregate span should be a child of the server span
+        SpanData serverSpan = spans.stream()
+                .filter(s -> s.getName().equals("mcp.request"))
+                .findFirst().orElseThrow();
+
+        assertEquals(serverSpan.getSpanId(), aggregateSpan.getParentSpanId(),
+                "aggregate.function should be a child of mcp.request");
+        assertEquals(serverSpan.getTraceId(), aggregateSpan.getTraceId(),
+                "Both spans should share the same trace");
+    }
+
+    @Test
+    void mcpToolCallShouldRecordErrorOnUnknownTool() {
+        McpServerAdapter adapter = (McpServerAdapter) capability.getServerAdapters().get(0);
+        ToolHandler handler = adapter.getToolHandler();
+
+        assertThrows(Exception.class, () ->
+                handler.handleToolCall("nonexistent-tool", Map.of()));
+
+        List<SpanData> spans = exporter.getFinishedSpanItems();
+        assertFalse(spans.isEmpty(), "Should produce a span even on error");
+
+        SpanData serverSpan = spans.stream()
+                .filter(s -> s.getName().equals("mcp.request"))
+                .findFirst().orElseThrow();
+
+        assertEquals(io.opentelemetry.api.trace.StatusCode.ERROR,
+                serverSpan.getStatus().getStatusCode());
+    }
+}

--- a/src/test/java/io/naftiko/engine/exposes/rest/ObservabilityRestIntegrationTest.java
+++ b/src/test/java/io/naftiko/engine/exposes/rest/ObservabilityRestIntegrationTest.java
@@ -45,6 +45,7 @@ import java.util.List;
  * Integration tests verifying that REST adapter requests produce the expected OTel span hierarchy,
  * including W3C traceparent extraction.
  */
+@SuppressWarnings("null")
 public class ObservabilityRestIntegrationTest {
 
     private final InMemorySpanExporter exporter = InMemorySpanExporter.create();

--- a/src/test/java/io/naftiko/engine/exposes/rest/ObservabilityRestIntegrationTest.java
+++ b/src/test/java/io/naftiko/engine/exposes/rest/ObservabilityRestIntegrationTest.java
@@ -1,0 +1,204 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.naftiko.engine.exposes.rest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.naftiko.Capability;
+import io.naftiko.engine.telemetry.TelemetryBootstrap;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.naftiko.spec.NaftikoSpec;
+import io.naftiko.spec.exposes.RestServerSpec;
+import io.naftiko.util.VersionHelper;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.restlet.Request;
+import org.restlet.Response;
+import org.restlet.data.Method;
+import org.restlet.data.Status;
+
+import java.util.List;
+
+/**
+ * Integration tests verifying that REST adapter requests produce the expected OTel span hierarchy,
+ * including W3C traceparent extraction.
+ */
+public class ObservabilityRestIntegrationTest {
+
+    private final InMemorySpanExporter exporter = InMemorySpanExporter.create();
+    private static String schemaVersion;
+
+    @BeforeEach
+    void setUp() {
+        OpenTelemetrySdk sdk = OpenTelemetrySdk.builder()
+                .setTracerProvider(SdkTracerProvider.builder()
+                        .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                        .build())
+                .setPropagators(ContextPropagators.create(
+                        W3CTraceContextPropagator.getInstance()))
+                .build();
+        TelemetryBootstrap.init(sdk);
+        schemaVersion = VersionHelper.getSchemaVersion();
+    }
+
+    @AfterEach
+    void tearDown() {
+        TelemetryBootstrap.reset();
+        exporter.reset();
+    }
+
+    private Capability capabilityFromYaml(String yaml) throws Exception {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        NaftikoSpec spec = mapper.readValue(yaml, NaftikoSpec.class);
+        return new Capability(spec);
+    }
+
+    @Test
+    void restHandleShouldProduceServerSpanWithCorrectAttributes() throws Exception {
+        Capability capability = capabilityFromYaml("""
+                naftiko: "%s"
+                capability:
+                  exposes:
+                    - type: "rest"
+                      address: "localhost"
+                      port: 0
+                      namespace: "test"
+                      resources:
+                        - path: "/orders"
+                          operations:
+                            - method: "GET"
+                              name: "list-orders"
+                              outputParameters:
+                                - name: "status"
+                                  type: "string"
+                                  value: "ok"
+                  consumes: []
+                """.formatted(schemaVersion));
+
+        RestServerSpec serverSpec =
+                (RestServerSpec) capability.getServerAdapters().get(0).getSpec();
+        ResourceRestlet restlet = new ResourceRestlet(capability, serverSpec,
+                serverSpec.getResources().get(0));
+
+        Request request = new Request(Method.GET, "http://localhost/orders");
+        Response response = new Response(request);
+        restlet.handle(request, response);
+
+        assertEquals(Status.SUCCESS_OK, response.getStatus());
+
+        List<SpanData> spans = exporter.getFinishedSpanItems();
+        assertEquals(1, spans.size(), "Mock response should produce 1 server span (no HTTP call)");
+
+        SpanData serverSpan = spans.get(0);
+        assertEquals("rest.request", serverSpan.getName());
+        assertEquals(SpanKind.SERVER, serverSpan.getKind());
+        assertEquals("rest",
+                serverSpan.getAttributes().get(TelemetryBootstrap.ATTR_ADAPTER_TYPE));
+        assertEquals("GET",
+                serverSpan.getAttributes().get(TelemetryBootstrap.ATTR_HTTP_METHOD));
+        assertNotNull(serverSpan.getAttributes().get(TelemetryBootstrap.ATTR_OPERATION_ID));
+    }
+
+    @Test
+    void restHandleShouldExtractInboundTraceparent() throws Exception {
+        Capability capability = capabilityFromYaml("""
+                naftiko: "%s"
+                capability:
+                  exposes:
+                    - type: "rest"
+                      address: "localhost"
+                      port: 0
+                      namespace: "test"
+                      resources:
+                        - path: "/orders"
+                          operations:
+                            - method: "GET"
+                              name: "list-orders"
+                              outputParameters:
+                                - name: "status"
+                                  type: "string"
+                                  value: "ok"
+                  consumes: []
+                """.formatted(schemaVersion));
+
+        RestServerSpec serverSpec =
+                (RestServerSpec) capability.getServerAdapters().get(0).getSpec();
+        ResourceRestlet restlet = new ResourceRestlet(capability, serverSpec,
+                serverSpec.getResources().get(0));
+
+        Request request = new Request(Method.GET, "http://localhost/orders");
+        // Inject W3C traceparent header on the inbound request
+        String traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        request.getHeaders().add("traceparent", traceparent);
+        Response response = new Response(request);
+        restlet.handle(request, response);
+
+        List<SpanData> spans = exporter.getFinishedSpanItems();
+        assertEquals(1, spans.size());
+
+        SpanData serverSpan = spans.get(0);
+        // The server span should be a child of the extracted trace context
+        assertEquals("4bf92f3577b34da6a3ce929d0e0e4736", serverSpan.getTraceId(),
+                "Server span should continue the inbound trace");
+        assertEquals("00f067aa0ba902b7", serverSpan.getParentSpanId(),
+                "Server span parent should be the inbound span");
+    }
+
+    @Test
+    void restHandleShouldReturnNotFoundAndStillProduceSpan() throws Exception {
+        Capability capability = capabilityFromYaml("""
+                naftiko: "%s"
+                capability:
+                  exposes:
+                    - type: "rest"
+                      address: "localhost"
+                      port: 0
+                      namespace: "test"
+                      resources:
+                        - path: "/orders"
+                          operations:
+                            - method: "POST"
+                              name: "create-order"
+                  consumes: []
+                """.formatted(schemaVersion));
+
+        RestServerSpec serverSpec =
+                (RestServerSpec) capability.getServerAdapters().get(0).getSpec();
+        ResourceRestlet restlet = new ResourceRestlet(capability, serverSpec,
+                serverSpec.getResources().get(0));
+
+        // GET doesn't match any operation (only POST is defined)
+        Request request = new Request(Method.GET, "http://localhost/orders");
+        Response response = new Response(request);
+        restlet.handle(request, response);
+
+        assertEquals(Status.CLIENT_ERROR_NOT_FOUND, response.getStatus());
+
+        List<SpanData> spans = exporter.getFinishedSpanItems();
+        assertEquals(1, spans.size(), "Should still produce a server span on not-found");
+        assertEquals("rest.request", spans.get(0).getName());
+    }
+}

--- a/src/test/java/io/naftiko/engine/exposes/rest/ObservabilityRestIntegrationTest.java
+++ b/src/test/java/io/naftiko/engine/exposes/rest/ObservabilityRestIntegrationTest.java
@@ -45,7 +45,7 @@ import java.util.List;
  * Integration tests verifying that REST adapter requests produce the expected OTel span hierarchy,
  * including W3C traceparent extraction.
  */
-@SuppressWarnings("null")
+@SuppressWarnings("null") // OTel SDK types lack @Nonnull annotations
 public class ObservabilityRestIntegrationTest {
 
     private final InMemorySpanExporter exporter = InMemorySpanExporter.create();

--- a/src/test/java/io/naftiko/engine/exposes/skill/ObservabilitySkillIntegrationTest.java
+++ b/src/test/java/io/naftiko/engine/exposes/skill/ObservabilitySkillIntegrationTest.java
@@ -44,6 +44,7 @@ import java.util.List;
  * Integration tests verifying that Skill adapter requests produce the expected OTel server spans,
  * including W3C traceparent extraction.
  */
+@SuppressWarnings("null")
 public class ObservabilitySkillIntegrationTest {
 
     private static final int SKILL_PORT = 9098;

--- a/src/test/java/io/naftiko/engine/exposes/skill/ObservabilitySkillIntegrationTest.java
+++ b/src/test/java/io/naftiko/engine/exposes/skill/ObservabilitySkillIntegrationTest.java
@@ -44,7 +44,7 @@ import java.util.List;
  * Integration tests verifying that Skill adapter requests produce the expected OTel server spans,
  * including W3C traceparent extraction.
  */
-@SuppressWarnings("null")
+@SuppressWarnings("null") // OTel SDK types lack @Nonnull annotations
 public class ObservabilitySkillIntegrationTest {
 
     private static final int SKILL_PORT = 9098;

--- a/src/test/java/io/naftiko/engine/exposes/skill/ObservabilitySkillIntegrationTest.java
+++ b/src/test/java/io/naftiko/engine/exposes/skill/ObservabilitySkillIntegrationTest.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.naftiko.engine.exposes.skill;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.naftiko.Capability;
+import io.naftiko.engine.telemetry.TelemetryBootstrap;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.naftiko.spec.NaftikoSpec;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+
+/**
+ * Integration tests verifying that Skill adapter requests produce the expected OTel server spans,
+ * including W3C traceparent extraction.
+ */
+public class ObservabilitySkillIntegrationTest {
+
+    private static final int SKILL_PORT = 9098;
+    private static final String BASE_URL = "http://localhost:" + SKILL_PORT;
+
+    private static final InMemorySpanExporter exporter = InMemorySpanExporter.create();
+    private static SdkTracerProvider tracerProvider;
+    private static SkillServerAdapter skillAdapter;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        tracerProvider = SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                .build();
+        OpenTelemetrySdk sdk = OpenTelemetrySdk.builder()
+                .setTracerProvider(tracerProvider)
+                .setPropagators(ContextPropagators.create(
+                        W3CTraceContextPropagator.getInstance()))
+                .build();
+        TelemetryBootstrap.init(sdk);
+
+        File file = new File("src/test/resources/skill-capability.yaml");
+        assertTrue(file.exists());
+
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        NaftikoSpec spec = mapper.readValue(file, NaftikoSpec.class);
+
+        // Override the port to avoid conflict with other tests
+        spec.getCapability().getExposes().stream()
+                .filter(s -> "skill".equals(s.getType()))
+                .findFirst()
+                .ifPresent(s -> s.setPort(SKILL_PORT));
+
+        Capability capability = new Capability(spec);
+
+        skillAdapter = (SkillServerAdapter) capability.getServerAdapters().stream()
+                .filter(a -> a instanceof SkillServerAdapter)
+                .findFirst()
+                .orElseThrow();
+
+        skillAdapter.start();
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        if (skillAdapter != null) {
+            skillAdapter.stop();
+        }
+        TelemetryBootstrap.reset();
+        exporter.reset();
+    }
+
+    @Test
+    void skillRequestShouldProduceServerSpan() throws Exception {
+        exporter.reset();
+
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(BASE_URL + "/skills"))
+                .GET()
+                .build();
+
+        HttpResponse<String> response =
+                client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode());
+
+        tracerProvider.forceFlush().join(5, java.util.concurrent.TimeUnit.SECONDS);
+
+        List<SpanData> spans = exporter.getFinishedSpanItems();
+        assertFalse(spans.isEmpty(), "Should produce at least one span");
+
+        SpanData serverSpan = spans.stream()
+                .filter(s -> s.getName().equals("skill.request"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Missing skill.request span"));
+
+        assertEquals(SpanKind.SERVER, serverSpan.getKind());
+        assertEquals("skill",
+                serverSpan.getAttributes().get(TelemetryBootstrap.ATTR_ADAPTER_TYPE));
+        assertEquals("GET",
+                serverSpan.getAttributes().get(TelemetryBootstrap.ATTR_HTTP_METHOD));
+    }
+
+    @Test
+    void skillRequestShouldExtractInboundTraceparent() throws Exception {
+        exporter.reset();
+
+        String traceparent = "00-abcdef1234567890abcdef1234567890-1234567890abcdef-01";
+
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(BASE_URL + "/skills"))
+                .header("traceparent", traceparent)
+                .GET()
+                .build();
+
+        HttpResponse<String> response =
+                client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode());
+
+        tracerProvider.forceFlush().join(5, java.util.concurrent.TimeUnit.SECONDS);
+
+        List<SpanData> spans = exporter.getFinishedSpanItems();
+        SpanData serverSpan = spans.stream()
+                .filter(s -> s.getName().equals("skill.request"))
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals("abcdef1234567890abcdef1234567890", serverSpan.getTraceId(),
+                "Server span should continue the inbound trace");
+        assertEquals("1234567890abcdef", serverSpan.getParentSpanId(),
+                "Server span parent should be the inbound span");
+    }
+}

--- a/src/test/java/io/naftiko/engine/telemetry/ContextPropagationTest.java
+++ b/src/test/java/io/naftiko/engine/telemetry/ContextPropagationTest.java
@@ -35,7 +35,7 @@ import org.restlet.data.Method;
  * Integration tests for W3C trace context propagation round-trip:
  * extract from inbound headers → create child span → inject into outbound headers.
  */
-@SuppressWarnings("null")
+@SuppressWarnings("null") // OTel SDK types lack @Nonnull annotations
 public class ContextPropagationTest {
 
     private final InMemorySpanExporter exporter = InMemorySpanExporter.create();

--- a/src/test/java/io/naftiko/engine/telemetry/ContextPropagationTest.java
+++ b/src/test/java/io/naftiko/engine/telemetry/ContextPropagationTest.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.naftiko.engine.telemetry;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.restlet.Request;
+import org.restlet.data.Method;
+
+/**
+ * Integration tests for W3C trace context propagation round-trip:
+ * extract from inbound headers → create child span → inject into outbound headers.
+ */
+public class ContextPropagationTest {
+
+    private final InMemorySpanExporter exporter = InMemorySpanExporter.create();
+    private OpenTelemetrySdk sdk;
+
+    @BeforeEach
+    void setUp() {
+        sdk = OpenTelemetrySdk.builder()
+                .setTracerProvider(SdkTracerProvider.builder()
+                        .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                        .build())
+                .setPropagators(ContextPropagators.create(
+                        W3CTraceContextPropagator.getInstance()))
+                .build();
+        TelemetryBootstrap.init(sdk);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TelemetryBootstrap.reset();
+        exporter.reset();
+    }
+
+    @Test
+    void extractShouldRecoverTraceAndSpanIds() {
+        Request inboundRequest = new Request(Method.GET, "http://localhost/test");
+        inboundRequest.getHeaders().add("traceparent",
+                "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01");
+
+        Context extracted = sdk.getPropagators().getTextMapPropagator()
+                .extract(Context.current(), inboundRequest, RestletHeaderGetter.INSTANCE);
+
+        Span serverSpan = sdk.getTracer("test")
+                .spanBuilder("test.request")
+                .setSpanKind(SpanKind.SERVER)
+                .setParent(extracted)
+                .startSpan();
+        serverSpan.end();
+
+        SpanData data = exporter.getFinishedSpanItems().get(0);
+        assertEquals("4bf92f3577b34da6a3ce929d0e0e4736", data.getTraceId());
+        assertEquals("00f067aa0ba902b7", data.getParentSpanId());
+    }
+
+    @Test
+    void injectShouldSetTraceparentHeader() {
+        Span serverSpan = sdk.getTracer("test")
+                .spanBuilder("test.request")
+                .setSpanKind(SpanKind.SERVER)
+                .startSpan();
+
+        Request outboundRequest = new Request(Method.GET, "http://api.example.com/data");
+
+        try (var scope = serverSpan.makeCurrent()) {
+            sdk.getPropagators().getTextMapPropagator()
+                    .inject(Context.current(), outboundRequest, RestletHeaderSetter.INSTANCE);
+        }
+        serverSpan.end();
+
+        String traceparent = outboundRequest.getHeaders()
+                .getFirstValue("traceparent", true);
+        assertNotNull(traceparent, "traceparent should be injected into outbound headers");
+        assertTrue(traceparent.startsWith("00-"),
+                "traceparent should start with version 00");
+
+        // Verify the trace ID in the injected header matches the server span
+        SpanData data = exporter.getFinishedSpanItems().get(0);
+        assertTrue(traceparent.contains(data.getTraceId()),
+                "Injected traceparent should carry the server span's trace ID");
+        assertTrue(traceparent.contains(data.getSpanId()),
+                "Injected traceparent should carry the server span's span ID");
+    }
+
+    @Test
+    void roundTripShouldPreserveTraceAcrossExtractAndInject() {
+        // 1. Simulate inbound request with traceparent
+        Request inboundRequest = new Request(Method.GET, "http://localhost/test");
+        inboundRequest.getHeaders().add("traceparent",
+                "00-abcdef0123456789abcdef0123456789-fedcba9876543210-01");
+
+        Context extracted = sdk.getPropagators().getTextMapPropagator()
+                .extract(Context.current(), inboundRequest, RestletHeaderGetter.INSTANCE);
+
+        // 2. Create a server span parented to the extracted context
+        Span serverSpan = sdk.getTracer("test")
+                .spanBuilder("server.request")
+                .setSpanKind(SpanKind.SERVER)
+                .setParent(extracted)
+                .startSpan();
+
+        // 3. Inside the server span scope, inject context into an outbound request
+        Request outboundRequest = new Request(Method.POST, "http://api.example.com/action");
+        try (var scope = serverSpan.makeCurrent()) {
+            sdk.getPropagators().getTextMapPropagator()
+                    .inject(Context.current(), outboundRequest, RestletHeaderSetter.INSTANCE);
+        }
+        serverSpan.end();
+
+        // 4. The outbound request should carry the same trace ID
+        String outboundTraceparent = outboundRequest.getHeaders()
+                .getFirstValue("traceparent", true);
+        assertNotNull(outboundTraceparent);
+        assertTrue(outboundTraceparent.contains("abcdef0123456789abcdef0123456789"),
+                "Outbound should carry the original trace ID across the hop");
+
+        // The outbound span ID should be the server span's ID (the parent of downstream)
+        SpanData data = exporter.getFinishedSpanItems().get(0);
+        assertTrue(outboundTraceparent.contains(data.getSpanId()),
+                "Outbound traceparent should reference the server span as parent");
+    }
+}

--- a/src/test/java/io/naftiko/engine/telemetry/ContextPropagationTest.java
+++ b/src/test/java/io/naftiko/engine/telemetry/ContextPropagationTest.java
@@ -35,6 +35,7 @@ import org.restlet.data.Method;
  * Integration tests for W3C trace context propagation round-trip:
  * extract from inbound headers → create child span → inject into outbound headers.
  */
+@SuppressWarnings("null")
 public class ContextPropagationTest {
 
     private final InMemorySpanExporter exporter = InMemorySpanExporter.create();

--- a/src/test/java/io/naftiko/engine/telemetry/RestletHeaderGetterTest.java
+++ b/src/test/java/io/naftiko/engine/telemetry/RestletHeaderGetterTest.java
@@ -49,6 +49,7 @@ public class RestletHeaderGetterTest {
     }
 
     @Test
+    @SuppressWarnings("null") // deliberately passing null to @Nonnull param
     void getShouldReturnNullForNullKey() {
         Request request = new Request(Method.GET, "http://localhost/test");
         assertNull(RestletHeaderGetter.INSTANCE.get(request, null));

--- a/src/test/java/io/naftiko/engine/telemetry/RestletHeaderGetterTest.java
+++ b/src/test/java/io/naftiko/engine/telemetry/RestletHeaderGetterTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.naftiko.engine.telemetry;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.restlet.Request;
+import org.restlet.data.Method;
+
+/**
+ * Unit tests for {@link RestletHeaderGetter} — W3C traceparent extraction from Restlet requests.
+ */
+public class RestletHeaderGetterTest {
+
+    @Test
+    void getShouldReturnHeaderValueCaseInsensitively() {
+        Request request = new Request(Method.GET, "http://localhost/test");
+        request.getHeaders().add("traceparent",
+                "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01");
+
+        String value = RestletHeaderGetter.INSTANCE.get(request, "traceparent");
+        assertEquals("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01", value);
+    }
+
+    @Test
+    void getShouldReturnNullForMissingHeader() {
+        Request request = new Request(Method.GET, "http://localhost/test");
+
+        assertNull(RestletHeaderGetter.INSTANCE.get(request, "traceparent"));
+    }
+
+    @Test
+    void getShouldReturnNullForNullRequest() {
+        assertNull(RestletHeaderGetter.INSTANCE.get(null, "traceparent"));
+    }
+
+    @Test
+    void getShouldReturnNullForNullKey() {
+        Request request = new Request(Method.GET, "http://localhost/test");
+        assertNull(RestletHeaderGetter.INSTANCE.get(request, null));
+    }
+
+    @Test
+    void keysShouldReturnAllHeaderNames() {
+        Request request = new Request(Method.GET, "http://localhost/test");
+        request.getHeaders().add("traceparent", "value1");
+        request.getHeaders().add("tracestate", "value2");
+
+        Iterable<String> keys = RestletHeaderGetter.INSTANCE.keys(request);
+        assertNotNull(keys);
+
+        List<String> keyList = new ArrayList<>();
+        keys.forEach(keyList::add);
+        assertTrue(keyList.size() >= 2, "Should return at least the 2 added headers");
+    }
+
+    @Test
+    void keysShouldReturnEmptyForNullRequest() {
+        Iterable<String> keys = RestletHeaderGetter.INSTANCE.keys(null);
+        assertFalse(keys.iterator().hasNext());
+    }
+}

--- a/src/test/java/io/naftiko/engine/telemetry/RestletHeaderSetterTest.java
+++ b/src/test/java/io/naftiko/engine/telemetry/RestletHeaderSetterTest.java
@@ -53,6 +53,7 @@ public class RestletHeaderSetterTest {
     }
 
     @Test
+    @SuppressWarnings("null") // deliberately passing null to @Nonnull param
     void setShouldIgnoreNullKey() {
         Request request = new Request(Method.GET, "http://localhost/test");
         assertDoesNotThrow(() ->
@@ -60,6 +61,7 @@ public class RestletHeaderSetterTest {
     }
 
     @Test
+    @SuppressWarnings("null") // deliberately passing null to @Nonnull param
     void setShouldIgnoreNullValue() {
         Request request = new Request(Method.GET, "http://localhost/test");
         assertDoesNotThrow(() ->

--- a/src/test/java/io/naftiko/engine/telemetry/RestletHeaderSetterTest.java
+++ b/src/test/java/io/naftiko/engine/telemetry/RestletHeaderSetterTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.naftiko.engine.telemetry;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.restlet.Request;
+import org.restlet.data.Method;
+
+/**
+ * Unit tests for {@link RestletHeaderSetter} — W3C traceparent injection into Restlet requests.
+ */
+public class RestletHeaderSetterTest {
+
+    @Test
+    void setShouldAddHeaderToRequest() {
+        Request request = new Request(Method.GET, "http://localhost/test");
+
+        RestletHeaderSetter.INSTANCE.set(request,
+                "traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01");
+
+        assertEquals("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+                request.getHeaders().getFirstValue("traceparent", true));
+    }
+
+    @Test
+    void setShouldOverwriteExistingHeader() {
+        Request request = new Request(Method.GET, "http://localhost/test");
+        request.getHeaders().set("traceparent", "old-value");
+
+        RestletHeaderSetter.INSTANCE.set(request, "traceparent", "new-value");
+
+        assertEquals("new-value",
+                request.getHeaders().getFirstValue("traceparent", true));
+    }
+
+    @Test
+    void setShouldIgnoreNullRequest() {
+        assertDoesNotThrow(() ->
+                RestletHeaderSetter.INSTANCE.set(null, "traceparent", "value"));
+    }
+
+    @Test
+    void setShouldIgnoreNullKey() {
+        Request request = new Request(Method.GET, "http://localhost/test");
+        assertDoesNotThrow(() ->
+                RestletHeaderSetter.INSTANCE.set(request, null, "value"));
+    }
+
+    @Test
+    void setShouldIgnoreNullValue() {
+        Request request = new Request(Method.GET, "http://localhost/test");
+        assertDoesNotThrow(() ->
+                RestletHeaderSetter.INSTANCE.set(request, "traceparent", null));
+    }
+}

--- a/src/test/java/io/naftiko/engine/telemetry/TelemetryBootstrapTest.java
+++ b/src/test/java/io/naftiko/engine/telemetry/TelemetryBootstrapTest.java
@@ -32,6 +32,7 @@ import java.util.List;
  * Unit tests for {@link TelemetryBootstrap} — SDK initialization, no-op fallback,
  * span factory methods, and error recording.
  */
+@SuppressWarnings("null")
 public class TelemetryBootstrapTest {
 
     private final InMemorySpanExporter exporter = InMemorySpanExporter.create();

--- a/src/test/java/io/naftiko/engine/telemetry/TelemetryBootstrapTest.java
+++ b/src/test/java/io/naftiko/engine/telemetry/TelemetryBootstrapTest.java
@@ -65,7 +65,7 @@ public class TelemetryBootstrapTest {
     @Test
     void noOpInstanceShouldProduceInvalidSpans() {
         TelemetryBootstrap bootstrap = TelemetryBootstrap.get();
-        Span span = bootstrap.startServerSpan("rest", "test-op");
+        Span span = bootstrap.startServerSpan("rest", "test-op", null, null, null);
         assertNotNull(span);
         assertFalse(span.getSpanContext().isValid(),
                 "No-op tracer should produce spans with invalid context");
@@ -91,7 +91,7 @@ public class TelemetryBootstrapTest {
         TelemetryBootstrap.reset();
         // After reset, get() should return a new no-op instance
         TelemetryBootstrap after = TelemetryBootstrap.get();
-        Span span = after.startServerSpan("rest", "test-op");
+        Span span = after.startServerSpan("rest", "test-op", null, null, null);
         assertFalse(span.getSpanContext().isValid());
         span.end();
     }
@@ -102,7 +102,8 @@ public class TelemetryBootstrapTest {
     void startServerSpanShouldCreateSpanWithCorrectAttributes() {
         initWithInMemoryExporter();
 
-        Span span = TelemetryBootstrap.get().startServerSpan("rest", "GET /orders");
+        Span span = TelemetryBootstrap.get().startServerSpan("rest", "GET /orders",
+                null, null, "my-capability");
         span.end();
 
         List<SpanData> spans = exporter.getFinishedSpanItems();
@@ -114,17 +115,20 @@ public class TelemetryBootstrapTest {
         assertEquals("rest", data.getAttributes().get(TelemetryBootstrap.ATTR_ADAPTER_TYPE));
         assertEquals("GET /orders",
                 data.getAttributes().get(TelemetryBootstrap.ATTR_OPERATION_ID));
+        assertEquals("my-capability",
+                data.getAttributes().get(TelemetryBootstrap.ATTR_CAPABILITY));
     }
 
     @Test
     void startServerSpanShouldDefaultOperationIdWhenNull() {
         initWithInMemoryExporter();
 
-        Span span = TelemetryBootstrap.get().startServerSpan("mcp", null);
+        Span span = TelemetryBootstrap.get().startServerSpan("mcp", null, null, null, null);
         span.end();
 
         SpanData data = exporter.getFinishedSpanItems().get(0);
         assertEquals("unknown", data.getAttributes().get(TelemetryBootstrap.ATTR_OPERATION_ID));
+        assertNull(data.getAttributes().get(TelemetryBootstrap.ATTR_CAPABILITY));
     }
 
     // ── Step call span factory ──
@@ -133,7 +137,8 @@ public class TelemetryBootstrapTest {
     void startStepCallSpanShouldCreateInternalSpanWithAttributes() {
         initWithInMemoryExporter();
 
-        Span span = TelemetryBootstrap.get().startStepCallSpan(0, "weather-api.get-forecast");
+        Span span = TelemetryBootstrap.get().startStepCallSpan(0, "weather-api.get-forecast",
+                "weather-ns");
         span.end();
 
         SpanData data = exporter.getFinishedSpanItems().get(0);
@@ -142,6 +147,8 @@ public class TelemetryBootstrapTest {
         assertEquals(0L, data.getAttributes().get(TelemetryBootstrap.ATTR_STEP_INDEX));
         assertEquals("weather-api.get-forecast",
                 data.getAttributes().get(TelemetryBootstrap.ATTR_STEP_CALL));
+        assertEquals("weather-ns",
+                data.getAttributes().get(TelemetryBootstrap.ATTR_NAMESPACE));
     }
 
     // ── Step lookup span factory ──
@@ -195,7 +202,7 @@ public class TelemetryBootstrapTest {
         initWithInMemoryExporter();
 
         Span span = TelemetryBootstrap.get()
-                .startClientSpan("GET", "http://api.example.com/forecast");
+                .startClientSpan("GET", "http://api.example.com/forecast", "weather-api");
         span.end();
 
         SpanData data = exporter.getFinishedSpanItems().get(0);
@@ -204,19 +211,22 @@ public class TelemetryBootstrapTest {
         assertEquals("GET", data.getAttributes().get(TelemetryBootstrap.ATTR_HTTP_METHOD));
         assertEquals("http://api.example.com/forecast",
                 data.getAttributes().get(TelemetryBootstrap.ATTR_HTTP_URL));
+        assertEquals("weather-api",
+                data.getAttributes().get(TelemetryBootstrap.ATTR_NAMESPACE));
     }
 
     @Test
     void startClientSpanShouldDefaultMethodWhenNull() {
         initWithInMemoryExporter();
 
-        Span span = TelemetryBootstrap.get().startClientSpan(null, null);
+        Span span = TelemetryBootstrap.get().startClientSpan(null, null, null);
         span.end();
 
         SpanData data = exporter.getFinishedSpanItems().get(0);
         assertEquals("http.client.UNKNOWN", data.getName());
         assertEquals("UNKNOWN", data.getAttributes().get(TelemetryBootstrap.ATTR_HTTP_METHOD));
         assertEquals("unknown", data.getAttributes().get(TelemetryBootstrap.ATTR_HTTP_URL));
+        assertNull(data.getAttributes().get(TelemetryBootstrap.ATTR_NAMESPACE));
     }
 
     // ── Error recording ──
@@ -225,7 +235,8 @@ public class TelemetryBootstrapTest {
     void recordErrorShouldSetStatusAndRecordException() {
         initWithInMemoryExporter();
 
-        Span span = TelemetryBootstrap.get().startServerSpan("rest", "test-op");
+        Span span = TelemetryBootstrap.get().startServerSpan("rest", "test-op",
+                null, null, null);
         TelemetryBootstrap.recordError(span, new RuntimeException("test failure"));
         span.end();
 
@@ -243,7 +254,8 @@ public class TelemetryBootstrapTest {
     @Test
     void recordErrorShouldHandleNullErrorSafely() {
         initWithInMemoryExporter();
-        Span span = TelemetryBootstrap.get().startServerSpan("rest", "test-op");
+        Span span = TelemetryBootstrap.get().startServerSpan("rest", "test-op",
+                null, null, null);
         assertDoesNotThrow(() -> TelemetryBootstrap.recordError(span, null));
         span.end();
     }
@@ -261,12 +273,13 @@ public class TelemetryBootstrapTest {
     void childSpansShouldBeParentedCorrectly() {
         initWithInMemoryExporter();
 
-        Span serverSpan = TelemetryBootstrap.get().startServerSpan("mcp", "query-database");
+        Span serverSpan = TelemetryBootstrap.get().startServerSpan("mcp", "query-database",
+                null, null, null);
         try (var scope = serverSpan.makeCurrent()) {
-            Span stepSpan = TelemetryBootstrap.get().startStepCallSpan(0, "db-api.query");
+            Span stepSpan = TelemetryBootstrap.get().startStepCallSpan(0, "db-api.query", null);
             try (var stepScope = stepSpan.makeCurrent()) {
                 Span clientSpan = TelemetryBootstrap.get()
-                        .startClientSpan("POST", "http://localhost:8080/query");
+                        .startClientSpan("POST", "http://localhost:8080/query", null);
                 clientSpan.end();
             }
             stepSpan.end();

--- a/src/test/java/io/naftiko/engine/telemetry/TelemetryBootstrapTest.java
+++ b/src/test/java/io/naftiko/engine/telemetry/TelemetryBootstrapTest.java
@@ -32,7 +32,7 @@ import java.util.List;
  * Unit tests for {@link TelemetryBootstrap} — SDK initialization, no-op fallback,
  * span factory methods, and error recording.
  */
-@SuppressWarnings("null")
+@SuppressWarnings("null") // OTel SDK types lack @Nonnull annotations
 public class TelemetryBootstrapTest {
 
     private final InMemorySpanExporter exporter = InMemorySpanExporter.create();

--- a/src/test/java/io/naftiko/engine/telemetry/TelemetryBootstrapTest.java
+++ b/src/test/java/io/naftiko/engine/telemetry/TelemetryBootstrapTest.java
@@ -1,0 +1,295 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.naftiko.engine.telemetry;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+/**
+ * Unit tests for {@link TelemetryBootstrap} — SDK initialization, no-op fallback,
+ * span factory methods, and error recording.
+ */
+public class TelemetryBootstrapTest {
+
+    private final InMemorySpanExporter exporter = InMemorySpanExporter.create();
+
+    @AfterEach
+    void tearDown() {
+        TelemetryBootstrap.reset();
+        exporter.reset();
+    }
+
+    private TelemetryBootstrap initWithInMemoryExporter() {
+        OpenTelemetrySdk sdk = OpenTelemetrySdk.builder()
+                .setTracerProvider(SdkTracerProvider.builder()
+                        .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                        .build())
+                .build();
+        return TelemetryBootstrap.init(sdk);
+    }
+
+    // ── Initialization ──
+
+    @Test
+    void getShouldReturnNoOpWhenNotInitialized() {
+        TelemetryBootstrap bootstrap = TelemetryBootstrap.get();
+        assertNotNull(bootstrap);
+        assertNotNull(bootstrap.getTracer());
+        assertNotNull(bootstrap.getOpenTelemetry());
+    }
+
+    @Test
+    void noOpInstanceShouldProduceInvalidSpans() {
+        TelemetryBootstrap bootstrap = TelemetryBootstrap.get();
+        Span span = bootstrap.startServerSpan("rest", "test-op");
+        assertNotNull(span);
+        assertFalse(span.getSpanContext().isValid(),
+                "No-op tracer should produce spans with invalid context");
+        span.end();
+    }
+
+    @Test
+    void initWithOpenTelemetryShouldSetGlobalInstance() {
+        TelemetryBootstrap bootstrap = initWithInMemoryExporter();
+        assertSame(bootstrap, TelemetryBootstrap.get());
+    }
+
+    @Test
+    void initWithServiceNameShouldSetGlobalInstance() {
+        TelemetryBootstrap bootstrap = TelemetryBootstrap.init("test-service");
+        assertNotNull(bootstrap);
+        assertSame(bootstrap, TelemetryBootstrap.get());
+    }
+
+    @Test
+    void resetShouldClearGlobalInstance() {
+        initWithInMemoryExporter();
+        TelemetryBootstrap.reset();
+        // After reset, get() should return a new no-op instance
+        TelemetryBootstrap after = TelemetryBootstrap.get();
+        Span span = after.startServerSpan("rest", "test-op");
+        assertFalse(span.getSpanContext().isValid());
+        span.end();
+    }
+
+    // ── Server span factory ──
+
+    @Test
+    void startServerSpanShouldCreateSpanWithCorrectAttributes() {
+        initWithInMemoryExporter();
+
+        Span span = TelemetryBootstrap.get().startServerSpan("rest", "GET /orders");
+        span.end();
+
+        List<SpanData> spans = exporter.getFinishedSpanItems();
+        assertEquals(1, spans.size());
+
+        SpanData data = spans.get(0);
+        assertEquals("rest.request", data.getName());
+        assertEquals(SpanKind.SERVER, data.getKind());
+        assertEquals("rest", data.getAttributes().get(TelemetryBootstrap.ATTR_ADAPTER_TYPE));
+        assertEquals("GET /orders",
+                data.getAttributes().get(TelemetryBootstrap.ATTR_OPERATION_ID));
+    }
+
+    @Test
+    void startServerSpanShouldDefaultOperationIdWhenNull() {
+        initWithInMemoryExporter();
+
+        Span span = TelemetryBootstrap.get().startServerSpan("mcp", null);
+        span.end();
+
+        SpanData data = exporter.getFinishedSpanItems().get(0);
+        assertEquals("unknown", data.getAttributes().get(TelemetryBootstrap.ATTR_OPERATION_ID));
+    }
+
+    // ── Step call span factory ──
+
+    @Test
+    void startStepCallSpanShouldCreateInternalSpanWithAttributes() {
+        initWithInMemoryExporter();
+
+        Span span = TelemetryBootstrap.get().startStepCallSpan(0, "weather-api.get-forecast");
+        span.end();
+
+        SpanData data = exporter.getFinishedSpanItems().get(0);
+        assertEquals("step.call", data.getName());
+        assertEquals(SpanKind.INTERNAL, data.getKind());
+        assertEquals(0L, data.getAttributes().get(TelemetryBootstrap.ATTR_STEP_INDEX));
+        assertEquals("weather-api.get-forecast",
+                data.getAttributes().get(TelemetryBootstrap.ATTR_STEP_CALL));
+    }
+
+    // ── Step lookup span factory ──
+
+    @Test
+    void startStepLookupSpanShouldCreateInternalSpanWithAttributes() {
+        initWithInMemoryExporter();
+
+        Span span = TelemetryBootstrap.get().startStepLookupSpan(1, "vessel-name");
+        span.end();
+
+        SpanData data = exporter.getFinishedSpanItems().get(0);
+        assertEquals("step.lookup", data.getName());
+        assertEquals(SpanKind.INTERNAL, data.getKind());
+        assertEquals(1L, data.getAttributes().get(TelemetryBootstrap.ATTR_STEP_INDEX));
+        assertEquals("vessel-name", data.getAttributes().get(TelemetryBootstrap.ATTR_STEP_MATCH));
+    }
+
+    // ── Aggregate function span factory ──
+
+    @Test
+    void startAggregateFunctionSpanShouldCreateInternalSpanWithRef() {
+        initWithInMemoryExporter();
+
+        Span span = TelemetryBootstrap.get().startAggregateFunctionSpan("forecast.get-forecast");
+        span.end();
+
+        SpanData data = exporter.getFinishedSpanItems().get(0);
+        assertEquals("aggregate.function", data.getName());
+        assertEquals(SpanKind.INTERNAL, data.getKind());
+        assertEquals("forecast.get-forecast",
+                data.getAttributes().get(TelemetryBootstrap.ATTR_AGGREGATE_REF));
+    }
+
+    @Test
+    void startAggregateFunctionSpanShouldDefaultRefWhenNull() {
+        initWithInMemoryExporter();
+
+        Span span = TelemetryBootstrap.get().startAggregateFunctionSpan(null);
+        span.end();
+
+        SpanData data = exporter.getFinishedSpanItems().get(0);
+        assertEquals("unknown",
+                data.getAttributes().get(TelemetryBootstrap.ATTR_AGGREGATE_REF));
+    }
+
+    // ── Client span factory ──
+
+    @Test
+    void startClientSpanShouldCreateClientSpanWithAttributes() {
+        initWithInMemoryExporter();
+
+        Span span = TelemetryBootstrap.get()
+                .startClientSpan("GET", "http://api.example.com/forecast");
+        span.end();
+
+        SpanData data = exporter.getFinishedSpanItems().get(0);
+        assertEquals("http.client.GET", data.getName());
+        assertEquals(SpanKind.CLIENT, data.getKind());
+        assertEquals("GET", data.getAttributes().get(TelemetryBootstrap.ATTR_HTTP_METHOD));
+        assertEquals("http://api.example.com/forecast",
+                data.getAttributes().get(TelemetryBootstrap.ATTR_HTTP_URL));
+    }
+
+    @Test
+    void startClientSpanShouldDefaultMethodWhenNull() {
+        initWithInMemoryExporter();
+
+        Span span = TelemetryBootstrap.get().startClientSpan(null, null);
+        span.end();
+
+        SpanData data = exporter.getFinishedSpanItems().get(0);
+        assertEquals("http.client.UNKNOWN", data.getName());
+        assertEquals("UNKNOWN", data.getAttributes().get(TelemetryBootstrap.ATTR_HTTP_METHOD));
+        assertEquals("unknown", data.getAttributes().get(TelemetryBootstrap.ATTR_HTTP_URL));
+    }
+
+    // ── Error recording ──
+
+    @Test
+    void recordErrorShouldSetStatusAndRecordException() {
+        initWithInMemoryExporter();
+
+        Span span = TelemetryBootstrap.get().startServerSpan("rest", "test-op");
+        TelemetryBootstrap.recordError(span, new RuntimeException("test failure"));
+        span.end();
+
+        SpanData data = exporter.getFinishedSpanItems().get(0);
+        assertEquals(StatusCode.ERROR, data.getStatus().getStatusCode());
+        assertEquals("test failure", data.getStatus().getDescription());
+        assertFalse(data.getEvents().isEmpty(), "Should have recorded exception event");
+    }
+
+    @Test
+    void recordErrorShouldHandleNullSpanSafely() {
+        assertDoesNotThrow(() -> TelemetryBootstrap.recordError(null, new RuntimeException()));
+    }
+
+    @Test
+    void recordErrorShouldHandleNullErrorSafely() {
+        initWithInMemoryExporter();
+        Span span = TelemetryBootstrap.get().startServerSpan("rest", "test-op");
+        assertDoesNotThrow(() -> TelemetryBootstrap.recordError(span, null));
+        span.end();
+    }
+
+    // ── endSpan ──
+
+    @Test
+    void endSpanShouldHandleNullSafely() {
+        assertDoesNotThrow(() -> TelemetryBootstrap.endSpan(null));
+    }
+
+    // ── Span hierarchy ──
+
+    @Test
+    void childSpansShouldBeParentedCorrectly() {
+        initWithInMemoryExporter();
+
+        Span serverSpan = TelemetryBootstrap.get().startServerSpan("mcp", "query-database");
+        try (var scope = serverSpan.makeCurrent()) {
+            Span stepSpan = TelemetryBootstrap.get().startStepCallSpan(0, "db-api.query");
+            try (var stepScope = stepSpan.makeCurrent()) {
+                Span clientSpan = TelemetryBootstrap.get()
+                        .startClientSpan("POST", "http://localhost:8080/query");
+                clientSpan.end();
+            }
+            stepSpan.end();
+        }
+        serverSpan.end();
+
+        List<SpanData> spans = exporter.getFinishedSpanItems();
+        assertEquals(3, spans.size());
+
+        // Spans are finished in reverse order: client, step, server
+        SpanData clientData = spans.get(0);
+        SpanData stepData = spans.get(1);
+        SpanData serverData = spans.get(2);
+
+        assertEquals("http.client.POST", clientData.getName());
+        assertEquals("step.call", stepData.getName());
+        assertEquals("mcp.request", serverData.getName());
+
+        // Verify parent-child: client → step → server
+        assertEquals(stepData.getSpanId(), clientData.getParentSpanId());
+        assertEquals(serverData.getSpanId(), stepData.getParentSpanId());
+
+        // All share the same trace
+        assertEquals(serverData.getTraceId(), stepData.getTraceId());
+        assertEquals(serverData.getTraceId(), clientData.getTraceId());
+    }
+}


### PR DESCRIPTION
## Related Issue

Closes #14, #332

---

## What does this PR do?

Adds Phase 1 distributed tracing to the Naftiko engine using OpenTelemetry, with the SDK kept fully optional for library embedding scenarios.

**Key changes:**

- **TelemetryBootstrap** — singleton bootstrap with `Class.forName` guard: autoconfigures when the SDK is on the classpath, falls back to zero-cost no-ops when absent. Supports embedder-provided `OpenTelemetry` instances via `init(OpenTelemetry)`.
- **Server spans** — MCP (`ToolHandler`), REST (`ResourceRestlet`), and Skill (`SkillServerResource`) adapters produce `SERVER` spans with `naftiko.*` attributes (adapter type, operation ID, HTTP method).
- **W3C trace context propagation** — `RestletHeaderGetter` / `RestletHeaderSetter` extract and inject `traceparent` headers on inbound and outbound Restlet requests.
- **Span hierarchy** — aggregate function spans (`startAggregateFunctionSpan`) and orchestration step spans (`startStepCallSpan`, `startStepLookupSpan`) nest under the server span. Client spans (`startClientSpan`) wrap outbound HTTP calls.
- **Optional SDK** — `opentelemetry-sdk`, `-sdk-extension-autoconfigure`, `-exporter-otlp`, and `-logback-appender-1.0` are all `<optional>true</optional>` in `pom.xml`. Only `opentelemetry-api` is required.
- **Blueprint** — updated `opentelemetry-observability.md` to reflect the optional mode, dependency changes, and acceptance criteria.

---

## Tests

**Unit tests (4 classes, 32 tests):**
- `TelemetryBootstrapTest` — init paths, span factories, hierarchy, error recording, null safety
- `RestletHeaderGetterTest` — header extraction, null handling, keys enumeration
- `RestletHeaderSetterTest` — header injection, null handling
- `ContextPropagationTest` — W3C traceparent round-trip (extract → inject → full cycle)

**Integration tests (3 classes, 9 tests):**
- `ObservabilityMcpIntegrationTest` — MCP server span, aggregate span hierarchy, error recording
- `ObservabilityRestIntegrationTest` — REST server span attributes, traceparent extraction, not-found span
- `ObservabilitySkillIntegrationTest` — Skill server span, traceparent extraction (live Jetty server)

All 562 tests pass.

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Claude Opus 4.6
tool: VS Code Chat
confidence: high
source_event: user request for OTel observability
discovery_method: code_review
review_focus: src/main/java/io/naftiko/engine/telemetry/, SkillServerResource.java (handle() vs doHandle() fix)
```