### PR TITLE
feat: improve pr-review skill

### DIFF
--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -213,7 +213,28 @@ Return to this step when the user is ready.
 Submit all inline comments in a **single** API call. Do not post without explicit
 user confirmation — this is an irreversible action on a shared system.
 
+> **PowerShell — backtick hazard in `--field` strings**
+> In PowerShell double-quoted strings (`"..."`), the backtick `` ` `` is an escape
+> character: `` `e `` → ESC, `` `n `` → newline, `` `t `` → tab, etc. Comment bodies
+> that contain Markdown inline code (e.g. `` `engine.exposes` ``) will be silently
+> corrupted before reaching the API (`` `e `` becomes ESC, rendering as `→ngine.exposes`
+> on GitHub). Always use **single-quoted strings** for `--field` body values on Windows.
+
+```powershell
+# Windows (PowerShell) — use single quotes for body values to avoid backtick expansion
+gh api repos/{owner}/{repo}/pulls/<number>/reviews `
+  --method POST `
+  --field event=COMMENT `
+  --field 'comments[][path]=src/main/java/io/naftiko/Foo.java' `
+  --field 'comments[][line]=42' `
+  --field 'comments[][body]=Your comment here, safe to use `backticks` in single quotes.' `
+  --field 'comments[][path]=src/main/resources/schemas/naftiko-schema.json' `
+  --field 'comments[][line]=2586' `
+  --field 'comments[][body]=Another comment.'
+```
+
 ```bash
+# Linux / macOS
 gh api repos/{owner}/{repo}/pulls/<number>/reviews \
   --method POST \
   --field event=COMMENT \

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -26,17 +26,17 @@ Before fetching the diff, check whether the PR already has reviews or inline com
 
 ```powershell
 # Windows (PowerShell)
-gh api repos/{owner}/{repo}/pulls/<number>/reviews `
+gh api repos/{owner}/{repo}/pulls/<number>/reviews --paginate `
   --jq '[.[] | {id, state, submitted_at, user: .user.login, body: .body[:80]}]'
-gh api repos/{owner}/{repo}/pulls/<number>/comments `
+gh api repos/{owner}/{repo}/pulls/<number>/comments --paginate `
   --jq '[.[] | {id, path, line, user: .user.login, outdated}]'
 ```
 
 ```bash
 # Linux / macOS
-gh api repos/{owner}/{repo}/pulls/<number>/reviews \
+gh api repos/{owner}/{repo}/pulls/<number>/reviews --paginate \
   --jq '[.[] | {id, state, submitted_at, user: .user.login, body: .body[:80]}]'
-gh api repos/{owner}/{repo}/pulls/<number>/comments \
+gh api repos/{owner}/{repo}/pulls/<number>/comments --paginate \
   --jq '[.[] | {id, path, line, user: .user.login, outdated}]'
 ```
 
@@ -46,7 +46,7 @@ gh api repos/{owner}/{repo}/pulls/<number>/comments \
 
 > «This PR already has N review(s) and M inline comment(s) (latest state: X, by [reviewers]).
 > How do you want to proceed?
-> - **Continue** — check comments from `CHANGES_REQUESTED` reviews first, skip `outdated` comments, then add net-new findings only.
+> - **Continue** — check `CHANGES_REQUESTED` review bodies and their linked inline comments first, skip `outdated` inline comments, then add net-new findings only.
 > - **Fresh start** — ignore prior review activity and review the full diff from scratch.»
 
 Wait for the user's answer before proceeding.
@@ -56,29 +56,29 @@ Wait for the user's answer before proceeding.
 Join reviews and inline comments to identify which comments belong to a `CHANGES_REQUESTED` review:
 
 ```powershell
-# Step A — get review IDs with CHANGES_REQUESTED state
-gh api repos/{owner}/{repo}/pulls/<number>/reviews `
-  --jq '[.[] | select(.state == "CHANGES_REQUESTED") | {id, user: .user.login}]'
+# Step A — get CHANGES_REQUESTED reviews including their body feedback
+gh api repos/{owner}/{repo}/pulls/<number>/reviews --paginate `
+  --jq '[.[] | select(.state == "CHANGES_REQUESTED") | {id, user: .user.login, body}]'
 
 # Step B — get inline comments including their review linkage
-gh api repos/{owner}/{repo}/pulls/<number>/comments `
+gh api repos/{owner}/{repo}/pulls/<number>/comments --paginate `
   --jq '[.[] | {id, pull_request_review_id, path, line, user: .user.login, body, outdated}]'
 ```
 
 ```bash
 # Step A
-gh api repos/{owner}/{repo}/pulls/<number>/reviews \
-  --jq '[.[] | select(.state == "CHANGES_REQUESTED") | {id, user: .user.login}]'
+gh api repos/{owner}/{repo}/pulls/<number>/reviews --paginate \
+  --jq '[.[] | select(.state == "CHANGES_REQUESTED") | {id, user: .user.login, body}]'
 
 # Step B
-gh api repos/{owner}/{repo}/pulls/<number>/comments \
+gh api repos/{owner}/{repo}/pulls/<number>/comments --paginate \
   --jq '[.[] | {id, pull_request_review_id, path, line, user: .user.login, body, outdated}]'
 ```
 
-Cross-reference: a comment belongs to a `CHANGES_REQUESTED` review when its `pull_request_review_id` matches an ID from Step A.
-
-- Verify each `CHANGES_REQUESTED` comment against the current diff first (is the issue fixed or still present?)
-- Skip comments with `outdated: true` — they target stale code; do not re-raise unless the same defect reappears in current hunks
+Verify both sources against the current diff:
+- **Review bodies** (Step A) — each `CHANGES_REQUESTED` review may contain blocking feedback in its top-level body; verify whether the issue it describes is fixed in the current diff
+- **Inline comments** (Step B) — a comment belongs to a `CHANGES_REQUESTED` review when its `pull_request_review_id` matches an ID from Step A; verify each non-`outdated` one against the current diff
+- Skip inline comments with `outdated: true` — they target stale code; do not re-raise unless the same defect reappears in current hunks
 - After checking those items, scan the diff for net-new findings only
 
 ### If the user chooses **Fresh start**

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -24,6 +24,12 @@ present findings → post only after explicit user confirmation.
 
 Before fetching the diff, check whether the PR already has reviews or inline comments.
 
+Retrieve `{owner}/{repo}` from the local git remote if not known:
+
+```bash
+gh repo view --json nameWithOwner -q .nameWithOwner
+```
+
 ```powershell
 # Windows (PowerShell)
 gh api repos/{owner}/{repo}/pulls/<number>/reviews --paginate `
@@ -90,8 +96,6 @@ Ignore all prior review data. Proceed to Step 2 as if the PR had no prior activi
 ## Step 2 — Fetch and save the diff
 
 Save the diff to a temp file to enable repeated querying without extra API calls.
-
-
 
 ```powershell
 # Windows (PowerShell)
@@ -224,12 +228,6 @@ gh api repos/{owner}/{repo}/pulls/<number>/reviews \
 Use `event=COMMENT` for a non-approving review.
 Use `event=REQUEST_CHANGES` when at least one finding is blocking (🔴 HIGH).
 Use `event=APPROVE` only when explicitly asked to approve the PR.
-
-Retrieve owner/repo from the local git remote if not known:
-
-```bash
-gh repo view --json nameWithOwner -q .nameWithOwner
-```
 
 After posting, verify the review was accepted:
 

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -15,7 +15,7 @@ allowed-tools:
 
 This skill guides the agent through a structured PR review workflow:
 check for existing reviews → offer Continue/Fresh-start choice → fetch the diff →
-compute line numbers accurately → verify each line →
+compute line numbers accurately → verify each line number →
 present findings → post only after explicit user confirmation.
 
 ---
@@ -46,23 +46,40 @@ gh api repos/{owner}/{repo}/pulls/<number>/comments \
 
 > «This PR already has N review(s) and M inline comment(s) (latest state: X, by [reviewers]).
 > How do you want to proceed?
-> - **Continue** — focus on open CHANGES_REQUESTED items, skip already-resolved or outdated comments, then add net-new findings only.
+> - **Continue** — check comments from `CHANGES_REQUESTED` reviews first, skip `outdated` comments, then add net-new findings only.
 > - **Fresh start** — ignore prior review activity and review the full diff from scratch.»
 
 Wait for the user's answer before proceeding.
 
 ### If the user chooses **Continue**
 
-Fetch the full inline comment list and build a filter:
+Join reviews and inline comments to identify which comments belong to a `CHANGES_REQUESTED` review:
 
 ```powershell
+# Step A — get review IDs with CHANGES_REQUESTED state
+gh api repos/{owner}/{repo}/pulls/<number>/reviews `
+  --jq '[.[] | select(.state == "CHANGES_REQUESTED") | {id, user: .user.login}]'
+
+# Step B — get inline comments including their review linkage
 gh api repos/{owner}/{repo}/pulls/<number>/comments `
-  --jq '[.[] | {id, path, line, user: .user.login, body, outdated}]'
+  --jq '[.[] | {id, pull_request_review_id, path, line, user: .user.login, body, outdated}]'
 ```
 
-- Extract open CHANGES_REQUESTED comment bodies → verify each one against the current diff first (is it fixed or still present?)
-- Mark `outdated: true` comments as resolved — do not re-raise unless the same defect reappears in current hunks
-- After checking open items, scan the diff for net-new findings only
+```bash
+# Step A
+gh api repos/{owner}/{repo}/pulls/<number>/reviews \
+  --jq '[.[] | select(.state == "CHANGES_REQUESTED") | {id, user: .user.login}]'
+
+# Step B
+gh api repos/{owner}/{repo}/pulls/<number>/comments \
+  --jq '[.[] | {id, pull_request_review_id, path, line, user: .user.login, body, outdated}]'
+```
+
+Cross-reference: a comment belongs to a `CHANGES_REQUESTED` review when its `pull_request_review_id` matches an ID from Step A.
+
+- Verify each `CHANGES_REQUESTED` comment against the current diff first (is the issue fixed or still present?)
+- Skip comments with `outdated: true` — they target stale code; do not re-raise unless the same defect reappears in current hunks
+- After checking those items, scan the diff for net-new findings only
 
 ### If the user chooses **Fresh start**
 
@@ -73,6 +90,7 @@ Ignore all prior review data. Proceed to Step 2 as if the PR had no prior activi
 ## Step 2 — Fetch and save the diff
 
 Save the diff to a temp file to enable repeated querying without extra API calls.
+
 
 
 ```powershell
@@ -102,7 +120,7 @@ gh pr view <number> --json files | python3 -c \
 
 ---
 
-## Step 2 — Compute line numbers for inline comments
+## Step 3 — Compute line numbers for inline comments
 
 GitHub inline comments require the **line number in the resulting file** (after the
 diff is applied). The algorithm:
@@ -118,7 +136,7 @@ diff is applied). The algorithm:
 
 ---
 
