### PR TITLE
feat: add Javadoc package descriptions for all packages

### DIFF
--- a/src/main/java/io/naftiko/cli/package-info.java
+++ b/src/main/java/io/naftiko/cli/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Command-line interface providing subcommands for capability creation, validation, OpenAPI
+ * import/export, and runtime management (health, status, traces, metrics, scripting).
+ */
+package io.naftiko.cli;

--- a/src/main/java/io/naftiko/engine/aggregates/package-info.java
+++ b/src/main/java/io/naftiko/engine/aggregates/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Runtime representation of domain aggregates — reusable operation functions that can be
+ * referenced by multiple exposed adapters, with function result encapsulation and ref resolution.
+ */
+package io.naftiko.engine.aggregates;

--- a/src/main/java/io/naftiko/engine/consumes/http/package-info.java
+++ b/src/main/java/io/naftiko/engine/consumes/http/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * HTTP client adapter implementation that makes authenticated calls to external APIs, handling
+ * various auth schemes (Basic, Bearer, API Key, Digest, OAuth2) and parameter/response mapping.
+ */
+package io.naftiko.engine.consumes.http;

--- a/src/main/java/io/naftiko/engine/consumes/package-info.java
+++ b/src/main/java/io/naftiko/engine/consumes/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Consumed adapter base — handles external API client lifecycle and import resolution for
+ * external capability references.
+ */
+package io.naftiko.engine.consumes;

--- a/src/main/java/io/naftiko/engine/exposes/control/package-info.java
+++ b/src/main/java/io/naftiko/engine/exposes/control/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Control server adapter providing management endpoints for Kubernetes probes (liveness/readiness),
+ * Prometheus metrics, OpenTelemetry trace inspection, and runtime script evaluation.
+ */
+package io.naftiko.engine.exposes.control;

--- a/src/main/java/io/naftiko/engine/exposes/mcp/package-info.java
+++ b/src/main/java/io/naftiko/engine/exposes/mcp/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * MCP server adapter supporting HTTP and stdio transports — handles tool execution, prompts,
+ * resources, and JSON-RPC protocol dispatch with OAuth2 integration.
+ */
+package io.naftiko.engine.exposes.mcp;

--- a/src/main/java/io/naftiko/engine/exposes/package-info.java
+++ b/src/main/java/io/naftiko/engine/exposes/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Exposed adapter base — shared server lifecycle, authentication middleware, and OAuth2 token
+ * refresh handling common to REST, MCP, Control, and Skill servers.
+ */
+package io.naftiko.engine.exposes;

--- a/src/main/java/io/naftiko/engine/exposes/rest/package-info.java
+++ b/src/main/java/io/naftiko/engine/exposes/rest/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * REST server adapter that creates a routing layer with template-based paths, dispatches requests
+ * to resource handlers, and executes operation steps to produce JSON responses.
+ */
+package io.naftiko.engine.exposes.rest;

--- a/src/main/java/io/naftiko/engine/exposes/skill/package-info.java
+++ b/src/main/java/io/naftiko/engine/exposes/skill/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Skill server adapter exposing read-only HTTP endpoints for skill catalog browsing, metadata
+ * retrieval, ZIP downloads, and instruction file serving.
+ */
+package io.naftiko.engine.exposes.skill;

--- a/src/main/java/io/naftiko/engine/observability/package-info.java
+++ b/src/main/java/io/naftiko/engine/observability/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * OpenTelemetry SDK bootstrap and instrumentation — tracer/meter initialization, span processing
+ * with local buffering, Prometheus metrics serialization, and distributed trace header propagation.
+ */
+package io.naftiko.engine.observability;

--- a/src/main/java/io/naftiko/engine/package-info.java
+++ b/src/main/java/io/naftiko/engine/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Abstract adapter lifecycle defining the universal start/stop contract and shared utilities
+ * used by all server and client adapters.
+ */
+package io.naftiko.engine;

--- a/src/main/java/io/naftiko/engine/scripting/package-info.java
+++ b/src/main/java/io/naftiko/engine/scripting/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Script step executor using GraalVM Polyglot (JavaScript/Python) and GroovyShell with sandbox
+ * security, timeout enforcement, and JsonNode result mapping.
+ */
+package io.naftiko.engine.scripting;

--- a/src/main/java/io/naftiko/engine/util/package-info.java
+++ b/src/main/java/io/naftiko/engine/util/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Core orchestration utilities — Mustache template resolution, path traversal safety, variable
+ * binding, step execution state management, JSON path lookup, and format conversion.
+ */
+package io.naftiko.engine.util;

--- a/src/main/java/io/naftiko/package-info.java
+++ b/src/main/java/io/naftiko/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Core entry point for the Naftiko framework — loads YAML capabilities, orchestrates spec parsing,
+ * instantiates runtime adapters, and manages the complete capability lifecycle.
+ */
+package io.naftiko;

