### PR TITLE
fix: convert non-JSON responses before applying MCP output mappings

### DIFF
--- a/src/main/java/io/naftiko/engine/aggregates/AggregateFunction.java
+++ b/src/main/java/io/naftiko/engine/aggregates/AggregateFunction.java
@@ -161,8 +161,12 @@ public class AggregateFunction {
                 && found != null && found.clientResponse != null
                 && found.clientResponse.getEntity() != null) {
             String responseText = found.clientResponse.getEntity().getText();
+            String outputRawFormat = found.clientOperation != null
+                    ? found.clientOperation.getOutputRawFormat() : null;
+            String outputSchema = found.clientOperation != null
+                    ? found.clientOperation.getOutputSchema() : null;
             String mapped = stepExecutor.applyOutputMappings(responseText,
-                    spec.getOutputParameters());
+                    spec.getOutputParameters(), outputRawFormat, outputSchema);
             if (mapped != null) {
                 return new FunctionResult(found, mapped, null);
             }

--- a/src/main/java/io/naftiko/engine/exposes/OperationStepExecutor.java
+++ b/src/main/java/io/naftiko/engine/exposes/OperationStepExecutor.java
@@ -35,6 +35,7 @@ import io.naftiko.engine.consumes.http.HttpClientAdapter;
 import io.naftiko.engine.telemetry.RestletHeaderSetter;
 import io.naftiko.engine.telemetry.TelemetryBootstrap;
 import io.naftiko.engine.util.LookupExecutor;
+import io.naftiko.engine.util.Converter;
 import io.naftiko.engine.util.Resolver;
 import io.naftiko.engine.util.StepExecutionContext;
 import io.naftiko.spec.InputParameterSpec;