-## Step 3 — Verify each line number before reporting
+## Step 4 — Verify each line number before reporting
 
 **Always run the algorithm in a terminal** for each finding. Do not estimate or compute mentally.
 
@@ -167,7 +185,7 @@ reject the comment silently.
 
 ---
 
-## Step 4 — Present findings, then branch on user response
+## Step 5 — Present findings, then branch on user response
 
 Present all findings to the user in a table:
 

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -195,6 +195,8 @@ Present all findings to the user in a table:
 
 Severity scale: 🔴 HIGH (blocking) · 🟡 MEDIUM · 🔵 LOW (nit).
 
+**All comments must be written in English**, regardless of the language used in the conversation with the user — see AGENTS.md.
+
 **Then wait for the user's response and branch:**
 
 ### Branch A — User wants clarifications

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -14,7 +14,7 @@ allowed-tools:
 ## Overview
 
 This skill guides the agent through a structured PR review workflow:
-check for existing reviews → offer Continue/Fresh-start choice → fetch the diff →
+check for existing reviews → offer Continue/Fresh start choice → fetch the diff →
 compute line numbers accurately → verify each line number →
 present findings → post only after explicit user confirmation.
 
@@ -27,7 +27,7 @@ Before fetching the diff, check whether the PR already has reviews or inline com
 ```powershell
 # Windows (PowerShell)
 gh api repos/{owner}/{repo}/pulls/<number>/reviews --paginate `
