### PR TITLE
fix: disable default otlp endpoint localhost:4317 when no exposes con…

### DIFF
--- a/src/main/java/io/naftiko/engine/telemetry/TelemetryBootstrap.java
+++ b/src/main/java/io/naftiko/engine/telemetry/TelemetryBootstrap.java
@@ -134,9 +134,7 @@ public class TelemetryBootstrap {
         DelegatingSpanProcessor spanProcessorSlot = new DelegatingSpanProcessor();
         Map<String, String> specProperties = buildSpecProperties(observabilitySpec);
         var builder = io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk.builder();
-        if (!specProperties.isEmpty()) {
-            builder.addPropertiesSupplier(() -> specProperties);
-        }
+        builder.addPropertiesSupplier(() -> specProperties);
         OpenTelemetry otel = builder
                 .addResourceCustomizer((resource, config) ->
                         resource.merge(io.opentelemetry.sdk.resources.Resource.create(
@@ -156,6 +154,11 @@ public class TelemetryBootstrap {
     static Map<String, String> buildSpecProperties(ObservabilitySpec spec) {
         Map<String, String> props = new HashMap<>();
         if (spec == null) {
+            // No observability spec — default to none to avoid spurious connection errors
+            // to localhost:4317 (e.g. inside Docker). OTel env vars still take precedence.
+            props.put("otel.traces.exporter", "none");
+            props.put("otel.metrics.exporter", "none");
+            props.put("otel.logs.exporter", "none");
             return props;
         }
         if (spec.getTraces() != null) {
@@ -172,11 +175,18 @@ public class TelemetryBootstrap {
                 props.put("otel.propagators", propagators);
             }
         }
-        if (spec.getExporters() != null && spec.getExporters().getOtlp() != null) {
-            String endpoint = spec.getExporters().getOtlp().getEndpoint();
-            if (endpoint != null && !endpoint.isBlank()) {
-                props.put("otel.exporter.otlp.endpoint", endpoint);
-            }
+        boolean hasOtlpEndpoint = spec.getExporters() != null
+                && spec.getExporters().getOtlp() != null
+                && spec.getExporters().getOtlp().getEndpoint() != null
+                && !spec.getExporters().getOtlp().getEndpoint().isBlank();
+        if (hasOtlpEndpoint) {
+            props.put("otel.exporter.otlp.endpoint", spec.getExporters().getOtlp().getEndpoint());
+        } else {
+            // No OTLP endpoint in spec — default to none to avoid spurious connection errors
+            // to localhost:4317 (e.g. inside Docker). OTel env vars still take precedence.
+            props.putIfAbsent("otel.traces.exporter", "none");
+            props.putIfAbsent("otel.metrics.exporter", "none");
+            props.putIfAbsent("otel.logs.exporter", "none");
         }
         return props;
     }

--- a/src/test/java/io/naftiko/engine/telemetry/TelemetryBootstrapTest.java
+++ b/src/test/java/io/naftiko/engine/telemetry/TelemetryBootstrapTest.java
@@ -370,16 +370,20 @@ public class TelemetryBootstrapTest {
     }
 
     @Test
-    void buildSpecPropertiesShouldReturnEmptyMapForNull() {
+    void buildSpecPropertiesShouldDefaultToNoneExportersForNull() {
         Map<String, String> props = TelemetryBootstrap.buildSpecProperties(null);
-        assertTrue(props.isEmpty());
+        assertEquals("none", props.get("otel.traces.exporter"));
+        assertEquals("none", props.get("otel.metrics.exporter"));
+        assertEquals("none", props.get("otel.logs.exporter"));
     }
 
     @Test
-    void buildSpecPropertiesShouldReturnEmptyMapForDefaults() {
+    void buildSpecPropertiesShouldDefaultToNoneExportersWhenNoEndpoint() {
         ObservabilitySpec spec = new ObservabilitySpec();
         Map<String, String> props = TelemetryBootstrap.buildSpecProperties(spec);
-        assertTrue(props.isEmpty());
+        assertEquals("none", props.get("otel.traces.exporter"));
+        assertEquals("none", props.get("otel.metrics.exporter"));
+        assertEquals("none", props.get("otel.logs.exporter"));
     }
 
     @Test
@@ -458,6 +462,10 @@ public class TelemetryBootstrapTest {
         Map<String, String> props = TelemetryBootstrap.buildSpecProperties(spec);
 
         assertFalse(props.containsKey("otel.exporter.otlp.endpoint"));
+        // blank endpoint falls through to none defaults
+        assertEquals("none", props.get("otel.traces.exporter"));
+        assertEquals("none", props.get("otel.metrics.exporter"));
+        assertEquals("none", props.get("otel.logs.exporter"));
     }
 
     @Test


### PR DESCRIPTION
…trol configuration

## Related Issue

Closes #<!-- issue number -->

---

## What does this PR do?

When running the engine into Docker with a capability having no exposes: control, this generates errors in logs. It is because without configuration, the otlp endpoint is using localhost:4317 by default.
This fix disable the otlp endpoint when no config in the capability file.

---

## Tests

2 tests have been updated

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main`
- [ ] Small and focused — one concern per PR
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

<!-- If this PR was created or assisted by an AI agent, provide metadata below (YAML) -->

```yaml
# agent_name:
# llm:
# tool:
# confidence:          # low | medium | high
# source_event:
# discovery_method:    # runtime_observation | code_review | test_failure | user_report
# review_focus:        # e.g. ClassName.java:line-range
```
