### PR TITLE
fix: patch in builder script

### DIFF
--- a/src/main/resources/scripts/builder.sh
+++ b/src/main/resources/scripts/builder.sh
@@ -36,9 +36,14 @@ config_gpg(){
   mkdir -p ~/.gnupg/
   chmod 700 ~/.gnupg/
   
-  print "${GPG_SIGNING_KEY}" | base64 --decode > ~/.gnupg/private.key
+  echo "${GPG_SIGNING_KEY}" > ~/.gnupg/private.key
   chmod 600 ~/.gnupg/private.key
-  gpg --batch --import ~/.gnupg/private.key
+  
+  if ! gpg --batch --import ~/.gnupg/private.key 2>/dev/null; then
+    println "ERROR: Failed to import GPG key. Ensure it's in ASCII armor format."
+    println "Expected format: -----BEGIN PGP PRIVATE KEY BLOCK-----"
+    exit 201
+  fi
   
   cat <<EOF > ~/.gnupg/gpg.conf
 use-agent


### PR DESCRIPTION
## Related Issue

No Related Issue

---

## What does this PR do?

A small patch in builder script because using ASCII armor directly is simpler and it's the standard GPG format.

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)


