### PR TITLE
feat: surface parse warnings on successful imports and align Swagger 2.0 test parsing path

### DIFF
--- a/src/main/java/io/naftiko/cli/ImportOpenApiCommand.java
+++ b/src/main/java/io/naftiko/cli/ImportOpenApiCommand.java
@@ -81,7 +81,14 @@ public class ImportOpenApiCommand implements Callable<Integer> {
                 httpClient.setNamespace(namespace);
             }
 
-            // Print warnings to stderr
+            // Print parse warnings (e.g. Swagger 2.0 -> OAS 3 conversion notes)
+            if (parseResult.getMessages() != null) {
+                for (String msg : parseResult.getMessages()) {
+                    System.err.println("Warning: " + msg);
+                }
+            }
+
+            // Print conversion warnings to stderr
             for (String warning : result.getWarnings()) {
                 System.err.println("Warning: " + warning);
             }

--- a/src/test/java/io/naftiko/spec/openapi/OasImportIntegrationTest.java
+++ b/src/test/java/io/naftiko/spec/openapi/OasImportIntegrationTest.java
@@ -267,10 +267,13 @@ public class OasImportIntegrationTest {
     @Test
     void importSwagger20ShouldConvertBaseUriFromHostAndBasePath() {
         String path = getFixturePath("openapi/petstore-2.0.yaml");
-        OpenAPI openApi = new OpenAPIV3Parser().read(path);
-        assertNotNull(openApi);
+        SwaggerParseResult parseResult =
+                new OpenAPIParser().readLocation(path, null, null);
+        assertNotNull(parseResult.getOpenAPI(),
+                "readLocation should auto-convert Swagger 2.0; messages: "
+                        + parseResult.getMessages());
 
-        OasImportResult result = converter.convert(openApi);
+        OasImportResult result = converter.convert(parseResult.getOpenAPI());
 
         assertEquals("https://petstore.swagger.io/v1", result.getHttpClient().getBaseUri());
     }
@@ -278,10 +281,13 @@ public class OasImportIntegrationTest {
     @Test
     void importSwagger20ShouldConvertPathAndQueryParameters() {
         String path = getFixturePath("openapi/petstore-2.0.yaml");
-        OpenAPI openApi = new OpenAPIV3Parser().read(path);
-        assertNotNull(openApi);
+        SwaggerParseResult parseResult =
+                new OpenAPIParser().readLocation(path, null, null);
+        assertNotNull(parseResult.getOpenAPI(),
+                "readLocation should auto-convert Swagger 2.0; messages: "
+                        + parseResult.getMessages());
 
-        OasImportResult result = converter.convert(openApi);
+        OasImportResult result = converter.convert(parseResult.getOpenAPI());
 
         HttpClientOperationSpec showPet = result.getHttpClient().getResources().stream()
                 .flatMap(r -> r.getOperations().stream())


### PR DESCRIPTION
## Related Issue

Follow-up to #336

---

## What does this PR do?

Two improvements to the OAS import feature:

1. **Surface parser warnings on successful imports** — `ImportOpenApiCommand` now prints `parseResult.getMessages()` as warnings even when parsing succeeds. Swagger 2.0 → OAS 3 auto-conversion can produce important messages (e.g. resolution warnings) that were previously silenced on success.

2. **Align Swagger 2.0 integration tests with CLI parsing path** — The two remaining Swagger 2.0 tests (`importSwagger20ShouldConvertBaseUriFromHostAndBasePath`, `importSwagger20ShouldConvertPathAndQueryParameters`) now use `OpenAPIParser.readLocation(...)` instead of `OpenAPIV3Parser.read(...)`, matching the actual parsing path used by `ImportOpenApiCommand`.

---

## Tests

- Updated `OasImportIntegrationTest`: two Swagger 2.0 tests switched to `OpenAPIParser.readLocation()` with assertions on `parseResult.getOpenAPI()` (including parse messages on failure).

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Claude Opus 4.6
tool: VS Code Chat
confidence: high
source_event: PR review feedback on #336
discovery_method: code_review
review_focus: ImportOpenApiCommand.java:58-75, OasImportIntegrationTest.java:267-310
```