--- a/src/main/java/io/naftiko/spec/aggregates/package-info.java
+++ b/src/main/java/io/naftiko/spec/aggregates/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Specification model for domain aggregates and their functions, including input/output parameters,
+ * orchestration steps, and semantic metadata (safe, idempotent, cacheable).
+ */
+package io.naftiko.spec.aggregates;

--- a/src/main/java/io/naftiko/spec/consumes/http/package-info.java
+++ b/src/main/java/io/naftiko/spec/consumes/http/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Specification model for HTTP client configuration — baseUri, resources, operations, input
+ * parameters, and authentication strategies (Basic, Bearer, API Key, Digest, OAuth2).
+ */
+package io.naftiko.spec.consumes.http;

--- a/src/main/java/io/naftiko/spec/consumes/package-info.java
+++ b/src/main/java/io/naftiko/spec/consumes/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Abstract specification for consumed adapters with polymorphic deserialization dispatching to
+ * concrete implementations based on the adapter type field.
+ */
+package io.naftiko.spec.consumes;

--- a/src/main/java/io/naftiko/spec/exposes/control/package-info.java
+++ b/src/main/java/io/naftiko/spec/exposes/control/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Specification model for control (management) servers providing health checks, metrics, traces,
+ * diagnostics endpoints, and scripting management with optional OpenTelemetry configuration.
+ */
+package io.naftiko.spec.exposes.control;

--- a/src/main/java/io/naftiko/spec/exposes/mcp/package-info.java
+++ b/src/main/java/io/naftiko/spec/exposes/mcp/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Specification model for MCP protocol servers — tools, resources, prompts with message templates,
+ * tool execution hints, and transport configuration (HTTP/stdio).
+ */
+package io.naftiko.spec.exposes.mcp;

--- a/src/main/java/io/naftiko/spec/exposes/package-info.java
+++ b/src/main/java/io/naftiko/spec/exposes/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Abstract specification for exposed adapters with polymorphic deserialization routing to concrete
+ * implementations (REST, MCP, Control, Skill) and shared server configuration.
+ */
+package io.naftiko.spec.exposes;

--- a/src/main/java/io/naftiko/spec/exposes/rest/package-info.java
+++ b/src/main/java/io/naftiko/spec/exposes/rest/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Specification model for REST API servers — resources with paths, operations with HTTP methods,
+ * input/output parameters, forward proxying, and orchestration steps.
+ */
+package io.naftiko.spec.exposes.rest;

--- a/src/main/java/io/naftiko/spec/exposes/skill/package-info.java
+++ b/src/main/java/io/naftiko/spec/exposes/skill/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Specification model for skill catalog servers that expose read-only metadata and files about
+ * agent skills, with tools referencing sibling adapters or local instruction files.
+ */
+package io.naftiko.spec.exposes.skill;

--- a/src/main/java/io/naftiko/spec/observability/package-info.java
+++ b/src/main/java/io/naftiko/spec/observability/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Specification model for OpenTelemetry observability configuration — metrics and traces exporters
+ * (OTLP, Jaeger) with optional local buffering, defaulting to OTel environment variables.
+ */
+package io.naftiko.spec.observability;

--- a/src/main/java/io/naftiko/spec/openapi/package-info.java
+++ b/src/main/java/io/naftiko/spec/openapi/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Bidirectional OpenAPI 3.0 conversion — exporting REST capability specs to OAS documents and
+ * importing OpenAPI specs into Naftiko capabilities with security scheme mapping.
+ */
+package io.naftiko.spec.openapi;

--- a/src/main/java/io/naftiko/spec/package-info.java
+++ b/src/main/java/io/naftiko/spec/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Data model for the Naftiko capability YAML structure — defines top-level capability, resource,
+ * operation, input/output parameters, and stakeholder metadata as deserialized POJOs.
+ */
+package io.naftiko.spec;

--- a/src/main/java/io/naftiko/spec/scripting/package-info.java
+++ b/src/main/java/io/naftiko/spec/scripting/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Specification model for script steps (JavaScript/Python/Groovy) executed during operation
+ * orchestration, with external file loading and dependency management.
+ */
+package io.naftiko.spec.scripting;

--- a/src/main/java/io/naftiko/spec/util/package-info.java
+++ b/src/main/java/io/naftiko/spec/util/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Specification model for orchestration steps (call, lookup, script), step-level bindings,
+ * output parameter mapping, and the execution context interface for variable resolution.
+ */
+package io.naftiko.spec.util;

--- a/src/main/java/io/naftiko/util/package-info.java
+++ b/src/main/java/io/naftiko/util/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * General-purpose utilities for the framework, including version retrieval from bundled resources.
+ */
+package io.naftiko.util;


### PR DESCRIPTION
## Related Issue

N/A — standalone documentation improvement.

---

## What does this PR do?

Adds package-info.java with Javadoc descriptions for all 28 packages in the io.naftiko hierarchy. This provides package-level documentation for the spec, engine, CLI, and utility layers.

---

## Tests

No tests added — documentation-only change (package-info.java files contain no executable code). Compilation verified locally.

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Claude Opus 4.6
tool: VS Code Chat
confidence: high
discovery_method: user_report
```
