### PR TITLE
chore: sync pom.xml version to vscode package.json version

### DIFF
--- a/.github/workflows/synchronize-naftiko-version.yml
+++ b/.github/workflows/synchronize-naftiko-version.yml
@@ -139,3 +139,60 @@ jobs:
             Updated files:
             - `templates/skeletons/capabilities/*.naftiko.yml`
           delete-branch: true
+
+  sync-vscode-version:
+    runs-on: ubuntu-latest
+    needs: sync-backstage-version
+
+    steps:
+      - name: Checkout framework
+        uses: actions/checkout@v4
+        with:
+          path: framework
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Checkout vscode
+        uses: actions/checkout@v4
+        with:
+          repository: naftiko/vscode
+          token: ${{ secrets.VSCODE_CONTENTS_WRITE_PR_WRITE }}
+          path: vscode
+
+      - name: Sync Naftiko version to vscode
+        id: sync
+        run: |
+          VERSION=$(python3 framework/src/main/resources/scripts/sync-naftiko-version-to-vscode.py \
+            --pom framework/pom.xml \
+            --target vscode/extensions/naftiko-vscode/package.json)
+          echo "value=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Check for changes
+        id: git-check
+        working-directory: vscode
+        run: |
+          if git diff --quiet; then
+            echo "changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Pull Request
+        if: steps.git-check.outputs.changes == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.VSCODE_CONTENTS_WRITE_PR_WRITE }}
+          path: vscode
+          base: main
+          branch: "chore/sync-naftiko-version"
+          commit-message: "chore: sync Naftiko version to ${{ steps.sync.outputs.value }} [skip ci]"
+          title: "chore: sync Naftiko version to ${{ steps.sync.outputs.value }}"
+          body: |
+            Automated sync from [framework@${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}).
+
+            Updated files:
+            - `extensions/naftiko-vscode/package.json`
+          delete-branch: true

--- a/src/main/resources/scripts/sync-naftiko-version-to-vscode.py
+++ b/src/main/resources/scripts/sync-naftiko-version-to-vscode.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""
+Script to synchronize the Naftiko version from pom.xml into the VS Code extension package.json.
+"""
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).parent))
+from naftiko_version import extract_version_from_pom
+
+
+def update_package_json_version(file_path, new_version):
+    """Updates the version field in a package.json file."""
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+
+        if data.get("version") == new_version:
+            return False
+
+        data["version"] = new_version
+
+        with open(file_path, 'w', encoding='utf-8') as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+            f.write('\n')
+
+        return True
+
+    except Exception as e:
+        print(f"✗ Error while updating {file_path}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Sync Naftiko version to VS Code extension package.json")
+    parser.add_argument("--pom", required=True, help="Path to framework pom.xml")
+    parser.add_argument("--target", required=True, help="Path to extensions/naftiko-vscode/package.json")
+    args = parser.parse_args()
+
+    version = extract_version_from_pom(args.pom)
+
+    target = Path(args.target)
+    if update_package_json_version(target, version):
+        print(f"   ✓ {target}", file=sys.stderr)
+    else:
+        print(f"   - {target} (no change)", file=sys.stderr)
+
+    # Output clean version for workflow capture
+    print(version)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Related Issue

No specific issue. Part of fleet#52

---

## What does this PR do?

Add a ne job to the existing GitHub action synchronize-naftiko-version.yml. Similarly to what is done for backstage, this new job gets the version from pom.xml and update the vscode extension package.json with it.

---

## Tests

No specific test

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main`
- [ ] Small and focused — one concern per PR
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

<!-- If this PR was created or assisted by an AI agent, provide metadata below (YAML) -->

```yaml
# agent_name:
# llm:
# tool:
# confidence:          # low | medium | high
# source_event:
# discovery_method:    # runtime_observation | code_review | test_failure | user_report
# review_focus:        # e.g. ClassName.java:line-range
```
