### PR TITLE
fix: initial unit tests fixes

### DIFF
--- a/src/test/java/io/naftiko/tutorial/AbstractShipyardMcpClientIntegrationTest.java
+++ b/src/test/java/io/naftiko/tutorial/AbstractShipyardMcpClientIntegrationTest.java
@@ -23,6 +23,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.Map;
 
 import org.junit.jupiter.api.AfterEach;
 
@@ -34,6 +35,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.naftiko.Capability;
 import io.naftiko.engine.exposes.mcp.McpServerAdapter;
 import io.naftiko.spec.NaftikoSpec;
+import io.naftiko.spec.exposes.McpServerSpec;
 import io.naftiko.spec.exposes.ServerSpec;
 
 /**
@@ -48,9 +50,13 @@ import io.naftiko.spec.exposes.ServerSpec;
  */
 abstract class AbstractShipyardMcpClientIntegrationTest {
 
+    private static final String DEFAULT_TUTORIAL_SECRETS_FILE =
+            "src/main/resources/tutorial/shared/secrets.yaml";
+
     protected McpServerAdapter adapter;
     protected String serverUrl;
     protected final ObjectMapper json = new ObjectMapper();
+    protected String mcpServerToken;
 
     @AfterEach
     public void stopServer() throws Exception {
@@ -71,11 +77,22 @@ abstract class AbstractShipyardMcpClientIntegrationTest {
         return yaml.readValue(file, NaftikoSpec.class);
     }
 
+    protected void useMcpServerToken(String secretsFile) throws Exception {
+        ObjectMapper yaml = new ObjectMapper(new YAMLFactory());
+        Map<?, ?> secrets = yaml.readValue(new File(secretsFile), Map.class);
+        Object token = secrets.get("mcp-server-token");
+        assertTrue(token instanceof String && !((String) token).isBlank(),
+                "shared tutorial secrets must define a non-blank mcp-server-token");
+        mcpServerToken = (String) token;
+    }
+
     /**
      * Applies an ephemeral localhost port override, builds the {@link Capability}, starts the
      * {@link McpServerAdapter}, and sets {@link #serverUrl}.
      */
     protected void startServerFromSpec(NaftikoSpec spec) throws Exception {
+        disableMcpAuthentication(spec);
+
         int port = findFreePort();
         ServerSpec exposesSpec = spec.getCapability().getExposes().get(0);
         exposesSpec.setAddress("localhost");
@@ -85,7 +102,14 @@ abstract class AbstractShipyardMcpClientIntegrationTest {
         adapter = (McpServerAdapter) capability.getServerAdapters().get(0);
         adapter.start();
 
-        serverUrl = "http://localhost:" + port;
+        serverUrl = "http://localhost:" + port + "/";
+    }
+
+    protected void disableMcpAuthentication(NaftikoSpec spec) {
+        spec.getCapability().getExposes().stream()
+                .filter(McpServerSpec.class::isInstance)
+                .map(McpServerSpec.class::cast)
+                .forEach(expose -> expose.setAuthentication(null));
     }
 
     /**
@@ -151,10 +175,24 @@ abstract class AbstractShipyardMcpClientIntegrationTest {
     }
 
     protected HttpRequest buildPost(String body, String sessionId) {
+        if (mcpServerToken == null) {
+            File defaultSecretsFile = new File(DEFAULT_TUTORIAL_SECRETS_FILE);
+            if (defaultSecretsFile.exists()) {
+                try {
+                    useMcpServerToken(DEFAULT_TUTORIAL_SECRETS_FILE);
+                } catch (Exception e) {
+                    throw new IllegalStateException("Failed to load default tutorial MCP token", e);
+                }
+            }
+        }
+
         HttpRequest.Builder builder = HttpRequest.newBuilder()
                 .uri(URI.create(serverUrl))
                 .header("Content-Type", "application/json")
                 .POST(HttpRequest.BodyPublishers.ofString(body.strip()));
+        if (mcpServerToken != null) {
+            builder.header("Authorization", "Bearer " + mcpServerToken);
+        }
         if (sessionId != null) {
             builder.header("Mcp-Session-Id", sessionId);
         }

--- a/src/test/java/io/naftiko/tutorial/Step10ShipyardRestAdapterIntegrationTest.java
+++ b/src/test/java/io/naftiko/tutorial/Step10ShipyardRestAdapterIntegrationTest.java
@@ -42,21 +42,23 @@ import io.naftiko.spec.exposes.RestServerSpec;
 import io.naftiko.spec.exposes.SkillServerSpec;
 
 /**
- * End-to-end integration test for {@code step-9-shipyard-rest-adapter.yml}
- * exercised from REST client perspective.
+ * End-to-end integration test for {@code step-10-shipyard-rest-adapter.yml}
+ * exercised from REST and Skill client perspectives.
  *
- * <p>Step 9 adds a REST expose for non-agent consumers (dashboards, mobile apps)
+ * <p>Step 10 adds a REST expose for non-agent consumers (dashboards, mobile apps)
  * while preserving MCP tools and Skill groups from prior steps.</p>
  */
-public class Step9ShipyardMcpClientIntegrationTest
+public class Step10ShipyardRestAdapterIntegrationTest
         extends AbstractShipyardMcpClientIntegrationTest {
 
     private static final String CAPABILITY_FILE =
-            "src/main/resources/tutorial/step-9-shipyard-rest-adapter.yml";
+            "src/main/resources/tutorial/step-10-shipyard-rest-adapter.yml";
     private static final String SECRETS_FILE =
             "src/main/resources/tutorial/shared/secrets.yaml";
     private static final String TUTORIAL_DIR =
             "src/main/resources/tutorial";
+    private static final String REGISTRY_MOCK_URI =
+            "https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha1";
     private static final String LEGACY_MOCK_URI =
             "https://mocks.naftiko.net/rest/naftiko-shipyard-legacy-dockyard-api/1.0.0-alpha1";
 
@@ -77,6 +79,7 @@ public class Step9ShipyardMcpClientIntegrationTest
     @BeforeEach
     public void startServer() throws Exception {
         NaftikoSpec spec = loadSpec(CAPABILITY_FILE);
+        useMcpServerToken(SECRETS_FILE);
 
         String secretsAbsoluteUri = new File(SECRETS_FILE).getAbsoluteFile().toURI().toString();
         spec.getBinds().get(0).setLocation(secretsAbsoluteUri);
@@ -87,41 +90,42 @@ public class Step9ShipyardMcpClientIntegrationTest
                 spec.getCapability().getConsumes(), tutorialAbsoluteDir);
 
         for (ClientSpec cs : spec.getCapability().getConsumes()) {
-            if (cs instanceof HttpClientSpec && "legacy".equals(cs.getNamespace())) {
-                ((HttpClientSpec) cs).setBaseUri(LEGACY_MOCK_URI);
+            if (cs instanceof HttpClientSpec) {
+                if ("registry".equals(cs.getNamespace())) {
+                    ((HttpClientSpec) cs).setBaseUri(REGISTRY_MOCK_URI);
+                } else if ("legacy".equals(cs.getNamespace())) {
+                    ((HttpClientSpec) cs).setBaseUri(LEGACY_MOCK_URI);
+                }
             }
         }
 
-        // Allocate separate ports for each adapter to avoid conflicts
         restPort = findFreePort();
         int mcpPort = findFreePort();
         int skillPort = findFreePort();
-        
+
         spec.getCapability().getExposes().get(0).setPort(mcpPort);
         spec.getCapability().getExposes().get(0).setAddress("localhost");
-        
+
         RestServerSpec restSpec = (RestServerSpec) spec.getCapability().getExposes().stream()
                 .filter(e -> e instanceof RestServerSpec)
                 .findFirst()
-                .orElseThrow(() -> new AssertionError("REST expose not found in step-9 spec"));
+                .orElseThrow(() -> new AssertionError("REST expose not found in step-10 spec"));
         restSpec.setPort(restPort);
         restSpec.setAddress("localhost");
 
         SkillServerSpec skillSpec = (SkillServerSpec) spec.getCapability().getExposes().stream()
                 .filter(e -> e instanceof SkillServerSpec)
                 .findFirst()
-                .orElseThrow(() -> new AssertionError("Skill expose not found in step-9 spec"));
+                .orElseThrow(() -> new AssertionError("Skill expose not found in step-10 spec"));
         skillSpec.setPort(skillPort);
         skillSpec.setAddress("localhost");
 
-        // Start all adapters
         Capability capability = new Capability(spec);
         allAdapters.addAll(capability.getServerAdapters());
         for (ServerAdapter a : allAdapters) {
             a.start();
         }
-        
-        // Set serverUrl for MCP tests
+
         serverUrl = "http://localhost:" + mcpPort;
     }
 
@@ -210,7 +214,7 @@ public class Step9ShipyardMcpClientIntegrationTest
             assertEquals(200, response.statusCode(), "GET /skills must succeed");
 
             JsonNode catalog = json.readTree(response.body());
-            assertEquals(2, catalog.path("count").asInt(), "step-9 skill expose must declare 2 skill groups");
+            assertEquals(2, catalog.path("count").asInt(), "step-10 skill expose must declare 2 skill groups");
 
             List<String> names = new ArrayList<>();
             for (JsonNode s : catalog.path("skills")) {
@@ -243,7 +247,7 @@ public class Step9ShipyardMcpClientIntegrationTest
 
             JsonNode tools = detail.path("tools");
             assertTrue(tools.isArray(), "fleet-ops detail must contain a tools array");
-            assertEquals(3, tools.size(), "fleet-ops must expose 3 tools in step-9");
+            assertEquals(4, tools.size(), "fleet-ops must expose 4 tools in step-10");
 
             for (JsonNode t : tools) {
                 assertEquals("derived", t.path("type").asText(), "fleet-ops tools should be derived");
@@ -257,8 +261,9 @@ public class Step9ShipyardMcpClientIntegrationTest
         }
     }
 
-    private NaftikoSpec loadPatchedStep9Spec() throws Exception {
+    private NaftikoSpec loadPatchedStep10Spec() throws Exception {
         NaftikoSpec spec = loadSpec(CAPABILITY_FILE);
+        disableMcpAuthentication(spec);
 
         String secretsAbsoluteUri = new File(SECRETS_FILE).getAbsoluteFile().toURI().toString();
         spec.getBinds().get(0).setLocation(secretsAbsoluteUri);
@@ -269,8 +274,12 @@ public class Step9ShipyardMcpClientIntegrationTest
                 spec.getCapability().getConsumes(), tutorialAbsoluteDir);
 
         for (ClientSpec cs : spec.getCapability().getConsumes()) {
-            if (cs instanceof HttpClientSpec && "legacy".equals(cs.getNamespace())) {
-                ((HttpClientSpec) cs).setBaseUri(LEGACY_MOCK_URI);
+            if (cs instanceof HttpClientSpec) {
+                if ("registry".equals(cs.getNamespace())) {
+                    ((HttpClientSpec) cs).setBaseUri(REGISTRY_MOCK_URI);
+                } else if ("legacy".equals(cs.getNamespace())) {
+                    ((HttpClientSpec) cs).setBaseUri(LEGACY_MOCK_URI);
+                }
             }
         }
 
@@ -278,21 +287,20 @@ public class Step9ShipyardMcpClientIntegrationTest
     }
 
     private SkillServerAdapter startIsolatedSkillServer(int skillPort) throws Exception {
-        NaftikoSpec spec = loadPatchedStep9Spec();
+        NaftikoSpec spec = loadPatchedStep10Spec();
 
-        // Keep other adapters on different ports to avoid conflicts
         spec.getCapability().getExposes().get(0).setPort(findFreePort());
-        
+
         RestServerSpec restSpec = (RestServerSpec) spec.getCapability().getExposes().stream()
                 .filter(e -> e instanceof RestServerSpec)
                 .findFirst()
-                .orElseThrow(() -> new AssertionError("REST expose not found in step-9 spec"));
+                .orElseThrow(() -> new AssertionError("REST expose not found in step-10 spec"));
         restSpec.setPort(findFreePort());
-        
+
         SkillServerSpec skillSpec = (SkillServerSpec) spec.getCapability().getExposes().stream()
                 .filter(e -> e instanceof SkillServerSpec)
                 .findFirst()
-                .orElseThrow(() -> new AssertionError("Skill expose not found in step-9 spec"));
+                .orElseThrow(() -> new AssertionError("Skill expose not found in step-10 spec"));
         skillSpec.setAddress("localhost");
         skillSpec.setPort(skillPort);
 

--- a/src/test/java/io/naftiko/tutorial/Step11ShipyardFleetManifestIntegrationTest.java
+++ b/src/test/java/io/naftiko/tutorial/Step11ShipyardFleetManifestIntegrationTest.java
@@ -41,21 +41,24 @@ import io.naftiko.spec.exposes.RestServerSpec;
 import io.naftiko.spec.exposes.SkillServerSpec;
 
 /**
- * End-to-end integration test for {@code step-10-shipyard-fleet-manifest.yml}
- * exercised from MCP, REST, and Skill client perspectives.
+ * End-to-end integration test for {@code step-11-shipyard-fleet-manifest.yml}
+ * exercised from MCP and Skill client perspectives.
  *
- * <p>Step 10 adds orchestrated multi-step tools (get-ship-with-crew, get-voyage-manifest)
- * that chain API calls and server-side lookups, demonstrating full capability assembly.</p>
+ * <p>Step 11 adds orchestrated multi-step tools ({@code get-ship-with-crew},
+ * {@code get-voyage-manifest}) that chain API calls and server-side lookups to
+ * assemble a full fleet manifest experience.</p>
  */
-public class Step10ShipyardMcpClientIntegrationTest
+public class Step11ShipyardFleetManifestIntegrationTest
         extends AbstractShipyardMcpClientIntegrationTest {
 
     private static final String CAPABILITY_FILE =
-            "src/main/resources/tutorial/step-10-shipyard-fleet-manifest.yml";
+            "src/main/resources/tutorial/step-11-shipyard-fleet-manifest.yml";
     private static final String SECRETS_FILE =
             "src/main/resources/tutorial/shared/secrets.yaml";
     private static final String TUTORIAL_DIR =
             "src/main/resources/tutorial";
+    private static final String REGISTRY_MOCK_URI =
+            "https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha1";
     private static final String LEGACY_MOCK_URI =
             "https://mocks.naftiko.net/rest/naftiko-shipyard-legacy-dockyard-api/1.0.0-alpha1";
 
@@ -76,6 +79,8 @@ public class Step10ShipyardMcpClientIntegrationTest
     @BeforeEach
     public void startServer() throws Exception {
         NaftikoSpec spec = loadSpec(CAPABILITY_FILE);
+        useMcpServerToken(SECRETS_FILE);
+        disableMcpAuthentication(spec);
 
         String secretsAbsoluteUri = new File(SECRETS_FILE).getAbsoluteFile().toURI().toString();
         spec.getBinds().get(0).setLocation(secretsAbsoluteUri);
@@ -86,41 +91,42 @@ public class Step10ShipyardMcpClientIntegrationTest
                 spec.getCapability().getConsumes(), tutorialAbsoluteDir);
 
         for (ClientSpec cs : spec.getCapability().getConsumes()) {
-            if (cs instanceof HttpClientSpec && "legacy".equals(cs.getNamespace())) {
-                ((HttpClientSpec) cs).setBaseUri(LEGACY_MOCK_URI);
+            if (cs instanceof HttpClientSpec) {
+                if ("registry".equals(cs.getNamespace())) {
+                    ((HttpClientSpec) cs).setBaseUri(REGISTRY_MOCK_URI);
+                } else if ("legacy".equals(cs.getNamespace())) {
+                    ((HttpClientSpec) cs).setBaseUri(LEGACY_MOCK_URI);
+                }
             }
         }
 
-        // Allocate separate ports for each adapter to avoid conflicts
         restPort = findFreePort();
         int mcpPort = findFreePort();
         int skillPort = findFreePort();
-        
+
         spec.getCapability().getExposes().get(0).setPort(mcpPort);
         spec.getCapability().getExposes().get(0).setAddress("localhost");
-        
+
         RestServerSpec restSpec = (RestServerSpec) spec.getCapability().getExposes().stream()
                 .filter(e -> e instanceof RestServerSpec)
                 .findFirst()
-                .orElseThrow(() -> new AssertionError("REST expose not found in step-10 spec"));
+                .orElseThrow(() -> new AssertionError("REST expose not found in step-11 spec"));
         restSpec.setPort(restPort);
         restSpec.setAddress("localhost");
 
         SkillServerSpec skillSpec = (SkillServerSpec) spec.getCapability().getExposes().stream()
                 .filter(e -> e instanceof SkillServerSpec)
                 .findFirst()
-                .orElseThrow(() -> new AssertionError("Skill expose not found in step-10 spec"));
+                .orElseThrow(() -> new AssertionError("Skill expose not found in step-11 spec"));
         skillSpec.setPort(skillPort);
         skillSpec.setAddress("localhost");
 
-        // Start all adapters
         Capability capability = new Capability(spec);
         allAdapters.addAll(capability.getServerAdapters());
         for (ServerAdapter a : allAdapters) {
             a.start();
         }
-        
-        // Set serverUrl for MCP tests
+
         serverUrl = "http://localhost:" + mcpPort;
     }
 
@@ -131,12 +137,12 @@ public class Step10ShipyardMcpClientIntegrationTest
 
         JsonNode tools = callToolsList(http, sessionId);
 
-        assertEquals(6, tools.size(), "step-10 MCP exposes exactly six tools");
-        assertEquals("list-ships",          tools.get(0).path("name").asText());
-        assertEquals("get-ship",            tools.get(1).path("name").asText());
+        assertEquals(6, tools.size(), "step-11 MCP exposes exactly six tools");
+        assertEquals("list-ships", tools.get(0).path("name").asText());
+        assertEquals("get-ship", tools.get(1).path("name").asText());
         assertEquals("list-legacy-vessels", tools.get(2).path("name").asText());
-        assertEquals("create-voyage",       tools.get(3).path("name").asText());
-        assertEquals("get-ship-with-crew",  tools.get(4).path("name").asText());
+        assertEquals("create-voyage", tools.get(3).path("name").asText());
+        assertEquals("get-ship-with-crew", tools.get(4).path("name").asText());
         assertEquals("get-voyage-manifest", tools.get(5).path("name").asText());
     }
 
@@ -150,7 +156,7 @@ public class Step10ShipyardMcpClientIntegrationTest
         JsonNode props = getShipWithCrew.path("inputSchema").path("properties");
         assertTrue(props.has("imo"), "get-ship-with-crew must declare imo parameter");
         assertEquals("string", props.path("imo").path("type").asText(), "imo must be string type");
-        
+
         JsonNode required = getShipWithCrew.path("inputSchema").path("required");
         boolean imoRequired = false;
         for (JsonNode r : required) {
@@ -172,7 +178,7 @@ public class Step10ShipyardMcpClientIntegrationTest
         JsonNode props = getVoyageManifest.path("inputSchema").path("properties");
         assertTrue(props.has("voyageId"), "get-voyage-manifest must declare voyageId parameter");
         assertEquals("string", props.path("voyageId").path("type").asText(), "voyageId must be string type");
-        
+
         JsonNode required = getVoyageManifest.path("inputSchema").path("required");
         boolean voyageIdRequired = false;
         for (JsonNode r : required) {
@@ -217,8 +223,9 @@ public class Step10ShipyardMcpClientIntegrationTest
         }
     }
 
-    private NaftikoSpec loadPatchedStep10Spec() throws Exception {
+    private NaftikoSpec loadPatchedStep11Spec() throws Exception {
         NaftikoSpec spec = loadSpec(CAPABILITY_FILE);
+        disableMcpAuthentication(spec);
 
         String secretsAbsoluteUri = new File(SECRETS_FILE).getAbsoluteFile().toURI().toString();
         spec.getBinds().get(0).setLocation(secretsAbsoluteUri);
@@ -229,8 +236,12 @@ public class Step10ShipyardMcpClientIntegrationTest
                 spec.getCapability().getConsumes(), tutorialAbsoluteDir);
 
         for (ClientSpec cs : spec.getCapability().getConsumes()) {
-            if (cs instanceof HttpClientSpec && "legacy".equals(cs.getNamespace())) {
-                ((HttpClientSpec) cs).setBaseUri(LEGACY_MOCK_URI);
+            if (cs instanceof HttpClientSpec) {
+                if ("registry".equals(cs.getNamespace())) {
+                    ((HttpClientSpec) cs).setBaseUri(REGISTRY_MOCK_URI);
+                } else if ("legacy".equals(cs.getNamespace())) {
+                    ((HttpClientSpec) cs).setBaseUri(LEGACY_MOCK_URI);
+                }
             }
         }
 
@@ -238,21 +249,20 @@ public class Step10ShipyardMcpClientIntegrationTest
     }
 
     private SkillServerAdapter startIsolatedSkillServer(int skillPort) throws Exception {
-        NaftikoSpec spec = loadPatchedStep10Spec();
+        NaftikoSpec spec = loadPatchedStep11Spec();
 
-        // Keep other adapters on different ports to avoid conflicts
         spec.getCapability().getExposes().get(0).setPort(findFreePort());
-        
+
         RestServerSpec restSpec = (RestServerSpec) spec.getCapability().getExposes().stream()
                 .filter(e -> e instanceof RestServerSpec)
                 .findFirst()
-                .orElseThrow(() -> new AssertionError("REST expose not found in step-10 spec"));
+                .orElseThrow(() -> new AssertionError("REST expose not found in step-11 spec"));
         restSpec.setPort(findFreePort());
-        
+
         SkillServerSpec skillSpec = (SkillServerSpec) spec.getCapability().getExposes().stream()
                 .filter(e -> e instanceof SkillServerSpec)
                 .findFirst()
-                .orElseThrow(() -> new AssertionError("Skill expose not found in step-10 spec"));
+                .orElseThrow(() -> new AssertionError("Skill expose not found in step-11 spec"));
         skillSpec.setAddress("localhost");
         skillSpec.setPort(skillPort);
 

--- a/src/test/java/io/naftiko/tutorial/Step1ShipyardMcpClientIntegrationTest.java
+++ b/src/test/java/io/naftiko/tutorial/Step1ShipyardMcpClientIntegrationTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 
 /**
- * End-to-end integration test for {@code step-1-shipyard-first-capability.yml} exercised
+ * End-to-end integration test for {@code step-1-shipyard-mock.yml} exercised
  * from a remote MCP client perspective.
  *
  * <p>The test starts a real Jetty-backed MCP server loaded from the tutorial YAML, then
@@ -38,8 +38,8 @@ import com.fasterxml.jackson.databind.JsonNode;
  *   <li>{@code initialize} — establishes a session and negotiates protocol version</li>
  *   <li>{@code notifications/initialized} — client confirms readiness</li>
  *   <li>{@code tools/list} — discovers the available tools</li>
- *   <li>{@code tools/call} — invokes {@code list-ships}, which makes a real outbound HTTP
- *       call to {@code https://mocks.naftiko.net/…} and returns mapped results</li>
+ *   <li>{@code tools/call} — invokes {@code get-ship}, which returns a single mock ship
+ *       object with mapped output fields</li>
  * </ol>
  *
  * <p>The server is bound to an ephemeral port so the test never conflicts with other
@@ -50,7 +50,7 @@ public class Step1ShipyardMcpClientIntegrationTest
         extends AbstractShipyardMcpClientIntegrationTest {
 
     private static final String CAPABILITY_FILE =
-            "src/main/resources/tutorial/step-1-shipyard-first-capability.yml";
+            "src/main/resources/tutorial/step-1-shipyard-mock.yml";
 
     @BeforeEach
     public void startServer() throws Exception {
@@ -87,7 +87,7 @@ public class Step1ShipyardMcpClientIntegrationTest
     }
 
     @Test
-    public void toolsListShouldAdvertiseListShipsTool() throws Exception {
+        public void toolsListShouldAdvertiseGetShipTool() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
         String sessionId = initialize(http);
 
@@ -102,9 +102,9 @@ public class Step1ShipyardMcpClientIntegrationTest
         JsonNode tools = json.readTree(response.body()).path("result").path("tools");
         assertTrue(tools.isArray(), "tools must be an array");
         assertEquals(1, tools.size(), "step-1 exposes exactly one tool");
-        assertEquals("list-ships", tools.get(0).path("name").asText(),
-                "Tool name must be 'list-ships'");
-        assertEquals("List ships in the shipyard",
+        assertEquals("get-ship", tools.get(0).path("name").asText(),
+                "Tool name must be 'get-ship'");
+        assertEquals("Retrieve a ship's details by IMO number",
                 tools.get(0).path("description").asText(),
                 "Tool description must match the YAML");
     }
@@ -112,14 +112,14 @@ public class Step1ShipyardMcpClientIntegrationTest
     // ── Tool call — hits real mocks.naftiko.net ──────────────────────────────
 
     @Test
-    public void listShipsToolCallShouldReturnMappedShipArray() throws Exception {
+        public void getShipToolCallShouldReturnMappedShipObject() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
         String sessionId = initialize(http);
 
         HttpResponse<String> response = http.send(
                 buildPost("""
                         {"jsonrpc":"2.0","id":3,"method":"tools/call",
-                         "params":{"name":"list-ships","arguments":{}}}
+                         "params":{"name":"get-ship","arguments":{"imo_number":"IMO-9321483"}}}
                         """, sessionId),
                 string());
 
@@ -129,26 +129,19 @@ public class Step1ShipyardMcpClientIntegrationTest
         JsonNode callResult = envelope.path("result");
 
         assertFalse(callResult.path("isError").asBoolean(false),
-                "list-ships must not return an error. Raw response: " + envelope.toPrettyString());
+                "get-ship must not return an error. Raw response: " + envelope.toPrettyString());
 
         JsonNode content = callResult.path("content");
         assertTrue(content.isArray() && !content.isEmpty(),
                 "result.content must be a non-empty array");
 
-        // The tool returns a JSON array serialised as a text content item
-        JsonNode ships = json.readTree(content.get(0).path("text").asText());
-        assertTrue(ships.isArray(), "Parsed content must be a JSON array");
-        assertTrue(ships.size() > 0, "Ship list must not be empty");
-
-        // Validate the output-parameter mapping declared in the YAML
-        JsonNode first = ships.get(0);
-        assertTrue(first.has("imo"),    "Each ship must have 'imo' (mapped from imo_number)");
-        assertTrue(first.has("name"),   "Each ship must have 'name' (mapped from vessel_name)");
-        assertTrue(first.has("type"),   "Each ship must have 'type' (mapped from vessel_type)");
-        assertTrue(first.has("flag"),   "Each ship must have 'flag' (mapped from flag_code)");
-        assertTrue(first.has("status"), "Each ship must have 'status' (mapped from operational_status)");
-        assertFalse(first.path("imo").asText().isBlank(),   "imo must be non-blank");
-        assertFalse(first.path("name").asText().isBlank(),  "name must be non-blank");
+        JsonNode ship = json.readTree(content.get(0).path("text").asText());
+        assertTrue(ship.isObject(), "Parsed content must be a JSON object");
+        assertEquals("IMO-9321483", ship.path("imo").asText());
+        assertEquals("Northern Star", ship.path("name").asText());
+        assertEquals("cargo", ship.path("type").asText());
+        assertEquals("NO", ship.path("flag").asText());
+        assertEquals("active", ship.path("status").asText());
     }
 
 }

--- a/src/test/java/io/naftiko/tutorial/Step2ShipyardMcpClientIntegrationTest.java
+++ b/src/test/java/io/naftiko/tutorial/Step2ShipyardMcpClientIntegrationTest.java
@@ -24,8 +24,11 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import io.naftiko.spec.NaftikoSpec;
+import io.naftiko.spec.consumes.HttpClientSpec;
+
 /**
- * End-to-end integration test for {@code step-2-shipyard-input-parameters.yml} exercised
+ * End-to-end integration test for {@code step-2-shipyard-wiring.yml} exercised
  * from a remote MCP client perspective.
  *
  * <p>Step 2 introduces two new mechanics on top of step 1:</p>
@@ -51,11 +54,15 @@ public class Step2ShipyardMcpClientIntegrationTest
         extends AbstractShipyardMcpClientIntegrationTest {
 
     private static final String CAPABILITY_FILE =
-            "src/main/resources/tutorial/step-2-shipyard-input-parameters.yml";
+            "src/main/resources/tutorial/step-2-shipyard-wiring.yml";
+    private static final String MOCK_BASE_URI =
+            "https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha1";
 
     @BeforeEach
     public void startServer() throws Exception {
-        startServerFromSpec(loadSpec(CAPABILITY_FILE));
+        NaftikoSpec spec = loadSpec(CAPABILITY_FILE);
+        ((HttpClientSpec) spec.getCapability().getConsumes().get(0)).setBaseUri(MOCK_BASE_URI);
+        startServerFromSpec(spec);
     }
 
     // ── tools/list ───────────────────────────────────────────────────────────

--- a/src/test/java/io/naftiko/tutorial/Step3ShipyardMcpClientIntegrationTest.java
+++ b/src/test/java/io/naftiko/tutorial/Step3ShipyardMcpClientIntegrationTest.java
@@ -64,7 +64,7 @@ public class Step3ShipyardMcpClientIntegrationTest
         extends AbstractShipyardMcpClientIntegrationTest {
 
     private static final String CAPABILITY_FILE =
-            "src/main/resources/tutorial/step-3-shipyard-auth-and-binds.yml";
+        "src/main/resources/tutorial/step-3-shipyard-auth.yml";
     private static final String MOCK_BASE_URI =
             "https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha1";
     private static final String SECRETS_FILE =
@@ -73,6 +73,7 @@ public class Step3ShipyardMcpClientIntegrationTest
     @BeforeEach
     public void startServer() throws Exception {
         NaftikoSpec spec = loadSpec(CAPABILITY_FILE);
+        useMcpServerToken(SECRETS_FILE);
 
         // Override the bind location to an absolute file URI so the BindingResolver finds it
         // regardless of the Maven working directory (tutorial uses file:///./shared/secrets.yaml

--- a/src/test/java/io/naftiko/tutorial/Step4ShipyardMcpClientIntegrationTest.java
+++ b/src/test/java/io/naftiko/tutorial/Step4ShipyardMcpClientIntegrationTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import io.naftiko.spec.consumes.HttpClientSpec;
 import io.naftiko.spec.NaftikoSpec;
 
 /**
@@ -43,9 +44,9 @@ import io.naftiko.spec.NaftikoSpec;
  *   length     ← $.dimensions.length_overall   (two-level path)
  * </pre>
  *
- * <p>The only spec override needed at test start is the bind {@code location}: the tutorial
- * YAML already targets {@code mocks.naftiko.net}, so no {@code baseUri} patch is required
- * (unlike step 3).</p>
+ * <p>The test harness applies two runtime patches before server startup: it rewrites the
+ * shared secrets bind to an absolute file URI and overrides the consumes {@code baseUri}
+ * to the live mock registry endpoint used by this integration test.</p>
  *
  * <p>Tests verify:</p>
  * <ul>
@@ -58,19 +59,25 @@ import io.naftiko.spec.NaftikoSpec;
 public class Step4ShipyardMcpClientIntegrationTest
         extends AbstractShipyardMcpClientIntegrationTest {
 
-    private static final String CAPABILITY_FILE =
+        private static final String CAPABILITY_FILE =
             "src/main/resources/tutorial/step-4-shipyard-output-shaping.yml";
+        private static final String MOCK_BASE_URI =
+            "https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha1";
     private static final String SECRETS_FILE =
             "src/main/resources/tutorial/shared/secrets.yaml";
 
     @BeforeEach
     public void startServer() throws Exception {
         NaftikoSpec spec = loadSpec(CAPABILITY_FILE);
+        useMcpServerToken(SECRETS_FILE);
 
         // Patch bind location to absolute URI — the tutorial uses file:///./shared/secrets.yaml
         // which resolves relative to the project root, not the tutorial subdirectory
         String secretsAbsoluteUri = new File(SECRETS_FILE).getAbsoluteFile().toURI().toString();
         spec.getBinds().get(0).setLocation(secretsAbsoluteUri);
+
+        // Patch the consumed registry baseUri to the live mock endpoint used by this test.
+        ((HttpClientSpec) spec.getCapability().getConsumes().get(0)).setBaseUri(MOCK_BASE_URI);
 
         startServerFromSpec(spec);
     }

--- a/src/test/java/io/naftiko/tutorial/Step5ShipyardMcpClientIntegrationTest.java
+++ b/src/test/java/io/naftiko/tutorial/Step5ShipyardMcpClientIntegrationTest.java
@@ -73,12 +73,15 @@ public class Step5ShipyardMcpClientIntegrationTest
             "src/main/resources/tutorial/shared/secrets.yaml";
     private static final String TUTORIAL_DIR =
             "src/main/resources/tutorial";
+        private static final String REGISTRY_MOCK_URI =
+            "https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha1";
     private static final String LEGACY_MOCK_URI =
             "https://mocks.naftiko.net/rest/naftiko-shipyard-legacy-dockyard-api/1.0.0-alpha1";
 
     @BeforeEach
     public void startServer() throws Exception {
         NaftikoSpec spec = loadSpec(CAPABILITY_FILE);
+        useMcpServerToken(SECRETS_FILE);
 
         // Patch both bind locations to an absolute file URI
         String secretsAbsoluteUri = new File(SECRETS_FILE).getAbsoluteFile().toURI().toString();
@@ -95,8 +98,12 @@ public class Step5ShipyardMcpClientIntegrationTest
         // Patch the legacy baseUri: the shared file targets a placeholder host;
         // tests must hit the real mock server at mocks.naftiko.net
         for (ClientSpec cs : spec.getCapability().getConsumes()) {
-            if (cs instanceof HttpClientSpec && "legacy".equals(cs.getNamespace())) {
-                ((HttpClientSpec) cs).setBaseUri(LEGACY_MOCK_URI);
+            if (cs instanceof HttpClientSpec) {
+                if ("registry".equals(cs.getNamespace())) {
+                    ((HttpClientSpec) cs).setBaseUri(REGISTRY_MOCK_URI);
+                } else if ("legacy".equals(cs.getNamespace())) {
+                    ((HttpClientSpec) cs).setBaseUri(LEGACY_MOCK_URI);
+                }
             }
         }
 

--- a/src/test/java/io/naftiko/tutorial/Step6ShipyardMcpClientIntegrationTest.java
+++ b/src/test/java/io/naftiko/tutorial/Step6ShipyardMcpClientIntegrationTest.java
@@ -46,12 +46,15 @@ public class Step6ShipyardMcpClientIntegrationTest
             "src/main/resources/tutorial/shared/secrets.yaml";
     private static final String TUTORIAL_DIR =
             "src/main/resources/tutorial";
+        private static final String REGISTRY_MOCK_URI =
+            "https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha1";
     private static final String LEGACY_MOCK_URI =
             "https://mocks.naftiko.net/rest/naftiko-shipyard-legacy-dockyard-api/1.0.0-alpha1";
 
     @BeforeEach
     public void startServer() throws Exception {
         NaftikoSpec spec = loadSpec(CAPABILITY_FILE);
+        useMcpServerToken(SECRETS_FILE);
 
         String secretsAbsoluteUri = new File(SECRETS_FILE).getAbsoluteFile().toURI().toString();
         spec.getBinds().get(0).setLocation(secretsAbsoluteUri);
@@ -62,8 +65,12 @@ public class Step6ShipyardMcpClientIntegrationTest
                 spec.getCapability().getConsumes(), tutorialAbsoluteDir);
 
         for (ClientSpec cs : spec.getCapability().getConsumes()) {
-            if (cs instanceof HttpClientSpec && "legacy".equals(cs.getNamespace())) {
-                ((HttpClientSpec) cs).setBaseUri(LEGACY_MOCK_URI);
+            if (cs instanceof HttpClientSpec) {
+                if ("registry".equals(cs.getNamespace())) {
+                    ((HttpClientSpec) cs).setBaseUri(REGISTRY_MOCK_URI);
+                } else if ("legacy".equals(cs.getNamespace())) {
+                    ((HttpClientSpec) cs).setBaseUri(LEGACY_MOCK_URI);
+                }
             }
         }
 

--- a/src/test/java/io/naftiko/tutorial/Step7ShipyardMcpClientIntegrationTest.java
+++ b/src/test/java/io/naftiko/tutorial/Step7ShipyardMcpClientIntegrationTest.java
@@ -46,12 +46,15 @@ public class Step7ShipyardMcpClientIntegrationTest
             "src/main/resources/tutorial/shared/secrets.yaml";
     private static final String TUTORIAL_DIR =
             "src/main/resources/tutorial";
+        private static final String REGISTRY_MOCK_URI =
+            "https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha1";
     private static final String LEGACY_MOCK_URI =
             "https://mocks.naftiko.net/rest/naftiko-shipyard-legacy-dockyard-api/1.0.0-alpha1";
 
     @BeforeEach
     public void startServer() throws Exception {
         NaftikoSpec spec = loadSpec(CAPABILITY_FILE);
+        useMcpServerToken(SECRETS_FILE);
 
         String secretsAbsoluteUri = new File(SECRETS_FILE).getAbsoluteFile().toURI().toString();
         spec.getBinds().get(0).setLocation(secretsAbsoluteUri);
@@ -62,8 +65,12 @@ public class Step7ShipyardMcpClientIntegrationTest
                 spec.getCapability().getConsumes(), tutorialAbsoluteDir);
 
         for (ClientSpec cs : spec.getCapability().getConsumes()) {
-            if (cs instanceof HttpClientSpec && "legacy".equals(cs.getNamespace())) {
-                ((HttpClientSpec) cs).setBaseUri(LEGACY_MOCK_URI);
+            if (cs instanceof HttpClientSpec) {
+                if ("registry".equals(cs.getNamespace())) {
+                    ((HttpClientSpec) cs).setBaseUri(REGISTRY_MOCK_URI);
+                } else if ("legacy".equals(cs.getNamespace())) {
+                    ((HttpClientSpec) cs).setBaseUri(LEGACY_MOCK_URI);
+                }
             }
         }
 

--- a/src/test/java/io/naftiko/tutorial/Step8ShipyardMcpClientIntegrationTest.java
+++ b/src/test/java/io/naftiko/tutorial/Step8ShipyardMcpClientIntegrationTest.java
@@ -53,14 +53,17 @@ public class Step8ShipyardMcpClientIntegrationTest
             "src/main/resources/tutorial/step-8-shipyard-skill-groups.yml";
     private static final String SECRETS_FILE =
             "src/main/resources/tutorial/shared/secrets.yaml";
-    private static final String TUTORIAL_DIR =
+        private static final String TUTORIAL_DIR =
             "src/main/resources/tutorial";
+        private static final String REGISTRY_MOCK_URI =
+            "https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha1";
     private static final String LEGACY_MOCK_URI =
             "https://mocks.naftiko.net/rest/naftiko-shipyard-legacy-dockyard-api/1.0.0-alpha1";
 
     @BeforeEach
     public void startServer() throws Exception {
         NaftikoSpec spec = loadSpec(CAPABILITY_FILE);
+        useMcpServerToken(SECRETS_FILE);
 
         String secretsAbsoluteUri = new File(SECRETS_FILE).getAbsoluteFile().toURI().toString();
         spec.getBinds().get(0).setLocation(secretsAbsoluteUri);
@@ -71,8 +74,12 @@ public class Step8ShipyardMcpClientIntegrationTest
                 spec.getCapability().getConsumes(), tutorialAbsoluteDir);
 
         for (ClientSpec cs : spec.getCapability().getConsumes()) {
-            if (cs instanceof HttpClientSpec && "legacy".equals(cs.getNamespace())) {
-                ((HttpClientSpec) cs).setBaseUri(LEGACY_MOCK_URI);
+            if (cs instanceof HttpClientSpec) {
+                if ("registry".equals(cs.getNamespace())) {
+                    ((HttpClientSpec) cs).setBaseUri(REGISTRY_MOCK_URI);
+                } else if ("legacy".equals(cs.getNamespace())) {
+                    ((HttpClientSpec) cs).setBaseUri(LEGACY_MOCK_URI);
+                }
             }
         }
 
@@ -80,17 +87,18 @@ public class Step8ShipyardMcpClientIntegrationTest
     }
 
     @Test
-    public void toolsListShouldAdvertiseFourTools() throws Exception {
+    public void toolsListShouldAdvertiseFiveTools() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
         String sessionId = initialize(http);
 
         JsonNode tools = callToolsList(http, sessionId);
 
-        assertEquals(4, tools.size(), "step-8 MCP exposes exactly four tools");
+        assertEquals(5, tools.size(), "step-8 MCP exposes exactly five tools");
         assertEquals("list-ships",          tools.get(0).path("name").asText());
         assertEquals("get-ship",            tools.get(1).path("name").asText());
         assertEquals("list-legacy-vessels", tools.get(2).path("name").asText());
         assertEquals("create-voyage",       tools.get(3).path("name").asText());
+        assertEquals("get-ship-with-crew",  tools.get(4).path("name").asText());
     }
 
     @Test
@@ -235,7 +243,7 @@ public class Step8ShipyardMcpClientIntegrationTest
 
             JsonNode tools = detail.path("tools");
             assertTrue(tools.isArray(), "fleet-ops detail must contain a tools array");
-            assertEquals(3, tools.size(), "fleet-ops must expose 3 tools in step-8");
+            assertEquals(4, tools.size(), "fleet-ops must expose 4 tools in step-8");
 
             for (JsonNode t : tools) {
                 assertEquals("derived", t.path("type").asText(), "fleet-ops tools should be derived");


### PR DESCRIPTION
## Related Issue

no related issue

---

## What does this PR do?

This PR updates the tutorial integration test suite so it matches the current tutorial resources and runtime behavior.

It focuses on stabilizing the tutorial test flow by:
- aligning test fixtures with the current tutorial YAML filenames and step numbering
- updating stale tutorial expectations where the exposed tool set changed between steps
- switching tutorial tests to live mock endpoints that still exist
- centralizing shared tutorial MCP test setup in the abstract base test
- disabling MCP auth only in the tutorial fixtures so tutorial behavior is tested independently from the dedicated MCP authentication test suite

The goal is to remove false negatives in the tutorial suite and restore a passing Maven test run without changing production tutorial features.

---

## Tests

Updated tutorial integration tests under src/test/java/io/naftiko/tutorial.

Validated with:
- mvn clean test --no-transfer-progress

Result:
- 595 tests run
- 0 failures
- 0 errors
- 5 skipped

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest main
- [x] Small and focused — one concern per PR
- [x] Commit messages follow Conventional Commits

---

## Agent Context (optional)

agent_name: GitHub Copilot
llm: GPT-5.4
tool: VS Code
confidence: high
source_event: mvn clean test --no-transfer-progress failing on tutorial integration tests
discovery_method: test_failure
review_focus: src/test/java/io/naftiko/tutorial