### PR TITLE
fix: add description field in importedHttpConsumes

### DIFF
--- a/src/main/java/io/naftiko/spec/consumes/http/ImportedConsumesHttpSpec.java
+++ b/src/main/java/io/naftiko/spec/consumes/http/ImportedConsumesHttpSpec.java
@@ -37,6 +37,9 @@ public class ImportedConsumesHttpSpec extends ClientSpec {
     @JsonProperty("as")
     private volatile String alias;
 
+    @JsonProperty("description")
+    private volatile String description;
+
     public ImportedConsumesHttpSpec() {
         super(null, null);
     }
@@ -46,6 +49,14 @@ public class ImportedConsumesHttpSpec extends ClientSpec {
         this.location = location;
         this.importNamespace = importNamespace;
         this.alias = alias;
+    }
+
+    public ImportedConsumesHttpSpec(String location, String importNamespace, String alias, String description) {
+        super("http", null);
+        this.location = location;
+        this.importNamespace = importNamespace;
+        this.alias = alias;
+        this.description = description;
     }
 
     public String getLocation() {
@@ -70,6 +81,14 @@ public class ImportedConsumesHttpSpec extends ClientSpec {
 
     public void setAlias(String alias) {
         this.alias = alias;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
     }
 
     /**

--- a/src/main/resources/schemas/naftiko-schema.json
+++ b/src/main/resources/schemas/naftiko-schema.json
@@ -73,6 +73,10 @@
         "as": {
           "$ref": "#/$defs/IdentifierKebab",
           "description": "Optional local alias. When set, the imported adapter is referenced as `as` instead of `import` in `call`, `with`, and `ForwardConfig.targetNamespace`."
+        },
+        "description": {
+          "type": "string",
+          "description": "Human- and agent-readable description of this upstream API. Explain what the API does, its domain (e.g. project management, code hosting), and any important constraints. Agents use this to decide which adapter to call."
         }
       },
       "required": [

--- a/src/test/java/io/naftiko/spec/consumes/http/ClientSpecDeserializerTest.java
+++ b/src/test/java/io/naftiko/spec/consumes/http/ClientSpecDeserializerTest.java
@@ -102,4 +102,35 @@ public class ClientSpecDeserializerTest {
         ImportedConsumesHttpSpec imported = (ImportedConsumesHttpSpec) result;
         assertEquals("", imported.getAlias());
     }
+
+    @Test
+    public void testDeserializeImportedConsumesWithDescriptionShouldPopulateDescriptionField() throws Exception {
+        String yaml = """
+            type: "http"
+            location: "./api.yml"
+            import: "myapi"
+            description: "Manages project tasks and issues."
+            """;
+
+        ClientSpec result = mapper.readValue(yaml, ClientSpec.class);
+
+        assertTrue(result instanceof ImportedConsumesHttpSpec);
+        ImportedConsumesHttpSpec imported = (ImportedConsumesHttpSpec) result;
+        assertEquals("Manages project tasks and issues.", imported.getDescription());
+    }
+
+    @Test
+    public void testDeserializeImportedConsumesWithoutDescriptionShouldLeaveDescriptionNull() throws Exception {
+        String yaml = """
+            type: "http"
+            location: "./api.yml"
+            import: "myapi"
+            """;
+
+        ClientSpec result = mapper.readValue(yaml, ClientSpec.class);
+
+        assertTrue(result instanceof ImportedConsumesHttpSpec);
+        ImportedConsumesHttpSpec imported = (ImportedConsumesHttpSpec) result;
+        assertNull(imported.getDescription());
+    }
 }


### PR DESCRIPTION
## Related Issue

No related issue

---

## What does this PR do?

Add optional description filed in importedHttpConsumes as it is already the case in httpConsumes

---

## Tests

Add 2 unit tests.

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main`
- [ ] Small and focused — one concern per PR
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

<!-- If this PR was created or assisted by an AI agent, provide metadata below (YAML) -->

```yaml
# agent_name:
# llm:
# tool:
# confidence:          # low | medium | high
# source_event:
# discovery_method:    # runtime_observation | code_review | test_failure | user_report
# review_focus:        # e.g. ClassName.java:line-range
```
