### PR TITLE
fix: Change release event type from 'created' to 'published'

### DIFF
--- a/.github/workflows/publish-mvn-release-ghcr.yml
+++ b/.github/workflows/publish-mvn-release-ghcr.yml
@@ -1,7 +1,7 @@
 name: Publish MVN Release to GitHub Packages
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   publish:


### PR DESCRIPTION
## Related Issue

No Related Issue

---

## What does this PR do?

patches the trigger on the publish mvn to GHCR

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

