### PR TITLE
feat: add Swagger 2.0 auto-conversion support for OAS import

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Each capability is a coarse piece of domain that consumes existing HTTP-based AP
 | Domain-Driven Aggregates | Define reusable domain functions once, expose via multiple adapters — inspired by **DDD** Aggregate pattern |
 | Server Authentication | Secure exposed endpoints with **Bearer**, **API Key**, **Basic**, **Digest**, or **OAuth 2.1** authentication out of the box |
 | AI Native | Designed for Context Engineering and Agent Orchestration, making capabilities directly consumable by AI agents |
-| OpenAPI Interoperability | Import **OAS 3.0/3.1** into consumes adapters, export REST adapters as **OpenAPI** documents |
+| OpenAPI Interoperability | Import **Swagger 2.0**, **OAS 3.0/3.1** into consumes adapters, export REST adapters as **OpenAPI** documents |
 | Docker Native | Ships as a ready-to-run **Docker** container |
 | Extensible | Open-source core extensible with new protocols and adapters |
 

--- a/src/main/java/io/naftiko/cli/ImportOpenApiCommand.java
+++ b/src/main/java/io/naftiko/cli/ImportOpenApiCommand.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.parser.OpenAPIV3Parser;
+import io.swagger.parser.OpenAPIParser;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
 import io.naftiko.spec.NaftikoSpec;
 import io.naftiko.spec.consumes.HttpClientSpec;
