### PR TITLE
feat: add linux arm 64 Cli build

### DIFF
--- a/.github/workflows/publish-cli-bin.yml
+++ b/.github/workflows/publish-cli-bin.yml
@@ -17,6 +17,10 @@ jobs:
           - os: ubuntu-latest
             artifact_name: naftiko-cli-linux-amd64
             
+          # Linux ARM64
+          - os: ubuntu-24.04-arm
+            artifact_name: naftiko-cli-linux-arm64
+            
           # macOS Apple Silicon (ARM64)
           - os: macos-latest  # macos-14+ uses Mx runners
             artifact_name: naftiko-cli-macos-arm64
@@ -75,6 +79,8 @@ jobs:
         include:
           - os: ubuntu-latest
             artifact_name: naftiko-cli-linux-amd64
+          - os: ubuntu-24.04-arm
+            artifact_name: naftiko-cli-linux-arm64
           - os: macos-latest
             artifact_name: naftiko-cli-macos-arm64
           - os: windows-latest


### PR DESCRIPTION
## Related Issue

Part of shipyard#1

---

## What does this PR do?

Add the linux arm 64 plateform when building the CLI.

---

## Tests

Add this new CLI version to the CI tests.

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main`
- [ ] Small and focused — one concern per PR
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

<!-- If this PR was created or assisted by an AI agent, provide metadata below (YAML) -->

```yaml
# agent_name:
# llm:
# tool:
# confidence:          # low | medium | high
# source_event:
# discovery_method:    # runtime_observation | code_review | test_failure | user_report
# review_focus:        # e.g. ClassName.java:line-range
```
