### PR TITLE
feat: add pr-review skill for inline PR comments workflow

### DIFF
--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -73,20 +73,24 @@ diff is applied). The algorithm:
 ```powershell
 # Windows (PowerShell)
 $diff = Get-Content "$env:TEMP/pr<number>.diff" -Encoding utf8
-$inFile = $false; $lineNum = 0
+$inFile = $false; $inHunk = $false; $lineNum = 0
 foreach ($line in $diff) {
     if ($line -match "^diff --git") {
         $inFile = $line -match "YourFile\.java"
+        $inHunk = $false
         $lineNum = 0
     }
     if ($inFile) {
         if ($line -match "^@@") {
+            $inHunk = $true
             $m = [regex]::Match($line, '\+(\d+)')
             if ($m.Success) { $lineNum = [int]$m.Groups[1].Value - 1 }
-        } elseif ($line -match "^\+") { $lineNum++ }
-        elseif ($line -match "^ ")  { $lineNum++ }
+        } elseif ($line -match "^\+\+\+" -or $line -match "^---") {
+            # diff header lines — do not increment
+        } elseif ($inHunk -and $line -match "^\+") { $lineNum++ }
+        elseif ($inHunk -and $line -match "^ ")  { $lineNum++ }
         # -: do not increment
-        if ($line -match "pattern to find") {
+        if ($inHunk -and $line -notmatch "^-" -and $line -match "pattern to find") {
             Write-Host "L$lineNum [$line]"
         }
     }
@@ -94,13 +98,17 @@ foreach ($line in $diff) {
 ```
 
 ```bash
-# Linux / macOS
+# Linux / macOS (POSIX awk — compatible with macOS BSD awk and gawk)
 awk '
-  /^diff --git/ { in_file = ($0 ~ "YourFile\.java"); line_num = 0 }
-  in_file && /^@@/ { match($0, /\+([0-9]+)/, a); line_num = a[1] - 1 }
-  in_file && /^\+/ { line_num++ }
-  in_file && /^ /  { line_num++ }
-  in_file && /pattern to find/ { print "L" line_num " [" $0 "]" }
+  /^diff --git/ { in_file = ($0 ~ "YourFile\\.java"); in_hunk = 0; line_num = 0 }
+  in_file && /^@@/ {
+    if (match($0, /\+[0-9]+/)) line_num = substr($0, RSTART + 1, RLENGTH - 1) - 1
+    in_hunk = 1
+  }
+  in_file && in_hunk && /^\+\+\+/ { next }
+  in_file && in_hunk && /^\+/ { line_num++ }
+  in_file && in_hunk && /^ /  { line_num++ }
+  in_file && in_hunk && !/^-/ && /pattern to find/ { print "L" line_num " [" $0 "]" }
 ' /tmp/pr<number>.diff
 ```
 

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: pr-review
+version: "1.0.0"
+description: >
+  On-demand skill for reviewing GitHub Pull Requests and posting inline
+  comments via the GitHub API. Activate when the user asks to: review a PR,
+  review a pull request, do a code review, post inline comments on a PR,
+  comment on a pull request, review PR #<number>.
+allowed-tools:
+  - Read
+  - Bash
+---
+
+## Overview
+
+This skill guides the agent through a structured PR review workflow:
+fetch the diff → compute line numbers accurately → verify each line →
+present findings → post only after explicit user confirmation.
+
+---
+
+## Step 1 — Fetch and save the diff
+
+Save the diff to a temp file to enable repeated querying without extra API calls.
+
+```powershell
+# Windows (PowerShell)
+gh pr diff <number> | Out-File -FilePath "$env:TEMP/pr<number>.diff" -Encoding utf8
+```
+
+```bash
+# Linux / macOS
+gh pr diff <number> > /tmp/pr<number>.diff
+```
+
+Then list the changed files for an overview:
+
+```powershell
+# Windows (PowerShell)
+gh pr view <number> --json files | ConvertFrom-Json |
+  Select-Object -ExpandProperty files |
+  Select-Object path, additions, deletions, status
+```
+
+```bash
+# Linux / macOS
+gh pr view <number> --json files | python3 -c \
+  "import json,sys; [print(f['path'], f['additions'], f['deletions']) for f in json.load(sys.stdin)['files']]"
+```
+
+---
+
+## Step 2 — Compute line numbers for inline comments
+
+GitHub inline comments require the **line number in the resulting file** (after the
+diff is applied). The algorithm:
+
+1. When a `@@` hunk header is encountered, extract the `+N` value — the first line of
+   the hunk in the new file. Initialize `counter = N - 1`.
+2. For each subsequent line in the hunk:
+   - Line starts with `+` (added): `counter++` → **valid target**
+   - Line starts with ` ` (context): `counter++` → **valid target**
+   - Line starts with `-` (removed): **do not increment** — this line no longer exists
+     in the new file and **cannot** be targeted by an inline comment.
+3. The counter value after processing a line is that line's number in the resulting file.
+
+---
+
+## Step 3 — Verify each line number before reporting
+
+**Always run the algorithm in a terminal** for each finding. Do not estimate or compute mentally.
+
+```powershell
+# Windows (PowerShell)
+$diff = Get-Content "$env:TEMP/pr<number>.diff" -Encoding utf8
+$inFile = $false; $lineNum = 0
+foreach ($line in $diff) {
+    if ($line -match "^diff --git") {
+        $inFile = $line -match "YourFile\.java"
+        $lineNum = 0
+    }
+    if ($inFile) {
+        if ($line -match "^@@") {
+            $m = [regex]::Match($line, '\+(\d+)')
+            if ($m.Success) { $lineNum = [int]$m.Groups[1].Value - 1 }
+        } elseif ($line -match "^\+") { $lineNum++ }
+        elseif ($line -match "^ ")  { $lineNum++ }
+        # -: do not increment
+        if ($line -match "pattern to find") {
+            Write-Host "L$lineNum [$line]"
+        }
+    }
+}
+```
+
+```bash
+# Linux / macOS
+awk '
+  /^diff --git/ { in_file = ($0 ~ "YourFile\.java"); line_num = 0 }
+  in_file && /^@@/ { match($0, /\+([0-9]+)/, a); line_num = a[1] - 1 }
+  in_file && /^\+/ { line_num++ }
+  in_file && /^ /  { line_num++ }
+  in_file && /pattern to find/ { print "L" line_num " [" $0 "]" }
+' /tmp/pr<number>.diff
+```
+
+**Before including any line in the findings table**: confirm the output shows a `+` or ` `
+line. A `-` line or a line not present in the diff cannot be targeted — GitHub will
+reject the comment silently.
+
+---
+
+## Step 4 — Present findings, then branch on user response
+
+Present all findings to the user in a table:
+
+| # | File | Line | Severity | Comment (raw) |
+|---|------|------|----------|---------------|
+| 1 | `path/to/File.java` | L42 | 🔴 HIGH | Comment text ready to paste |
+
+Severity scale: 🔴 HIGH (blocking) · 🟡 MEDIUM · 🔵 LOW (nit).
+
+**Then wait for the user's response and branch:**
+
+### Branch A — User wants clarifications
+
+Answer questions and refine findings. Do **not** post anything yet.
+Return to this step when the user is ready.
+
+### Branch B — User confirms: post the review
+
+Submit all inline comments in a **single** API call. Do not post without explicit
+user confirmation — this is an irreversible action on a shared system.
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<number>/reviews \
+  --method POST \
+  --field event=COMMENT \
+  --field "comments[][path]=src/main/java/io/naftiko/Foo.java" \
+  --field "comments[][line]=42" \
+  --field "comments[][body]=Your comment here." \
+  --field "comments[][path]=src/main/resources/schemas/naftiko-schema.json" \
+  --field "comments[][line]=2586" \
+  --field "comments[][body]=Another comment."
+```
+
+Use `event=COMMENT` for a non-approving review.
+Use `event=REQUEST_CHANGES` when at least one finding is blocking (🔴 HIGH).
+Use `event=APPROVE` only when explicitly asked to approve the PR.
+
+Retrieve owner/repo from the local git remote if not known:
+
+```bash
+gh repo view --json nameWithOwner -q .nameWithOwner
+```
+
+After posting, verify the review was accepted:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<number>/reviews --jq '.[-1] | {id, state, submitted_at, body}'
+```
+
+Then check that all expected inline comments are present:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<number>/comments --jq '[.[] | {path, line, body}]'
+```
+
+GitHub silently drops comments that target a line outside the diff or with a malformed
+`path` — the review POST returns HTTP 200 even in that case. Compare the returned
+comment count against the number of findings submitted. If any are missing, identify
+the rejected entry (wrong line number or path mismatch) and report it to the user with
+the corrected values so they can post it manually.

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -85,8 +85,6 @@ foreach ($line in $diff) {
             $inHunk = $true
             $m = [regex]::Match($line, '\+(\d+)')
             if ($m.Success) { $lineNum = [int]$m.Groups[1].Value - 1 }
-        } elseif ($line -match "^\+\+\+" -or $line -match "^---") {
-            # diff header lines — do not increment
         } elseif ($inHunk -and $line -match "^\+") { $lineNum++ }
         elseif ($inHunk -and $line -match "^ ")  { $lineNum++ }
         # -: do not increment
@@ -105,7 +103,6 @@ awk '
     if (match($0, /\+[0-9]+/)) line_num = substr($0, RSTART + 1, RLENGTH - 1) - 1
     in_hunk = 1
   }
-  in_file && in_hunk && /^\+\+\+/ { next }
   in_file && in_hunk && /^\+/ { line_num++ }
   in_file && in_hunk && /^ /  { line_num++ }
   in_file && in_hunk && !/^-/ && /pattern to find/ { print "L" line_num " [" $0 "]" }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow. Key rules:
 - Always read the repository templates before creating issues or PRs:
   - Issues: `.github/ISSUE_TEMPLATE/` — use the matching template and fill in all required fields
   - PRs: `.github/PULL_REQUEST_TEMPLATE.md` — follow the structure exactly, do not improvise
+- When asked to review a PR, load and follow the `pr-review` skill in `.agents/skills/pr-review/` before doing anything else
 - Do **not** use `git push --force` — use `--force-with-lease`
 - When the user corrects a mistake, note it immediately so the insight is not lost — see [Self-Improvement](#self-improvement)
 - When the workflow is complete, review any noted corrections and propose rule updates if warranted


### PR DESCRIPTION
## Related Issue

Closes #360

---

## What does this PR do?

Adds an on-demand `pr-review` skill at `.agents/skills/pr-review/SKILL.md` that packages the full GitHub PR review workflow for the agent:

1. Fetch and save the diff locally (`gh pr diff`)
2. Compute exact line numbers using the hunk counter algorithm (`+N` from `@@`, increment on `+` / context lines, skip on `-`)
3. Mandatory terminal verification of each line before reporting (PowerShell + `awk` variants for cross-platform support)
4. Present findings table to user, then branch: clarification (A) or confirmation to post (B)
5. Submit review via a single `gh api .../pulls/<n>/reviews` POST, then verify no comments were silently dropped

Also adds a single pointer bullet in `AGENTS.md` Contribution Workflow so the skill is discovered and loaded on demand instead of inlining the workflow in the always-loaded context.

---

## Tests

Documentation-only change — no production code modified. No `mvn test` required.

Manual verification: in a fresh chat, asking "review PR #X" matches the skill's trigger phrases and loads the skill before any other action.

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main`
- [ ] Small and focused — one concern per PR
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: claude-sonnet-4-6
tool: VS Code Copilot Chat
confidence: high
source_event: PR review session (PR #343) — wrong line number observed (L573 vs actual L2586)
discovery_method: runtime_observation
review_focus: .agents/skills/pr-review/SKILL.md, AGENTS.md
```