@@ -55,8 +55,8 @@ public class ImportOpenApiCommand implements Callable<Integer> {
     @Override
     public Integer call() {
         try {
-            // Parse the OpenAPI document
-            SwaggerParseResult parseResult = new OpenAPIV3Parser().readLocation(source, null, null);
+            // Parse the OpenAPI document (supports Swagger 2.0 and OAS 3.x)
+            SwaggerParseResult parseResult = new OpenAPIParser().readLocation(source, null, null);
 
             if (parseResult.getOpenAPI() == null) {
                 System.err.println("Error: Failed to parse OpenAPI specification from: " + source);

--- a/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/reflect-config.json
@@ -121,6 +121,11 @@
     "allDeclaredMethods": true
   },
   {
+    "name": "io.swagger.parser.OpenAPIParser",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true
+  },
+  {
     "name": "io.swagger.v3.parser.core.extensions.SwaggerParserExtension",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true

--- a/src/main/resources/blueprints/openapi-interoperability.md
+++ b/src/main/resources/blueprints/openapi-interoperability.md
@@ -662,13 +662,13 @@ import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.media.Schema;
-import io.swagger.v3.parser.OpenAPIV3Parser;
+import io.swagger.parser.OpenAPIParser;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
 
 class OasImportConverter {
 
     OasImportResult convert(String source) {
-        SwaggerParseResult parseResult = new OpenAPIV3Parser().readLocation(source, null, null);
+        SwaggerParseResult parseResult = new OpenAPIParser().readLocation(source, null, null);
         OpenAPI openApi = parseResult.getOpenAPI();
         List<String> warnings = new ArrayList<>(parseResult.getMessages());
 

--- a/src/main/resources/wiki/Guide-‐-Use-Cases.md
+++ b/src/main/resources/wiki/Guide-‐-Use-Cases.md
@@ -217,12 +217,13 @@ How Naftiko achieves this technically:
 Bridge existing OpenAPI ecosystems with Naftiko capabilities: import OAS documents to bootstrap consumption adapters, and export REST adapters as standard OpenAPI specifications.
 
 How Naftiko achieves this technically:
-- Import an OpenAPI 3.0 or 3.1 document with `naftiko import openapi`, generating a ready-to-use `consumes` HTTP adapter with authentication, operations, input parameters, and output parameters pre-filled.
+- Import an OpenAPI 3.0 or 3.1 document (or a Swagger 2.0 document, which is auto-converted) with `naftiko import openapi`, generating a ready-to-use `consumes` HTTP adapter with authentication, operations, input parameters, and output parameters pre-filled.
 - Export a REST `exposes` adapter with `naftiko export openapi`, producing a standards-compliant OAS document that can be shared with API gateways, developer portals, and documentation tools.
 - Use `--adapter <namespace>` to target a specific REST adapter when the capability exposes more than one.
 
 #### Key features
 - [x] OpenAPI import into Naftiko `consumes` adapter
+  - [x] Swagger 2.0 support (auto-converted to OAS 3.0)
   - [x] OAS 3.0 and 3.1 support
   - [x] Authentication mapping (bearer, basic, API key, digest)
   - [x] Automatic namespace derivation from API title

--- a/src/main/resources/wiki/Home.md
+++ b/src/main/resources/wiki/Home.md
@@ -14,7 +14,7 @@ Each capability is a coarse piece of domain that consumes existing HTTP-based AP
 | Domain-Driven Aggregates | Define reusable domain functions once, expose via multiple adapters — inspired by **DDD** Aggregate pattern |
 | Server Authentication | Secure exposed endpoints with **Bearer**, **API Key**, **Basic**, **Digest**, or **OAuth 2.1** authentication out of the box |
 | AI Native | Designed for Context Engineering and Agent Orchestration, making capabilities directly consumable by AI agents |
-| OpenAPI Interoperability | Import **OAS 3.0/3.1** into consumes adapters, export REST adapters as **OpenAPI** documents |
+| OpenAPI Interoperability | Import **Swagger 2.0**, **OAS 3.0/3.1** into consumes adapters, export REST adapters as **OpenAPI** documents |
 | Docker Native | Ships as a ready-to-run **Docker** container |
 | Extensible | Open-source core extensible with new protocols and adapters |
 

--- a/src/test/java/io/naftiko/cli/ImportOpenApiCommandTest.java
+++ b/src/test/java/io/naftiko/cli/ImportOpenApiCommandTest.java
@@ -122,4 +122,139 @@ public class ImportOpenApiCommandTest {
         assertTrue(content.stripLeading().startsWith("{"), "Output should be valid JSON");
         assertTrue(content.contains("\"petstore\""));
     }
+
+    @Test
+    void importShouldAutoConvertSwagger20ToNaftikoConsumes() throws Exception {
+        Path oasFile = tempDir.resolve("petstore-v2.yaml");
+        Files.writeString(oasFile, """
+                swagger: "2.0"
+                info:
+                  title: "Petstore"
+                  version: "1.0.0"
+                host: "petstore.swagger.io"
+                basePath: "/v1"
+                schemes:
+                  - "https"
+                paths:
+                  /pets:
+                    get:
+                      operationId: listPets
+                      summary: List all pets
+                      parameters:
+                        - name: limit
+                          in: query
+                          required: false
+                          type: integer
+                      produces:
+                        - application/json
+                      responses:
+                        "200":
+                          description: A list of pets
+                          schema:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                id:
+                                  type: integer
+                                name:
+                                  type: string
+                """);
+
+        Path output = tempDir.resolve("output.yml");
+
+        CommandLine cmd = new CommandLine(new Cli());
+        int exitCode = cmd.execute("import", "openapi", oasFile.toString(),
+                "-o", output.toString());
+
+        assertEquals(0, exitCode);
+        assertTrue(Files.exists(output));
+        String content = Files.readString(output);
+        assertTrue(content.contains("petstore"), "Namespace should be derived from Swagger 2.0 title");
+        assertTrue(content.contains("list-pets"), "Operation should be converted from Swagger 2.0");
+    }
+
+    @Test
+    void importShouldDeriveBaseUriFromSwagger20HostAndBasePath() throws Exception {
+        Path oasFile = tempDir.resolve("v2-api.yaml");
+        Files.writeString(oasFile, """
+                swagger: "2.0"
+                info:
+                  title: "My Legacy API"
+                  version: "2.0.0"
+                host: "api.legacy.io"
+                basePath: "/v2"
+                schemes:
+                  - "https"
+                paths:
+                  /users:
+                    get:
+                      operationId: listUsers
+                      summary: List users
+                      responses:
+                        "200":
+                          description: OK
+                """);
+
+        Path output = tempDir.resolve("legacy.yml");
+
+        CommandLine cmd = new CommandLine(new Cli());
+        int exitCode = cmd.execute("import", "openapi", oasFile.toString(),
+                "-o", output.toString());
+
+        assertEquals(0, exitCode);
+        String content = Files.readString(output);
+        assertTrue(content.contains("https://api.legacy.io/v2"),
+                "Base URI should be derived from Swagger 2.0 host + basePath");
+        assertTrue(content.contains("my-legacy-api"), "Namespace should be kebab-cased title");
+    }
+
+    @Test
+    void importShouldConvertSwagger20RequestBodyParameters() throws Exception {
+        Path oasFile = tempDir.resolve("v2-body.yaml");
+        Files.writeString(oasFile, """
+                swagger: "2.0"
+                info:
+                  title: "Body Test API"
+                  version: "1.0.0"
+                host: "api.example.com"
+                basePath: "/"
+                schemes:
+                  - "https"
+                paths:
+                  /items:
+                    post:
+                      operationId: createItem
+                      summary: Create an item
+                      consumes:
+                        - application/json
+                      parameters:
+                        - name: body
+                          in: body
+                          required: true
+                          schema:
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                type: string
+                              description:
+                                type: string
+                      responses:
+                        "201":
+                          description: Created
+                """);
+
+        Path output = tempDir.resolve("body-test.yml");
+
+        CommandLine cmd = new CommandLine(new Cli());
+        int exitCode = cmd.execute("import", "openapi", oasFile.toString(),
+                "-o", output.toString());
+
+        assertEquals(0, exitCode);
+        String content = Files.readString(output);
+        assertTrue(content.contains("create-item"), "Operation name should be converted");
+        assertTrue(content.contains("name"), "Body parameter 'name' should be present");
+    }
 }

--- a/src/test/java/io/naftiko/spec/openapi/OasImportIntegrationTest.java
+++ b/src/test/java/io/naftiko/spec/openapi/OasImportIntegrationTest.java
@@ -20,6 +20,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.parser.OpenAPIV3Parser;
+import io.swagger.parser.OpenAPIParser;
+import io.swagger.v3.parser.core.models.SwaggerParseResult;
 import io.naftiko.spec.consumes.BearerAuthenticationSpec;
 import io.naftiko.spec.consumes.HttpClientOperationSpec;
 import io.naftiko.spec.consumes.HttpClientResourceSpec;
@@ -229,6 +231,70 @@ public class OasImportIntegrationTest {
         assertNotNull(tagParam, "Expected 'tag' body parameter");
         assertEquals("string", tagParam.getType(),
                 "OAS 3.1 type: [string, null] should resolve to string");
+    }
+
+    @Test
+    void importSwagger20ShouldAutoConvertAndProduceValidSpec() {
+        String path = getFixturePath("openapi/petstore-2.0.yaml");
+
+        // Verify readLocation also works (same method used by ImportOpenApiCommand)
+        SwaggerParseResult parseResult =
+                new OpenAPIParser().readLocation(path, null, null);
+        assertNotNull(parseResult.getOpenAPI(),
+                "readLocation should auto-convert Swagger 2.0; messages: "
+                        + parseResult.getMessages());
+
+        OpenAPI openApi = parseResult.getOpenAPI();
+
+        OasImportResult result = converter.convert(openApi);
+
+        HttpClientSpec httpClient = result.getHttpClient();
+        assertEquals("petstore", httpClient.getNamespace());
+        assertTrue(httpClient.getBaseUri().contains("petstore.swagger.io"),
+                "Base URI should be derived from Swagger 2.0 host + basePath");
+
+        assertFalse(httpClient.getResources().isEmpty(),
+                "Should have at least one resource");
+
+        HttpClientOperationSpec listPets = httpClient.getResources().stream()
+                .flatMap(r -> r.getOperations().stream())
+                .filter(o -> "list-pets".equals(o.getName()))
+                .findFirst().orElse(null);
+        assertNotNull(listPets, "listPets operation should be converted from Swagger 2.0");
+        assertEquals("GET", listPets.getMethod());
+    }
+
+    @Test
+    void importSwagger20ShouldConvertBaseUriFromHostAndBasePath() {
+        String path = getFixturePath("openapi/petstore-2.0.yaml");
+        OpenAPI openApi = new OpenAPIV3Parser().read(path);
+        assertNotNull(openApi);
+
+        OasImportResult result = converter.convert(openApi);
+
+        assertEquals("https://petstore.swagger.io/v1", result.getHttpClient().getBaseUri());
+    }
+
+    @Test
+    void importSwagger20ShouldConvertPathAndQueryParameters() {
+        String path = getFixturePath("openapi/petstore-2.0.yaml");
+        OpenAPI openApi = new OpenAPIV3Parser().read(path);
+        assertNotNull(openApi);
+
+        OasImportResult result = converter.convert(openApi);
+
+        HttpClientOperationSpec showPet = result.getHttpClient().getResources().stream()
+                .flatMap(r -> r.getOperations().stream())
+                .filter(o -> "show-pet-by-id".equals(o.getName()))
+                .findFirst().orElse(null);
+        assertNotNull(showPet, "showPetById should be converted from Swagger 2.0");
+
+        InputParameterSpec petIdParam = showPet.getInputParameters().stream()
+                .filter(p -> "petId".equals(p.getName()))
+                .findFirst().orElse(null);
+        assertNotNull(petIdParam, "petId path parameter should be present");
+        assertEquals("path", petIdParam.getIn());
+        assertTrue(petIdParam.isRequired());
     }
 
     private String getFixturePath(String resourcePath) {

--- a/src/test/resources/openapi/petstore-2.0.yaml
+++ b/src/test/resources/openapi/petstore-2.0.yaml
@@ -1,0 +1,98 @@
+swagger: "2.0"
+info:
+  title: "Petstore"
+  description: "A sample API that uses a petstore as an example"
+  version: "1.0.0"
+host: "petstore.swagger.io"
+basePath: "/v1"
+schemes:
+  - "https"
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      summary: List all pets
+      tags:
+        - Pets
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          type: integer
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: A list of pets
+          schema:
+            type: array
+            items:
+              type: object
+              properties:
+                id:
+                  type: integer
+                name:
+                  type: string
+                tag:
+                  type: string
+    post:
+      operationId: createPet
+      summary: Create a pet
+      tags:
+        - Pets
+      consumes:
+        - application/json
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            required:
+              - name
+            properties:
+              name:
+                type: string
+              tag:
+                type: string
+      responses:
+        "201":
+          description: Pet created
+  /pets/{petId}:
+    get:
+      operationId: showPetById
+      summary: Info for a specific pet
+      tags:
+        - Pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          type: integer
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: Expected response to a valid request
+          schema:
+            type: object
+            properties:
+              id:
+                type: integer
+              name:
+                type: string
+              tag:
+                type: string
+    delete:
+      operationId: deletePet
+      summary: Delete a pet
+      tags:
+        - Pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          type: integer
+      responses:
+        "204":
+          description: Pet deleted


### PR DESCRIPTION
## Related Issue

N/A — discovered during code review that Swagger 2.0 auto-conversion was not working despite the library supporting it.

---

## What does this PR do?

The `naftiko import openapi` command used `OpenAPIV3Parser.readLocation()` which only parses OAS 3.x documents. Swagger 2.0 input would fail with `"attribute openapi is missing"`.

This PR switches to `OpenAPIParser.readLocation()` — the high-level parser from `swagger-parser` that dispatches to both the v2-to-v3 converter and the v3 parser, enabling transparent Swagger 2.0 auto-conversion.

It also adds test coverage for the Swagger 2.0 import path and updates user-facing documentation to advertise the support.

**Changes:**
- **Production**: Replace `OpenAPIV3Parser` → `OpenAPIParser` in `ImportOpenApiCommand`
- **Native image**: Add `io.swagger.parser.OpenAPIParser` to `reflect-config.json`
- **Tests**: 3 CLI tests + 3 integration tests for Swagger 2.0 import
- **Fixture**: New `petstore-2.0.yaml` test fixture
- **Docs**: Update README, wiki Home, and Use Cases to mention Swagger 2.0 support

---

## Tests

- 3 new CLI tests in `ImportOpenApiCommandTest`: auto-conversion, base URI derivation from host+basePath, request body conversion
- 3 new integration tests in `OasImportIntegrationTest`: end-to-end import, base URI, path/query parameter conversion
- New `petstore-2.0.yaml` fixture mirroring the existing 3.0 petstore
- Full suite: 604 tests pass, 0 failures

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Claude Opus 4.6
tool: VS Code Chat
confidence: high
source_event: user question about Swagger 2.0 support
discovery_method: code_review
review_focus: ImportOpenApiCommand.java:59, OasImportIntegrationTest.java
```