-  --jq '[.[] | {id, state, submitted_at, user: .user.login, body: .body[:80]}]'
+  --jq '[.[] | {id, state, submitted_at, user: .user.login, body: (.body // "" | .[:80])}]'
 gh api repos/{owner}/{repo}/pulls/<number>/comments --paginate `
   --jq '[.[] | {id, path, line, user: .user.login, outdated}]'
 ```
@@ -35,7 +35,7 @@ gh api repos/{owner}/{repo}/pulls/<number>/comments --paginate `
 ```bash
 # Linux / macOS
 gh api repos/{owner}/{repo}/pulls/<number>/reviews --paginate \
-  --jq '[.[] | {id, state, submitted_at, user: .user.login, body: .body[:80]}]'
+  --jq '[.[] | {id, state, submitted_at, user: .user.login, body: (.body // "" | .[:80])}]'
 gh api repos/{owner}/{repo}/pulls/<number>/comments --paginate \
   --jq '[.[] | {id, path, line, user: .user.login, outdated}]'
 ```
@@ -75,7 +75,7 @@ gh api repos/{owner}/{repo}/pulls/<number>/comments --paginate \
   --jq '[.[] | {id, pull_request_review_id, path, line, user: .user.login, body, outdated}]'
 ```
 
-Verify both sources against the current diff:
+Fetch the diff in **Step 2**, then use it to verify both sources:
 - **Review bodies** (Step A) — each `CHANGES_REQUESTED` review may contain blocking feedback in its top-level body; verify whether the issue it describes is fixed in the current diff
 - **Inline comments** (Step B) — a comment belongs to a `CHANGES_REQUESTED` review when its `pull_request_review_id` matches an ID from Step A; verify each non-`outdated` one against the current diff
 - Skip inline comments with `outdated: true` — they target stale code; do not re-raise unless the same defect reappears in current hunks

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-review
-version: "1.0.0"
+version: "1.1.0"
 description: >
   On-demand skill for reviewing GitHub Pull Requests and posting inline
   comments via the GitHub API. Activate when the user asks to: review a PR,
