### PR TITLE
fest: add modeline in header of generated capability files

### DIFF
--- a/src/main/java/io/naftiko/cli/ImportOpenApiCommand.java
+++ b/src/main/java/io/naftiko/cli/ImportOpenApiCommand.java
@@ -13,6 +13,7 @@
  */
 package io.naftiko.cli;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.Callable;
@@ -126,7 +127,13 @@ public class ImportOpenApiCommand implements Callable<Integer> {
             spec.getConsumes().add(httpClient);
 
             Path path = Paths.get(outputPath);
-            mapper.writeValue(path.toFile(), spec);
+            if ("json".equalsIgnoreCase(format)) {
+                mapper.writeValue(path.toFile(), spec);
+            } else {
+                String yaml = mapper.writeValueAsString(spec);
+                // Add modeline header to be sure the file will be recognized by Naftiko VS Code extension
+                Files.writeString(path, "# @naftiko\n---\n" + yaml);
+            }
 
             System.out.println("✓ Imported OpenAPI specification successfully");
             System.out.println("  Output: " + path.toAbsolutePath());

--- a/src/main/resources/templates/capability.yaml.mustache
+++ b/src/main/resources/templates/capability.yaml.mustache
@@ -1,3 +1,5 @@
+# @naftiko
+---
 naftiko: "{{version}}"
 info:
   label: "{{capabilityName}}"

--- a/src/test/java/io/naftiko/cli/FileGeneratorTest.java
+++ b/src/test/java/io/naftiko/cli/FileGeneratorTest.java
@@ -40,6 +40,7 @@ public class FileGeneratorTest {
 
             String yamlContent = Files.readString(yaml);
 
+            assertTrue(yamlContent.startsWith("# @naftiko\n---\n"), "Output should start with Naftiko modeline header");
             assertTrue(yamlContent.contains(capabilityName));
             assertTrue(yamlContent.contains("https://api.example.com"));
             assertTrue(yamlContent.contains("8080"));

--- a/src/test/java/io/naftiko/cli/ImportOpenApiCommandTest.java
+++ b/src/test/java/io/naftiko/cli/ImportOpenApiCommandTest.java
@@ -64,6 +64,7 @@ public class ImportOpenApiCommandTest {
         assertEquals(0, exitCode);
         assertTrue(Files.exists(output));
         String content = Files.readString(output);
+        assertTrue(content.startsWith("# @naftiko\n---\n"), "Output should start with Naftiko modeline header");
         assertTrue(content.contains("petstore"));
     }
 
@@ -87,6 +88,7 @@ public class ImportOpenApiCommandTest {
         assertEquals(0, exitCode);
         assertTrue(Files.exists(output));
         String content = Files.readString(output);
+        assertTrue(content.startsWith("# @naftiko\n---\n"), "Output should start with Naftiko modeline header");
         assertTrue(content.contains("my-custom-ns"));
     }
 
@@ -172,6 +174,7 @@ public class ImportOpenApiCommandTest {
         String content = Files.readString(output);
         assertTrue(content.contains("petstore"), "Namespace should be derived from Swagger 2.0 title");
         assertTrue(content.contains("list-pets"), "Operation should be converted from Swagger 2.0");
+        assertTrue(content.startsWith("# @naftiko\n---\n"), "Output should start with Naftiko modeline header");
     }
 
     @Test
@@ -207,6 +210,7 @@ public class ImportOpenApiCommandTest {
         assertTrue(content.contains("https://api.legacy.io/v2"),
                 "Base URI should be derived from Swagger 2.0 host + basePath");
         assertTrue(content.contains("my-legacy-api"), "Namespace should be kebab-cased title");
+        assertTrue(content.startsWith("# @naftiko\n---\n"), "Output should start with Naftiko modeline header");
     }
 
     @Test
@@ -256,6 +260,7 @@ public class ImportOpenApiCommandTest {
         String content = Files.readString(output);
         assertTrue(content.contains("create-item"), "Operation name should be converted");
         assertTrue(content.contains("name"), "Body parameter 'name' should be present");
+        assertTrue(content.startsWith("# @naftiko\n---\n"), "Output should start with Naftiko modeline header");
     }
 
     @Test
@@ -276,6 +281,7 @@ public class ImportOpenApiCommandTest {
 
         String content = Files.readString(output);
         assertFalse(content.isBlank(), "Output should not be blank");
+        assertTrue(content.startsWith("# @naftiko\n---\n"), "Output should start with Naftiko modeline header");
         assertTrue(content.contains("naftiko:"), "Output should contain naftiko version");
         assertTrue(content.contains("consumes:"), "Output should contain consumes section");
         assertTrue(content.contains("swagger-petstore"), "Namespace should be derived from title");


### PR DESCRIPTION
## Related Issue

Closes fleet#11

---

## What does this PR do?

When generating a capability file with the CLI, either with `create` or `import`, a header comment with the VSCode extension modeline is added. This way the VSCode extension will be able to recognize and lint/validate the file.

---

## Tests

Appropriate tests have been updated

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main`
- [ ] Small and focused — one concern per PR
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

<!-- If this PR was created or assisted by an AI agent, provide metadata below (YAML) -->

```yaml
# agent_name:
# llm:
# tool:
# confidence:          # low | medium | high
# source_event:
# discovery_method:    # runtime_observation | code_review | test_failure | user_report
# review_focus:        # e.g. ClassName.java:line-range
```
