### PR TITLE
fix: add OAuth2AuthenticationSpec to native-image reflect-config.json

### DIFF
--- a/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/reflect-config.json
@@ -633,6 +633,12 @@
     "allDeclaredFields": true
   },
   {
+    "name": "io.naftiko.spec.consumes.OAuth2AuthenticationSpec",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
     "name": "io.naftiko.spec.InputParameterSerializer",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true

--- a/src/test/java/io/naftiko/cli/NativeImageReflectConfigTest.java
+++ b/src/test/java/io/naftiko/cli/NativeImageReflectConfigTest.java
@@ -77,7 +77,8 @@ public class NativeImageReflectConfigTest {
                 "io.naftiko.spec.consumes.ApiKeyAuthenticationSpec",
                 "io.naftiko.spec.consumes.BearerAuthenticationSpec",
                 "io.naftiko.spec.consumes.BasicAuthenticationSpec",
-                "io.naftiko.spec.consumes.DigestAuthenticationSpec");
+                "io.naftiko.spec.consumes.DigestAuthenticationSpec",
+                "io.naftiko.spec.consumes.OAuth2AuthenticationSpec");
 
         List<String> missing = requiredClasses.stream()
                 .filter(c -> !registeredClasses.contains(c))


### PR DESCRIPTION
## Related Issue

Closes #353

---

## What does this PR do?

`OAuth2AuthenticationSpec` is declared as a `@JsonSubTypes` subtype in `AuthenticationSpec.java` but was missing from `reflect-config.json`. In GraalVM native-image builds, Jackson cannot reflectively access the class, causing OAuth2 authentication blocks to silently serialize as empty objects or be omitted entirely.

This PR:
- Adds `io.naftiko.spec.consumes.OAuth2AuthenticationSpec` to `reflect-config.json`
- Adds the class to `NativeImageReflectConfigTest` required list to prevent regression

---

## Tests

- Updated `NativeImageReflectConfigTest.reflectConfigShouldContainAuthenticationSpecClasses` to include `OAuth2AuthenticationSpec` in the required classes list — the test now fails if the reflect registration is missing.

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Claude Opus 4.6
tool: VS Code Chat
confidence: high
source_event: code review of @JsonSubTypes vs reflect-config.json
discovery_method: code_review
review_focus: reflect-config.json, NativeImageReflectConfigTest.java
```