@@ -14,14 +14,66 @@ allowed-tools:
 ## Overview
 
 This skill guides the agent through a structured PR review workflow:
-fetch the diff → compute line numbers accurately → verify each line →
+check for existing reviews → offer Continue/Fresh-start choice → fetch the diff →
+compute line numbers accurately → verify each line →
 present findings → post only after explicit user confirmation.
 
 ---
 
-## Step 1 — Fetch and save the diff
+## Step 1 — Check for existing review activity
+
+Before fetching the diff, check whether the PR already has reviews or inline comments.
+
+```powershell
+# Windows (PowerShell)
+gh api repos/{owner}/{repo}/pulls/<number>/reviews `
+  --jq '[.[] | {id, state, submitted_at, user: .user.login, body: .body[:80]}]'
+gh api repos/{owner}/{repo}/pulls/<number>/comments `
+  --jq '[.[] | {id, path, line, user: .user.login, outdated}]'
+```
+
+```bash
+# Linux / macOS
+gh api repos/{owner}/{repo}/pulls/<number>/reviews \
+  --jq '[.[] | {id, state, submitted_at, user: .user.login, body: .body[:80]}]'
+gh api repos/{owner}/{repo}/pulls/<number>/comments \
+  --jq '[.[] | {id, path, line, user: .user.login, outdated}]'
+```
+
+**If no reviews and no inline comments exist** → proceed directly to Step 2.
+
+**If reviews or comments already exist**, summarize what was found and ask the user:
+
+> «This PR already has N review(s) and M inline comment(s) (latest state: X, by [reviewers]).
+> How do you want to proceed?
+> - **Continue** — focus on open CHANGES_REQUESTED items, skip already-resolved or outdated comments, then add net-new findings only.
+> - **Fresh start** — ignore prior review activity and review the full diff from scratch.»
+
+Wait for the user's answer before proceeding.
+
+### If the user chooses **Continue**
+
+Fetch the full inline comment list and build a filter:
+
+```powershell
+gh api repos/{owner}/{repo}/pulls/<number>/comments `
+  --jq '[.[] | {id, path, line, user: .user.login, body, outdated}]'
+```
+
+- Extract open CHANGES_REQUESTED comment bodies → verify each one against the current diff first (is it fixed or still present?)
+- Mark `outdated: true` comments as resolved — do not re-raise unless the same defect reappears in current hunks
+- After checking open items, scan the diff for net-new findings only
+
+### If the user chooses **Fresh start**
+
+Ignore all prior review data. Proceed to Step 2 as if the PR had no prior activity.
+
+---
+
+## Step 2 — Fetch and save the diff
 
 Save the diff to a temp file to enable repeated querying without extra API calls.
+
 
 ```powershell
 # Windows (PowerShell)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow. Key rules:
 - Always read the repository templates before creating issues or PRs:
   - Issues: `.github/ISSUE_TEMPLATE/` — use the matching template and fill in all required fields
   - PRs: `.github/PULL_REQUEST_TEMPLATE.md` — follow the structure exactly, do not improvise
