### PR TITLE
fix: manage windows return line encoding

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,10 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# Force LF for template and config files — prevents \r\n on Windows CI from breaking line-ending-sensitive tests
+*.mustache text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.sh text eol=lf

--- a/src/main/java/io/naftiko/cli/FileGenerator.java
+++ b/src/main/java/io/naftiko/cli/FileGenerator.java
@@ -18,6 +18,7 @@ import com.samskivert.mustache.Template;
 import io.naftiko.util.VersionHelper;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -39,7 +40,8 @@ public class FileGenerator {
         }
         
         // Render template and write file.
-        Template mustache = Mustache.compiler().compile(new InputStreamReader(templateStream));
+        Template mustache = Mustache.compiler()
+            .compile(new InputStreamReader(templateStream, StandardCharsets.UTF_8));
         Map<String, Object> scope = new HashMap<>();
         scope.put("version", VersionHelper.getSchemaVersion());
         scope.put("capabilityName", capabilityName);
@@ -47,7 +49,7 @@ public class FileGenerator {
         scope.put("baseUri", baseUri);
         scope.put("path", "{{path}}"); // Let this keyword as is.
         Path outputPath = Paths.get(outputFileName);
-        try (Writer writer = Files.newBufferedWriter(outputPath)) {
+        try (Writer writer = new OutputStreamWriter(Files.newOutputStream(outputPath), StandardCharsets.UTF_8)) {
             mustache.execute(scope, writer);
             writer.flush();
         }


### PR DESCRIPTION
## Related Issue

No specific issue

---

## What does this PR do?

Manage the return line encoding on windows. And fix the tests (when testing file generated by windows CLI)

---

## Tests

Adapt existing tests

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main`
- [ ] Small and focused — one concern per PR
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

<!-- If this PR was created or assisted by an AI agent, provide metadata below (YAML) -->

```yaml
# agent_name:
# llm:
# tool:
# confidence:          # low | medium | high
# source_event:
# discovery_method:    # runtime_observation | code_review | test_failure | user_report
# review_focus:        # e.g. ClassName.java:line-range
```