@@ -726,13 +727,32 @@ public class OperationStepExecutor {
      */
     public String applyOutputMappings(String responseText,
             List<OutputParameterSpec> outputParameters) throws IOException {
+        return applyOutputMappings(responseText, outputParameters, null, null);
+    }
+
+    /**
+     * Apply output parameter mappings, converting the response from the declared format first.
+     *
+     * <p>When {@code outputRawFormat} is non-null (e.g. {@code "xml"}), the response text
+     * is converted to a JSON tree via {@link Converter#convertToJson(String, String, String)}
+     * before mappings are applied. When {@code null}, the text is parsed as JSON directly.</p>
+     *
+     * @param responseText     the raw HTTP response body
+     * @param outputParameters the list of output parameter specs to try
+     * @param outputRawFormat  the declared format (may be {@code null} for JSON)
+     * @param outputSchema     the declared schema (used by HTML/Markdown selectors)
+     * @return the first mapped JSON string, or {@code null} if none matched
+     */
+    public String applyOutputMappings(String responseText,
+            List<OutputParameterSpec> outputParameters,
+            String outputRawFormat, String outputSchema) throws IOException {
         if (responseText == null || responseText.isEmpty()) {
             return null;
         }
         if (outputParameters == null || outputParameters.isEmpty()) {
             return null;
         }
-        JsonNode root = mapper.readTree(responseText);
+        JsonNode root = Converter.convertToJson(outputRawFormat, outputSchema, responseText);
         for (OutputParameterSpec outputParam : outputParameters) {
             JsonNode mapped = Resolver.resolveOutputMappings(outputParam, root, mapper);
             if (mapped != null && !(mapped instanceof NullNode)) {

--- a/src/main/java/io/naftiko/engine/exposes/mcp/ResourceHandler.java
+++ b/src/main/java/io/naftiko/engine/exposes/mcp/ResourceHandler.java
@@ -278,7 +278,12 @@ public class ResourceHandler {
             return "";
         }
 
-        String mapped = stepExecutor.applyOutputMappings(responseText, spec.getOutputParameters());
+        String outputRawFormat = found.clientOperation != null
+                ? found.clientOperation.getOutputRawFormat() : null;
+        String outputSchema = found.clientOperation != null
+                ? found.clientOperation.getOutputSchema() : null;
+        String mapped = stepExecutor.applyOutputMappings(responseText,
+                spec.getOutputParameters(), outputRawFormat, outputSchema);
         return mapped != null ? mapped : responseText;
     }
 

--- a/src/main/java/io/naftiko/engine/exposes/mcp/ToolHandler.java
+++ b/src/main/java/io/naftiko/engine/exposes/mcp/ToolHandler.java
@@ -263,8 +263,13 @@ public class ToolHandler {
         // Buffer entity text before any mapping to avoid double-read issues
         String responseText = found.clientResponse.getEntity().getText();
 
-        // Apply output parameter mappings if defined
-        String mapped = stepExecutor.applyOutputMappings(responseText, toolSpec.getOutputParameters());
+        // Apply output parameter mappings if defined, converting from the declared format
+        String outputRawFormat = found.clientOperation != null
+                ? found.clientOperation.getOutputRawFormat() : null;
+        String outputSchema = found.clientOperation != null
+                ? found.clientOperation.getOutputSchema() : null;
+        String mapped = stepExecutor.applyOutputMappings(responseText,
+                toolSpec.getOutputParameters(), outputRawFormat, outputSchema);
         if (mapped != null) {
             return new McpSchema.CallToolResult(List.of(new McpSchema.TextContent(mapped)),
                     isError, null, null);

--- a/src/main/java/io/naftiko/engine/util/ConversionFormat.java
+++ b/src/main/java/io/naftiko/engine/util/ConversionFormat.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.naftiko.engine.util;
+
+/**
+ * Centralized enum for the output raw formats declared in the Naftiko specification
+ * ({@code outputRawFormat} in {@code naftiko-schema.json}).
+ *
+ * <p>Labels are lowercase to match the JSON schema enum values. Use {@link #fromLabel(String)}
+ * for case-insensitive lookup from user-supplied strings.</p>
+ */
+public enum ConversionFormat {
+
+    JSON("json"),
+    XML("xml"),
+    YAML("yaml"),
+    CSV("csv"),
+    TSV("tsv"),
+    PSV("psv"),
+    HTML("html"),
+    MARKDOWN("markdown"),
+    PROTOBUF("protobuf"),
+    AVRO("avro");
+
+    public final String label;
+
+    ConversionFormat(String label) {
+        this.label = label;
+    }
+
+    /**
+     * Resolve a format string to a {@link ConversionFormat} constant (case-insensitive).
+     *
+     * @param format the raw format string (may be {@code null})
+     * @return the matching constant, or {@code null} if {@code format} is {@code null} or unknown
+     */
+    public static ConversionFormat fromLabel(String format) {
+        if (format == null) {
+            return null;
+        }
+        for (ConversionFormat f : values()) {
+            if (f.label.equalsIgnoreCase(format)) {
+                return f;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/io/naftiko/engine/util/Converter.java
+++ b/src/main/java/io/naftiko/engine/util/Converter.java
@@ -76,44 +76,41 @@ public class Converter {
     /** Convert various formats to JSON */
     public static JsonNode convertToJson(String format, String schema, Representation entity)
             throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
-        JsonNode root = null;
+        ConversionFormat fmt = ConversionFormat.fromLabel(format);
 
-        // Convert based on outputRawFormat
-        if ("XML".equalsIgnoreCase(format)) {
-            root = Converter.convertXmlToJson(entity.getReader());
-        } else if ("Protobuf".equalsIgnoreCase(format)) {
-            if (schema == null || schema.isEmpty()) {
-                throw new IOException(
-                        "Protobuf format requires outputSchema to be specified in operation specification");
-            }
-            root = Converter.convertProtobufToJson(entity.getStream(), schema);
-        } else if ("Avro".equalsIgnoreCase(format)) {
-            if (schema == null || schema.isEmpty()) {
-                throw new IOException(
-                        "Avro format requires outputSchema to be specified in operation specification");
-            }
-            root = Converter.convertAvroToJson(entity.getStream(), schema);
-        } else if ("YAML".equalsIgnoreCase(format)) {
-            // YAML is text-based; use the reader to parse to JsonNode
-            root = Converter.convertYamlToJson(entity.getReader());
-        } else if ("CSV".equalsIgnoreCase(format)) {
-            root = Converter.convertDelimitedToJson(entity.getReader(), ',');
-        } else if ("TSV".equalsIgnoreCase(format)) {
-            root = Converter.convertDelimitedToJson(entity.getReader(), '\t');
-        } else if ("PSV".equalsIgnoreCase(format)) {
-            root = Converter.convertDelimitedToJson(entity.getReader(), '|');
-        } else if ("HTML".equalsIgnoreCase(format)) {
-            root = Converter.convertHtmlToJson(entity.getReader(), schema);
-        } else if ("MARKDOWN".equalsIgnoreCase(format)) {
-            root = Converter.convertMarkdownToJson(entity.getReader(), schema);
-        } else if ("JSON".equalsIgnoreCase(format) || format == null) {
-            root = mapper.readTree(entity.getReader());
-        } else {
+        if (fmt == null && format != null) {
             throw new IOException("Unsupported \"" + format + "\" format specified");
         }
 
-        return root;
+        // null format defaults to JSON
+        if (fmt == null) {
+            fmt = ConversionFormat.JSON;
+        }
+
+        return switch (fmt) {
+            case XML -> Converter.convertXmlToJson(entity.getReader());
+            case PROTOBUF -> {
+                if (schema == null || schema.isEmpty()) {
+                    throw new IOException(
+                            "Protobuf format requires outputSchema to be specified in operation specification");
+                }
+                yield Converter.convertProtobufToJson(entity.getStream(), schema);
+            }
+            case AVRO -> {
+                if (schema == null || schema.isEmpty()) {
+                    throw new IOException(
+                            "Avro format requires outputSchema to be specified in operation specification");
+                }
+                yield Converter.convertAvroToJson(entity.getStream(), schema);
+            }
+            case YAML -> Converter.convertYamlToJson(entity.getReader());
+            case CSV -> Converter.convertDelimitedToJson(entity.getReader(), ',');
+            case TSV -> Converter.convertDelimitedToJson(entity.getReader(), '\t');
+            case PSV -> Converter.convertDelimitedToJson(entity.getReader(), '|');
+            case HTML -> Converter.convertHtmlToJson(entity.getReader(), schema);
+            case MARKDOWN -> Converter.convertMarkdownToJson(entity.getReader(), schema);
+            case JSON -> new ObjectMapper().readTree(entity.getReader());
+        };
     }
 
     /**
@@ -131,29 +128,30 @@ public class Converter {
      */
     public static JsonNode convertToJson(String format, String schema, String text)
             throws IOException {
-        if ("XML".equalsIgnoreCase(format)) {
-            return Converter.convertXmlToJson(new StringReader(text));
-        } else if ("YAML".equalsIgnoreCase(format)) {
-            return Converter.convertYamlToJson(new StringReader(text));
-        } else if ("CSV".equalsIgnoreCase(format)) {
-            return Converter.convertDelimitedToJson(new StringReader(text), ',');
-        } else if ("TSV".equalsIgnoreCase(format)) {
-            return Converter.convertDelimitedToJson(new StringReader(text), '\t');
-        } else if ("PSV".equalsIgnoreCase(format)) {
-            return Converter.convertDelimitedToJson(new StringReader(text), '|');
-        } else if ("HTML".equalsIgnoreCase(format)) {
-            return Converter.convertHtmlToJson(new StringReader(text), schema);
-        } else if ("MARKDOWN".equalsIgnoreCase(format)) {
-            return Converter.convertMarkdownToJson(new StringReader(text), schema);
-        } else if ("Protobuf".equalsIgnoreCase(format) || "Avro".equalsIgnoreCase(format)) {
-            throw new IOException(format
-                    + " format cannot be converted from a text string; "
-                    + "use the Representation-based overload instead");
-        } else if ("JSON".equalsIgnoreCase(format) || format == null) {
-            return new ObjectMapper().readTree(text);
-        } else {
+        ConversionFormat fmt = ConversionFormat.fromLabel(format);
+
+        if (fmt == null && format != null) {
             throw new IOException("Unsupported \"" + format + "\" format specified");
         }
+
+        // null format defaults to JSON
+        if (fmt == null) {
+            fmt = ConversionFormat.JSON;
+        }
+
+        return switch (fmt) {
+            case XML -> Converter.convertXmlToJson(new StringReader(text));
+            case YAML -> Converter.convertYamlToJson(new StringReader(text));
+            case CSV -> Converter.convertDelimitedToJson(new StringReader(text), ',');
+            case TSV -> Converter.convertDelimitedToJson(new StringReader(text), '\t');
+            case PSV -> Converter.convertDelimitedToJson(new StringReader(text), '|');
+            case HTML -> Converter.convertHtmlToJson(new StringReader(text), schema);
+            case MARKDOWN -> Converter.convertMarkdownToJson(new StringReader(text), schema);
+            case PROTOBUF, AVRO -> throw new IOException(fmt.label
+                    + " format cannot be converted from a text string; "
+                    + "use the Representation-based overload instead");
+            case JSON -> new ObjectMapper().readTree(text);
+        };
     }
 
     /**

--- a/src/main/java/io/naftiko/engine/util/Converter.java
+++ b/src/main/java/io/naftiko/engine/util/Converter.java
@@ -43,6 +43,7 @@ import io.naftiko.spec.OutputParameterSpec;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
+import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
@@ -113,6 +114,46 @@ public class Converter {
         }
 
         return root;
+    }
+
+    /**
+     * Convert a text-based response to a JSON tree, given the declared output format.
+     *
+     * <p>Handles every text-representable format (XML, YAML, CSV, TSV, PSV, HTML, Markdown,
+     * JSON). Binary formats (Protobuf, Avro) cannot be round-tripped through a
+     * {@link String} and will throw.</p>
+     *
+     * @param format the declared {@code outputRawFormat} (may be {@code null} for JSON)
+     * @param schema the declared {@code outputSchema} (used by HTML/Markdown selectors)
+     * @param text   the raw response body as a string
+     * @return the parsed JSON tree
+     * @throws IOException if parsing or conversion fails
+     */
+    public static JsonNode convertToJson(String format, String schema, String text)
+            throws IOException {
+        if ("XML".equalsIgnoreCase(format)) {
+            return Converter.convertXmlToJson(new StringReader(text));
+        } else if ("YAML".equalsIgnoreCase(format)) {
+            return Converter.convertYamlToJson(new StringReader(text));
+        } else if ("CSV".equalsIgnoreCase(format)) {
+            return Converter.convertDelimitedToJson(new StringReader(text), ',');
+        } else if ("TSV".equalsIgnoreCase(format)) {
+            return Converter.convertDelimitedToJson(new StringReader(text), '\t');
+        } else if ("PSV".equalsIgnoreCase(format)) {
+            return Converter.convertDelimitedToJson(new StringReader(text), '|');
+        } else if ("HTML".equalsIgnoreCase(format)) {
+            return Converter.convertHtmlToJson(new StringReader(text), schema);
+        } else if ("MARKDOWN".equalsIgnoreCase(format)) {
+            return Converter.convertMarkdownToJson(new StringReader(text), schema);
+        } else if ("Protobuf".equalsIgnoreCase(format) || "Avro".equalsIgnoreCase(format)) {
+            throw new IOException(format
+                    + " format cannot be converted from a text string; "
+                    + "use the Representation-based overload instead");
+        } else if ("JSON".equalsIgnoreCase(format) || format == null) {
+            return new ObjectMapper().readTree(text);
+        } else {
+            throw new IOException("Unsupported \"" + format + "\" format specified");
+        }
     }
 
     /**

--- a/src/test/java/io/naftiko/engine/exposes/OperationStepExecutorIntegrationTest.java
+++ b/src/test/java/io/naftiko/engine/exposes/OperationStepExecutorIntegrationTest.java
@@ -240,6 +240,78 @@ public class OperationStepExecutorIntegrationTest {
                 missingMode.getMessage());
     }
 
+    /**
+     * Regression test for #339: applyOutputMappings assumes JSON and throws
+     * JsonParseException when the response is XML. After the fix, the overloaded
+     * method accepting outputRawFormat should convert XML to JSON first.
+     */
+    @Test
+    public void applyOutputMappingsShouldThrowJsonParseExceptionForXmlInput() throws Exception {
+        OperationStepExecutor executor = new OperationStepExecutor(capabilityFromYaml("""
+                naftiko: "%s"
+                capability:
+                  exposes:
+                    - type: "rest"
+                      address: "localhost"
+                      port: 0
+                      namespace: "dummy"
+                      resources:
+                        - path: "/dummy"
+                          operations:
+                            - method: "GET"
+                              name: "dummy"
+                  consumes: []
+                """.formatted(schemaVersion)));
+
+        String xmlResponse = "<vessels><vessel>"
+                + "<vesselCode>V001</vesselCode>"
+                + "<vesselName>Sea Eagle</vesselName>"
+                + "</vessel></vessels>";
+
+        OutputParameterSpec spec = new OutputParameterSpec();
+        spec.setType("string");
+        spec.setMapping("$.vessel.vesselCode");
+
+        // Bug #339: this throws JsonParseException instead of converting XML first
+        assertThrows(com.fasterxml.jackson.core.JsonParseException.class,
+                () -> executor.applyOutputMappings(xmlResponse, List.of(spec)));
+    }
+
+    /**
+     * Regression test for #339: the 4-arg overload accepting outputRawFormat should
+     * convert the XML response to a JSON tree before applying output mappings.
+     */
+    @Test
+    public void applyOutputMappingsShouldMapXmlWhenOutputRawFormatIsXml() throws Exception {
+        OperationStepExecutor executor = new OperationStepExecutor(capabilityFromYaml("""
+                naftiko: "%s"
+                capability:
+                  exposes:
+                    - type: "rest"
+                      address: "localhost"
+                      port: 0
+                      namespace: "dummy"
+                      resources:
+                        - path: "/dummy"
+                          operations:
+                            - method: "GET"
+                              name: "dummy"
+                  consumes: []
+                """.formatted(schemaVersion)));
+
+        String xmlResponse = "<vessels><vessel>"
+                + "<vesselCode>V001</vesselCode>"
+                + "<vesselName>Sea Eagle</vesselName>"
+                + "</vessel></vessels>";
+
+        OutputParameterSpec spec = new OutputParameterSpec();
+        spec.setType("string");
+        spec.setMapping("$.vessel.vesselCode");
+
+        String mapped = executor.applyOutputMappings(xmlResponse, List.of(spec), "xml", null);
+        assertEquals("\"V001\"", mapped);
+    }
+
     @Test
     public void executeStepsShouldThrowWhenLookupReferencesMissingIndex() throws Exception {
         OperationStepExecutor executor = new OperationStepExecutor(capabilityFromYaml("""

--- a/src/test/java/io/naftiko/engine/exposes/mcp/McpXmlOutputIntegrationTest.java
+++ b/src/test/java/io/naftiko/engine/exposes/mcp/McpXmlOutputIntegrationTest.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.naftiko.engine.exposes.mcp;
+
+import static org.junit.jupiter.api.Assertions.*;
+import java.net.ServerSocket;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.restlet.Application;
+import org.restlet.Component;
+import org.restlet.Restlet;
+import org.restlet.data.MediaType;
+import org.restlet.data.Protocol;
+import org.restlet.data.Status;
+import org.restlet.routing.Router;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.naftiko.Capability;
+import io.naftiko.spec.NaftikoSpec;
+import io.naftiko.spec.exposes.McpServerSpec;
+import io.naftiko.util.VersionHelper;
+
+/**
+ * Regression test for #339: MCP tools calling operations with outputRawFormat: xml
+ * should transparently convert the XML response to JSON before applying output mappings.
+ */
+public class McpXmlOutputIntegrationTest {
+
+    private final String schemaVersion = VersionHelper.getSchemaVersion();
+
+    /**
+     * When an MCP tool calls a consumes operation that returns XML
+     * (outputRawFormat: xml), the output mappings should be applied
+     * against the XML-to-JSON conversion, not against the raw XML text.
+     */
+    @Test
+    public void handleToolCallShouldMapXmlResponseWhenOutputRawFormatIsXml() throws Exception {
+        int port = findFreePort();
+        Component server = createXmlServer(port, "/vessels",
+                "<vessels>"
+                + "<vessel><vesselCode>V001</vesselCode><vesselName>Sea Eagle</vesselName></vessel>"
+                + "<vessel><vesselCode>V002</vesselCode><vesselName>Ocean Star</vesselName></vessel>"
+                + "</vessels>");
+        server.start();
+
+        try {
+            Capability capability = capabilityFromYaml("""
+                    naftiko: "%s"
+                    capability:
+                      consumes:
+                        - namespace: legacy
+                          type: http
+                          baseUri: "http://localhost:%d"
+                          resources:
+                            - name: vessels
+                              path: "/vessels"
+                              operations:
+                                - name: list-vessels
+                                  method: GET
+                                  outputRawFormat: xml
+                      exposes:
+                        - type: mcp
+                          port: 0
+                          namespace: shipyard-tools
+                          tools:
+                            - name: list-legacy-vessels
+                              description: "List vessels from legacy XML API"
+                              call: legacy.list-vessels
+                              outputParameters:
+                                - type: array
+                                  mapping: "$.vessel"
+                                  items:
+                                    type: object
+                                    properties:
+                                      vesselCode:
+                                        type: string
+                                        mapping: "$.vesselCode"
+                                      name:
+                                        type: string
+                                        mapping: "$.vesselName"
+                    """.formatted(schemaVersion, port));
+
+            McpServerSpec mcpSpec =
+                    (McpServerSpec) capability.getSpec().getCapability().getExposes().get(0);
+            ToolHandler handler = new ToolHandler(capability, mcpSpec.getTools());
+
+            McpSchema.CallToolResult result =
+                    handler.handleToolCall("list-legacy-vessels", Map.of());
+
+            assertNotNull(result, "Tool result should not be null");
+            assertFalse(result.isError(), "Tool call should not be an error");
+            assertNotNull(result.content(), "Result content should not be null");
+            assertFalse(result.content().isEmpty(), "Result content should not be empty");
+
+            String text = ((McpSchema.TextContent) result.content().get(0)).text();
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode mapped = mapper.readTree(text);
+
+            assertTrue(mapped.isArray(), "Mapped result should be an array");
+            assertEquals(2, mapped.size(), "Should contain two vessels");
+            assertEquals("V001", mapped.get(0).path("vesselCode").asText());
+            assertEquals("Sea Eagle", mapped.get(0).path("name").asText());
+            assertEquals("V002", mapped.get(1).path("vesselCode").asText());
+            assertEquals("Ocean Star", mapped.get(1).path("name").asText());
+        } finally {
+            server.stop();
+        }
+    }
+
+    private static Capability capabilityFromYaml(String yaml) throws Exception {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        NaftikoSpec spec = mapper.readValue(yaml, NaftikoSpec.class);
+        return new Capability(spec);
+    }
+
+    private static Component createXmlServer(int port, String path, String xmlBody)
+            throws Exception {
+        Component component = new Component();
+        component.getServers().add(Protocol.HTTP, port);
+        component.getDefaultHost().attach(new Application() {
+            @Override
+            public Restlet createInboundRoot() {
+                Router router = new Router(getContext());
+                router.attach(path, new Restlet() {
+                    @Override
+                    public void handle(org.restlet.Request request,
+                            org.restlet.Response response) {
+                        response.setStatus(Status.SUCCESS_OK);
+                        response.setEntity(xmlBody, MediaType.APPLICATION_XML);
+                    }
+                });
+                return router;
+            }
+        });
+        return component;
+    }
+
+    private static int findFreePort() throws Exception {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+}

--- a/src/test/java/io/naftiko/tutorial/Step5ShipyardMcpClientIntegrationTest.java
+++ b/src/test/java/io/naftiko/tutorial/Step5ShipyardMcpClientIntegrationTest.java
@@ -103,6 +103,12 @@ public class Step5ShipyardMcpClientIntegrationTest
                     ((HttpClientSpec) cs).setBaseUri(REGISTRY_MOCK_URI);
                 } else if ("legacy".equals(cs.getNamespace())) {
                     ((HttpClientSpec) cs).setBaseUri(LEGACY_MOCK_URI);
+                    // The alpha1 mock returns JSON, not XML. Clear outputRawFormat so
+                    // the engine parses the response as JSON. The XML conversion path
+                    // is covered by McpXmlOutputIntegrationTest with a local XML mock.
+                    ((HttpClientSpec) cs).getResources()
+                            .forEach(r -> r.getOperations()
+                                    .forEach(op -> op.setOutputRawFormat(null)));
                 }
             }
         }


### PR DESCRIPTION
## Related Issue

Closes #339

---

## What does this PR do?

`OperationStepExecutor.applyOutputMappings` always parsed the response body as JSON via `mapper.readTree()`, ignoring the consumed operation's `outputRawFormat`. When an MCP tool called an operation with `outputRawFormat: xml`, the server threw a `JsonParseException` (`Unexpected character '<'`), returning `isError: true` to the client.

**Fix:**
- Added a text-based `Converter.convertToJson(String format, String schema, String text)` overload that handles all text-representable formats (XML, YAML, CSV, TSV, PSV, HTML, Markdown, JSON).
- Added a format-aware `applyOutputMappings` overload on `OperationStepExecutor` that delegates to the new converter. The existing 2-arg signature delegates with `null` format (backward compatible).
- Updated `ToolHandler.buildToolResult`, `ResourceHandler.extractContent`, and `AggregateFunction.execute` to pass `found.clientOperation.getOutputRawFormat()` and `getOutputSchema()` to the new overload.

---

## Tests

**Unit test** — `OperationStepExecutorIntegrationTest.applyOutputMappingsShouldThrowJsonParseExceptionForXmlInput`: documents the pre-fix behavior (the 2-arg overload still throws `JsonParseException` for XML input, proving the bug exists at the method level).

**Integration test** — `McpXmlOutputIntegrationTest.handleToolCallShouldMapXmlResponseWhenOutputRawFormatIsXml`: end-to-end test with a local XML mock server → MCP tool call → verifies XML-to-JSON conversion and output mapping produce the expected array of vessels.

**Existing test fix** — `Step5ShipyardMcpClientIntegrationTest`: the alpha1 legacy mock returns JSON (not XML), so the test now clears `outputRawFormat` on legacy operations to match the mock. The XML conversion path is fully covered by the new integration test.

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Claude Opus 4.6
tool: VS Code Chat
confidence: high
source_event: "#339"
discovery_method: user_report
review_focus: OperationStepExecutor.java:727-770, Converter.java:120-160, ToolHandler.java:264-270
```