-- When creating issues or PRs with multiline bodies via `gh`, **never use PowerShell here-strings** (`@"..."@`) — they hang waiting for the closing delimiter in the VS Code terminal. Always write the body to a temp file with `create_file` and pass it via `--body-file "$env:TEMP\filename.md"`
+- When creating issues or PRs with multiline bodies via `gh`, **never use PowerShell here-strings** (`@"..."@`) — they hang waiting for the closing delimiter in the VS Code terminal. Always write the body to a temp `.md` file (e.g. `Set-Content -Path "$env:TEMP\gh-body.md" -Encoding utf8 -Value $body`) and pass it via `--body-file "$env:TEMP\gh-body.md"`
 - When asked to review a PR, load and follow the `pr-review` skill in `.agents/skills/pr-review/` before doing anything else
 - Do **not** use `git push --force` — use `--force-with-lease`
 - When the user corrects a mistake, note it immediately so the insight is not lost — see [Self-Improvement](#self-improvement)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow. Key rules:
 - Always read the repository templates before creating issues or PRs:
   - Issues: `.github/ISSUE_TEMPLATE/` — use the matching template and fill in all required fields
   - PRs: `.github/PULL_REQUEST_TEMPLATE.md` — follow the structure exactly, do not improvise
+- When creating issues or PRs with multiline bodies via `gh`, **never use PowerShell here-strings** (`@"..."@`) — they hang waiting for the closing delimiter in the VS Code terminal. Always write the body to a temp file with `create_file` and pass it via `--body-file "$env:TEMP\filename.md"`
 - When asked to review a PR, load and follow the `pr-review` skill in `.agents/skills/pr-review/` before doing anything else
 - Do **not** use `git push --force` — use `--force-with-lease`
 - When the user corrects a mistake, note it immediately so the insight is not lost — see [Self-Improvement](#self-improvement)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,7 @@ When designing or modifying a Capability:
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow. Key rules:
 
 - Open an Issue before starting work
+- **All GitHub interactions must be in English** — issues, PR titles/bodies, inline review comments, and commit messages. The codebase and its community are English-first.
 - Branch from `main`: `feat/`, `fix/`, or `chore/` prefix
 - Use [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `chore:` — no scopes for now
 - AGENTS.md improvements are `feat:`, not `chore:` — they add value to the agent workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow. Key rules:
   - PRs: `.github/PULL_REQUEST_TEMPLATE.md` — follow the structure exactly, do not improvise
 - When creating issues or PRs with multiline bodies via `gh`, **never use PowerShell here-strings** (`@"..."@`) — they hang waiting for the closing delimiter in the VS Code terminal. Always write the body to a temp `.md` file (e.g. `Set-Content -Path "$env:TEMP\gh-body.md" -Encoding utf8 -Value $body`) and pass it via `--body-file "$env:TEMP\gh-body.md"`
 - When asked to review a PR, load and follow the `pr-review` skill in `.agents/skills/pr-review/` before doing anything else
+- When editing a documentation, skill, or instruction file (`.md`, `SKILL.md`, `AGENTS.md`), re-read the **entire file** after applying edits and before committing — to catch terminology drift, broken cross-references, and inconsistencies between sections that targeted edits cannot detect
 - Do **not** use `git push --force` — use `--force-with-lease`
 - When the user corrects a mistake, note it immediately so the insight is not lost — see [Self-Improvement](#self-improvement)
 - When the workflow is complete, review any noted corrections and propose rule updates if warranted

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow. Key rules:
   - PRs: `.github/PULL_REQUEST_TEMPLATE.md` — follow the structure exactly, do not improvise
 - When creating issues or PRs with multiline bodies via `gh`, **never use PowerShell here-strings** (`@"..."@`) — they hang waiting for the closing delimiter in the VS Code terminal. Always write the body to a temp `.md` file (e.g. `Set-Content -Path "$env:TEMP\gh-body.md" -Encoding utf8 -Value $body`) and pass it via `--body-file "$env:TEMP\gh-body.md"`
 - When asked to review a PR, load and follow the `pr-review` skill in `.agents/skills/pr-review/` before doing anything else
-- When editing a documentation, skill, or instruction file (`.md`, `SKILL.md`, `AGENTS.md`), re-read the **entire file** after applying edits and before committing — to catch terminology drift, broken cross-references, and inconsistencies between sections that targeted edits cannot detect
+- When editing documentation, skill, or instruction files (`.md`, `SKILL.md`, `AGENTS.md`), re-read the **entire file** after applying edits and before committing — to catch terminology drift, broken cross-references, and inconsistencies between sections that targeted edits cannot detect
 - Do **not** use `git push --force` — use `--force-with-lease`
 - When the user corrects a mistake, note it immediately so the insight is not lost — see [Self-Improvement](#self-improvement)
 - When the workflow is complete, review any noted corrections and propose rule updates if warranted


### PR DESCRIPTION
## Related Issue

Closes #363

---

## What does this PR do?

The `pr-review` skill jumped straight into diff analysis even when the PR already had reviews and inline comments. This caused the agent to re-raise already-flagged findings, miss open `CHANGES_REQUESTED` blockers, and treat outdated comments as active issues.

This PR inserts a **Step 1** before fetching the diff that:
1. Fetches existing reviews (`/reviews`) and inline comments (`/comments`)
2. If no prior activity exists, proceeds directly to Step 2 — no change in behaviour
3. If prior activity exists, summarizes it and asks the user to choose:
   - **Continue** — verify open `CHANGES_REQUESTED` items against the current diff first, skip resolved/outdated comments, then add net-new findings
   - **Fresh start** — ignore all prior review data and review the full diff from scratch

Also bumps the skill version to `1.1.0` and updates the Overview description.

---

## Tests

No automated tests — this is a skill (agent workflow instruction file, not production code). The updated workflow was exercised on PR #343 during this session, which is what motivated the change.

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Claude Sonnet 4.6
tool: VS Code Copilot Chat
confidence: high
source_event: user_correction
discovery_method: runtime_observation
review_focus: .agents/skills/pr-review/SKILL.md
```
