### PR TITLE
fix: read outputRawFormat from consumed operation in REST adapter

### DIFF
--- a/src/main/java/io/naftiko/engine/exposes/rest/ResourceRestlet.java
+++ b/src/main/java/io/naftiko/engine/exposes/rest/ResourceRestlet.java
@@ -493,8 +493,12 @@ public class ResourceRestlet extends Restlet {
             return null;
         }
 
-        JsonNode root = Converter.convertToJson(serverOp.getOutputRawFormat(),
-                serverOp.getOutputSchema(), found.clientResponse.getEntity());
+        String outputRawFormat = found.clientOperation != null
+                ? found.clientOperation.getOutputRawFormat() : null;
+        String outputSchema = found.clientOperation != null
+                ? found.clientOperation.getOutputSchema() : null;
+        JsonNode root = Converter.convertToJson(outputRawFormat, outputSchema,
+                found.clientResponse.getEntity());
 
         for (OutputParameterSpec outputParameter : serverOp.getOutputParameters()) {
             if ("body".equalsIgnoreCase(inOrDefault(outputParameter))) {

--- a/src/test/java/io/naftiko/engine/exposes/rest/ResourceRestletTest.java
+++ b/src/test/java/io/naftiko/engine/exposes/rest/ResourceRestletTest.java
@@ -300,15 +300,26 @@ public class ResourceRestletTest {
 
     // Unsupported output format triggers mapping exception path.
     RestServerOperationSpec failingOperation = new RestServerOperationSpec();
-    failingOperation.setOutputRawFormat("INI");
     OutputParameterSpec output = new OutputParameterSpec();
     output.setType("string");
     output.setIn("body");
     output.setMapping("$.id");
     failingOperation.getOutputParameters().add(output);
 
+    // Set unsupported format on the client operation (where the fix now reads it from)
+    io.naftiko.spec.consumes.HttpClientOperationSpec failingClientOp =
+        new io.naftiko.spec.consumes.HttpClientOperationSpec();
+    failingClientOp.setOutputRawFormat("INI");
+
+    OperationStepExecutor.HandlingContext failingContext =
+        new OperationStepExecutor.HandlingContext();
+    failingContext.clientOperation = failingClientOp;
+    Request failingClientRequest = new Request(Method.GET, "http://localhost/internal");
+    failingContext.clientResponse = new Response(failingClientRequest);
+    failingContext.clientResponse.setEntity("{\"id\":\"u-1\"}", MediaType.APPLICATION_JSON);
+
     Response errorResponse = new Response(new Request(Method.GET, "http://localhost/test"));
-    restlet.sendResponse(failingOperation, errorResponse, handlingContext);
+    restlet.sendResponse(failingOperation, errorResponse, failingContext);
     assertEquals(Status.SERVER_ERROR_INTERNAL, errorResponse.getStatus());
     assertTrue(errorResponse.getEntity().getText().contains("Failed to map output parameters"));
   }
@@ -449,6 +460,64 @@ public class ResourceRestletTest {
                               name: "test"
                   consumes: []
                 """.formatted(schemaVersion);
+  }
+
+  @Test
+  public void mapOutputParametersShouldHonorClientOperationOutputRawFormat() throws Exception {
+    Capability capability = capabilityFromYaml(minimalCapabilityYaml());
+    RestServerSpec serverSpec = (RestServerSpec) capability.getServerAdapters().get(0)
+        .getSpec();
+    ResourceRestlet restlet = new ResourceRestlet(capability, serverSpec,
+        serverSpec.getResources().get(0));
+
+    // Server operation does NOT declare outputRawFormat (it lives on the consumed side)
+    RestServerOperationSpec operation = new RestServerOperationSpec();
+    OutputParameterSpec mappedBody = new OutputParameterSpec();
+    mappedBody.setType("array");
+    mappedBody.setIn("body");
+    mappedBody.setMapping("$.user");
+
+    OutputParameterSpec itemSpec = new OutputParameterSpec();
+    itemSpec.setType("object");
+    OutputParameterSpec idProp = new OutputParameterSpec();
+    idProp.setName("id");
+    idProp.setType("string");
+    idProp.setMapping("$.id");
+    itemSpec.getProperties().add(idProp);
+    OutputParameterSpec nameProp = new OutputParameterSpec();
+    nameProp.setName("name");
+    nameProp.setType("string");
+    nameProp.setMapping("$.name");
+    itemSpec.getProperties().add(nameProp);
+    mappedBody.setItems(itemSpec);
+    operation.getOutputParameters().add(mappedBody);
+
+    // Client operation declares outputRawFormat: xml
+    io.naftiko.spec.consumes.HttpClientOperationSpec clientOp =
+        new io.naftiko.spec.consumes.HttpClientOperationSpec();
+    clientOp.setOutputRawFormat("xml");
+
+    String xml = "<root><user><id>1</id><name>Alice</name></user>"
+        + "<user><id>2</id><name>Bob</name></user></root>";
+
+    OperationStepExecutor.HandlingContext handlingContext =
+        new OperationStepExecutor.HandlingContext();
+    handlingContext.clientOperation = clientOp;
+    Request clientRequest = new Request(Method.GET, "http://localhost/internal");
+    handlingContext.clientResponse = new Response(clientRequest);
+    handlingContext.clientResponse.setEntity(xml, MediaType.APPLICATION_XML);
+
+    String mapped = restlet.mapOutputParameters(operation, handlingContext);
+
+    // Without the fix, this throws JsonParseException because the XML is parsed as JSON
+    assertNotNull(mapped, "XML response should be mapped successfully");
+    JsonNode payload = JSON.readTree(mapped);
+    assertTrue(payload.isArray(), "Result should be an array");
+    assertEquals(2, payload.size());
+    assertEquals("1", payload.get(0).path("id").asText());
+    assertEquals("Alice", payload.get(0).path("name").asText());
+    assertEquals("2", payload.get(1).path("id").asText());
+    assertEquals("Bob", payload.get(1).path("name").asText());
   }
 
   private static OutputParameterSpec stringOutput(String name, String value) {

--- a/src/test/java/io/naftiko/engine/exposes/rest/RestXmlOutputFormatIntegrationTest.java
+++ b/src/test/java/io/naftiko/engine/exposes/rest/RestXmlOutputFormatIntegrationTest.java
@@ -1,0 +1,178 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.naftiko.engine.exposes.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.net.ServerSocket;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.restlet.Application;
+import org.restlet.Component;
+import org.restlet.Request;
+import org.restlet.Response;
+import org.restlet.Restlet;
+import org.restlet.data.MediaType;
+import org.restlet.data.Method;
+import org.restlet.data.Protocol;
+import org.restlet.data.Status;
+import org.restlet.routing.Router;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.naftiko.Capability;
+import io.naftiko.spec.NaftikoSpec;
+import io.naftiko.spec.exposes.RestServerSpec;
+import io.naftiko.util.VersionHelper;
+
+/**
+ * Integration test proving the REST adapter honors {@code outputRawFormat} declared on the consumed
+ * operation. Before the fix, the REST adapter read the format from the server (exposes) operation —
+ * which never declares it — causing XML responses to be parsed as JSON and failing with
+ * {@code JsonParseException}.
+ */
+public class RestXmlOutputFormatIntegrationTest {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private String schemaVersion;
+
+    @BeforeEach
+    public void setUp() {
+        schemaVersion = VersionHelper.getSchemaVersion();
+    }
+
+    @Test
+    public void handleShouldMapXmlResponseWhenConsumedOperationDeclaresOutputRawFormatXml()
+            throws Exception {
+        int port = findFreePort();
+        Component upstream = createXmlServer(port);
+        upstream.start();
+
+        try {
+            Capability capability = capabilityFromYaml("""
+                    naftiko: "%s"
+                    capability:
+                      exposes:
+                        - type: "rest"
+                          address: "localhost"
+                          port: 0
+                          namespace: "test-rest"
+                          resources:
+                            - path: "/legacy/vessels"
+                              name: "legacy-vessels"
+                              operations:
+                                - method: "GET"
+                                  name: "list-legacy-vessels"
+                                  call: "legacy.list-vessels"
+                                  outputParameters:
+                                    - type: "array"
+                                      mapping: "$.vessel"
+                                      items:
+                                        type: "object"
+                                        properties:
+                                          code:
+                                            type: "string"
+                                            mapping: "$.vesselCode"
+                                          name:
+                                            type: "string"
+                                            mapping: "$.vesselName"
+                      consumes:
+                        - type: "http"
+                          namespace: "legacy"
+                          baseUri: "http://localhost:%d"
+                          resources:
+                            - path: "/vessels"
+                              name: "vessels"
+                              operations:
+                                - method: "GET"
+                                  name: "list-vessels"
+                                  outputRawFormat: "xml"
+                    """.formatted(schemaVersion, port));
+
+            RestServerSpec serverSpec =
+                    (RestServerSpec) capability.getServerAdapters().get(0).getSpec();
+            ResourceRestlet restlet = new ResourceRestlet(capability, serverSpec,
+                    serverSpec.getResources().get(0));
+
+            Request request = new Request(Method.GET, "http://localhost/legacy/vessels");
+            Response response = new Response(request);
+
+            restlet.handle(request, response);
+
+            assertEquals(Status.SUCCESS_OK, response.getStatus(),
+                    "REST adapter should return 200 for mapped XML response");
+            assertNotNull(response.getEntity(), "Response entity should not be null");
+
+            JsonNode payload = JSON.readTree(response.getEntity().getText());
+            assertTrue(payload.isArray(), "Mapped response should be a JSON array");
+            assertEquals(2, payload.size(), "Should contain 2 vessels");
+            assertEquals("V001", payload.get(0).path("code").asText());
+            assertEquals("Sea Eagle", payload.get(0).path("name").asText());
+            assertEquals("V002", payload.get(1).path("code").asText());
+            assertEquals("Harbor Star", payload.get(1).path("name").asText());
+        } finally {
+            upstream.stop();
+        }
+    }
+
+    private static Component createXmlServer(int port) throws Exception {
+        String xmlBody = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <vessels>
+                  <vessel>
+                    <vesselCode>V001</vesselCode>
+                    <vesselName>Sea Eagle</vesselName>
+                  </vessel>
+                  <vessel>
+                    <vesselCode>V002</vesselCode>
+                    <vesselName>Harbor Star</vesselName>
+                  </vessel>
+                </vessels>
+                """;
+
+        Component component = new Component();
+        component.getServers().add(Protocol.HTTP, port);
+        component.getDefaultHost().attach(new Application() {
+            @Override
+            public Restlet createInboundRoot() {
+                Router router = new Router(getContext());
+                router.attach("/vessels", new Restlet() {
+                    @Override
+                    public void handle(Request request, Response response) {
+                        response.setStatus(Status.SUCCESS_OK);
+                        response.setEntity(xmlBody, MediaType.APPLICATION_XML);
+                    }
+                });
+                return router;
+            }
+        });
+        return component;
+    }
+
+    private static Capability capabilityFromYaml(String yaml) throws Exception {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        NaftikoSpec spec = mapper.readValue(yaml, NaftikoSpec.class);
+        return new Capability(spec);
+    }
+
+    private static int findFreePort() throws Exception {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+}


### PR DESCRIPTION
## Related Issue

Closes #355

---

## What does this PR do?

`ResourceRestlet.mapOutputParameters` was reading `outputRawFormat` and `outputSchema` from the **server** (exposes) operation, which never declares these fields. The format is declared on the **consumed** operation — so non-JSON responses (XML, CSV, YAML, etc.) were always parsed as JSON, causing `JsonParseException`.

The fix reads both fields from `found.clientOperation` instead, matching the pattern already used by `ToolHandler`, `ResourceHandler`, and `AggregateFunction`.

**Before:** `GET /legacy/vessels` → HTTP 500 (`Unexpected character '<'`)
**After:** `GET /legacy/vessels` → HTTP 200 with properly mapped JSON array

---

## Tests

**Unit test** — `ResourceRestletTest.mapOutputParametersShouldHonorClientOperationOutputRawFormat`: calls `mapOutputParameters` directly with an XML entity and a `clientOperation` declaring `outputRawFormat: xml`. Verifies the XML is converted and mapped correctly.

**Integration test** — `RestXmlOutputFormatIntegrationTest.handleShouldMapXmlResponseWhenConsumedOperationDeclaresOutputRawFormatXml`: starts a mock upstream HTTP server returning XML, loads a capability with a REST exposes operation calling a consumed operation with `outputRawFormat: xml`, and exercises the full `ResourceRestlet.handle()` path end-to-end.

**Existing test updated** — `ResourceRestletTest.sendResponseShouldFallbackToRawEntityAndHandleMappingExceptions`: moved the unsupported format (`"INI"`) from `serverOp` to `clientOperation` to match the new code path.

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Claude
tool: vscode-copilot-chat
confidence: high
source_event: tutorial smoke test failure (step10-rest-list-legacy-vessels)
discovery_method: runtime_observation
review_focus: ResourceRestlet.java:496-500
```