### PR TITLE
fix: add missing crew-resolver aggregate and REST resource to step-10 tutorial

### DIFF
--- a/.github/tests/tests.yml
+++ b/.github/tests/tests.yml
@@ -208,6 +208,21 @@ tests:
   - jq: '.crew[0] | has("fullName")'
   - jq: '.crew[0] | has("role")'
 
+- name: step10-rest-get-ship-with-crew
+  type: rest
+  file: step-10-shipyard-rest-adapter.yml
+  port: 3003
+  method: GET
+  path: /ships/IMO-9321483/crew
+  validations:
+  - jq: 'has("imo")'
+  - jq: 'has("name")'
+  - jq: 'has("crew")'
+  - jq: '.crew | type == "array"'
+  - jq: '.crew | length > 0'
+  - jq: '.crew[0] | has("fullName")'
+  - jq: '.crew[0] | has("role")'
+
 - name: step10-voyage-manifest
   file: step-10-shipyard-fleet-manifest.yml
   port: 3001

--- a/src/main/resources/tutorial/step-10-shipyard-rest-adapter.yml
+++ b/src/main/resources/tutorial/step-10-shipyard-rest-adapter.yml
@@ -18,9 +18,85 @@ binds:
 capability:
   consumes:
     - import: registry
-      location: ./shared/registry-consumes.yaml
+      location: ./shared/step7-registry-consumes.yml
     - import: legacy
       location: ./shared/legacy-consumes.yaml
+
+  aggregates:
+    - label: "Crew Resolver"
+      namespace: crew-resolver
+      functions:
+        - name: resolve-crew-for-ship
+          description: "Resolve crew member names and roles for a given ship"
+          semantics:
+            safe: true
+            idempotent: true
+            cacheable: true
+          inputParameters:
+            - name: imo
+              type: string
+              required: true
+              description: "IMO number of the ship"
+          steps:
+            - name: get-ship
+              type: call
+              call: registry.get-ship
+              with:
+                imo_number: "{{imo}}"
+            - name: list-crew
+              type: call
+              call: registry.list-crew
+            - name: resolve-crew
+              type: lookup
+              index: list-crew
+              match: crewId
+              lookupValue: "$.get-ship.assignedCrew"
+              outputParameters:
+                - "fullName"
+                - "role"
+          mappings:
+            - targetName: imo
+              value: "$.get-ship.imo_number"
+            - targetName: name
+              value: "$.get-ship.vessel_name"
+            - targetName: type
+              value: "$.get-ship.vessel_type"
+            - targetName: flag
+              value: "$.get-ship.flag_code"
+            - targetName: status
+              value: "$.get-ship.operational_status"
+            - targetName: yearBuilt
+              value: "$.get-ship.year_built"
+            - targetName: tonnage
+              value: "$.get-ship.gross_tonnage"
+            - targetName: length
+              value: "$.get-ship.dimensions.length_overall"
+            - targetName: crew
+              value: "$.resolve-crew"
+          outputParameters:
+            - name: imo
+              type: string
+            - name: name
+              type: string
+            - name: type
+              type: string
+            - name: flag
+              type: string
+            - name: status
+              type: string
+            - name: yearBuilt
+              type: number
+            - name: tonnage
+              type: number
+            - name: length
+              type: number
+            - name: crew
+              type: array
+              items:
+                - name: fullName
+                  type: string
+                - name: role
+                  type: string
 
   exposes:
     - type: mcp
@@ -221,6 +297,9 @@ capability:
                 status:
                   type: string
                   mapping: "$.status"
+        - name: get-ship-with-crew
+          description: "Get ship details with resolved crew names"
+          ref: crew-resolver.resolve-crew-for-ship
 
     - type: skill
       address: "0.0.0.0" # Needed in Docker context. Permits to access the MCP with localhost from outside the container.
@@ -342,6 +421,17 @@ capability:
                         length:
                           type: number
                           mapping: "$.dimensions.length_overall"
+        - name: ship-crew
+          path: "/ships/{{imo}}/crew"
+          operations:
+            - name: get-ship-with-crew
+              method: GET
+              inputParameters:
+                - name: imo
+                  in: path
+                  type: string
+                  description: "IMO number of the ship"
+              ref: crew-resolver.resolve-crew-for-ship
         - name: legacy-vessels
           path: "/legacy/vessels"
           operations:


### PR DESCRIPTION
## Related Issue

Closes #351

---

## What does this PR do?

Fixes `step-10-shipyard-rest-adapter.yml` which was missing several pieces that should have carried forward from step-9 (aggregates), causing the `step10-rest-get-ship-with-crew` CI test to fail — `GET /ships/IMO-9321483/crew` on port 3003 returned empty data.

**Changes:**

- **Switch consumes import** from `registry-consumes.yaml` (no `list-crew`) to `step7-registry-consumes.yml`
- **Add `aggregates` section** with `crew-resolver` namespace and `resolve-crew-for-ship` function (matching step-9)
- **Add `get-ship-with-crew` MCP tool** using `ref: crew-resolver.resolve-crew-for-ship`
- **Add `ship-crew` REST resource** at `/ships/{{imo}}/crew` using `ref: crew-resolver.resolve-crew-for-ship`
- **Add test entry** `step10-rest-get-ship-with-crew` in `.github/tests/tests.yml`

---

## Tests

- All 779 existing unit tests pass (`mvn clean test`)
- Added `step10-rest-get-ship-with-crew` REST test entry in `.github/tests/tests.yml` validating `GET /ships/IMO-9321483/crew` returns `imo`, `name`, `crew` array with `fullName` and `role`

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Claude Opus 4.6
tool: VS Code Chat
confidence: high
source_event: CI test failure reported by user
discovery_method: user_report
review_focus: src/main/resources/tutorial/step-10-shipyard-rest-adapter.yml
```