### PR TITLE
fix: correct XML array mapping in legacy-vessels tutorial files

### DIFF
--- a/src/main/resources/tutorial/step-10-shipyard-rest-adapter.yml
+++ b/src/main/resources/tutorial/step-10-shipyard-rest-adapter.yml
@@ -115,7 +115,7 @@ capability:
             status: shipyard-tools.status
           outputParameters:
             - type: array
-              mapping: "$."
+              mapping: "$.vessel"
               items:
                 type: object
                 properties:
@@ -357,7 +357,7 @@ capability:
                 status: shipyard-api.status
               outputParameters:
                 - type: array
-                  mapping: "$."
+                  mapping: "$.vessel"
                   items:
                     type: object
                     properties:

--- a/src/main/resources/tutorial/step-11-shipyard-fleet-manifest.yml
+++ b/src/main/resources/tutorial/step-11-shipyard-fleet-manifest.yml
@@ -125,7 +125,7 @@ capability:
             status: shipyard-tools.status
           outputParameters:
             - type: array
-              mapping: "$."
+              mapping: "$.vessel"
               items:
                 type: object
                 properties:

--- a/src/main/resources/tutorial/step-6-shipyard-write-operations.yml
+++ b/src/main/resources/tutorial/step-6-shipyard-write-operations.yml
@@ -115,7 +115,7 @@ capability:
             status: shipyard-tools.status
           outputParameters:
             - type: array
-              mapping: "$."
+              mapping: "$.vessel"
               items:
                 type: object
                 properties:

--- a/src/main/resources/tutorial/step-7-shipyard-orchestrated-lookup.yml
+++ b/src/main/resources/tutorial/step-7-shipyard-orchestrated-lookup.yml
@@ -115,7 +115,7 @@ capability:
             status: shipyard-tools.status
           outputParameters:
             - type: array
-              mapping: "$."
+              mapping: "$.vessel"
               items:
                 type: object
                 properties:

--- a/src/main/resources/tutorial/step-8-shipyard-skill-groups.yml
+++ b/src/main/resources/tutorial/step-8-shipyard-skill-groups.yml
@@ -115,7 +115,7 @@ capability:
             status: shipyard-tools.status
           outputParameters:
             - type: array
-              mapping: "$."
+              mapping: "$.vessel"
               items:
                 type: object
                 properties:

--- a/src/main/resources/tutorial/step-9-shipyard-aggregates.yml
+++ b/src/main/resources/tutorial/step-9-shipyard-aggregates.yml
@@ -191,7 +191,7 @@ capability:
             status: shipyard-tools.status
           outputParameters:
             - type: array
-              mapping: "$."
+              mapping: "$.vessel"
               items:
                 type: object
                 properties:


### PR DESCRIPTION
## Related Issue

Closes #347

---

## What does this PR do?

Fixes the `list-legacy-vessels` MCP tool returning raw XML instead of a mapped JSON array in tutorial steps 6–11.

Jackson's `XmlMapper` converts `<vessels><vessel>…</vessel></vessels>` to `{"vessel": [{…}, {…}]}`. The output mapping `"$."` extracts the root object (not an array), so `resolveOutputMappings` falls back to raw XML. Changed to `"$.vessel"` which correctly targets the array.

**Files changed (6):**
- `step-6-shipyard-write-operations.yml`
- `step-7-shipyard-orchestrated-lookup.yml`
- `step-8-shipyard-skill-groups.yml`
- `step-9-shipyard-aggregates.yml`
- `step-10-shipyard-rest-adapter.yml` (2 occurrences: MCP tool + REST operation)
- `step-11-shipyard-fleet-manifest.yml`

---

## Tests

No new tests — existing test suite (779 tests, 0 failures) validates the change. The fix is a YAML-only data correction, not a code change.

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Claude Opus 4.6
tool: VS Code Chat
confidence: high
source_event: CI test failure (step6-list-legacy-vessels)
discovery_method: user_report
review_focus: mapping field in outputParameters of list-legacy-vessels tools
```