### PR TITLE
feat: enhancing the trigger of the publish

### DIFF
--- a/.github/workflows/publish-mvn-snapshot-ghcr.yml
+++ b/.github/workflows/publish-mvn-snapshot-ghcr.yml
@@ -9,13 +9,21 @@ jobs:
     permissions:
       contents: read
       packages: write
+
     steps:
       - uses: actions/checkout@v5
+
       - uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'temurin'
+
+      - name: Get project version
+        id: version
+        run: echo "VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)" >> $GITHUB_ENV
+
       - name: Publish snapshot
+        if: contains(env.VERSION, 'SNAPSHOT')
         run: mvn --batch-mode -Dgpg.skip=true deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Related Issue

Closes https://github.com/naftiko/framework/issues/396

---

## What does this PR do?

Refactors the mvn snapshot publish to GHCR so it only publishes when it finds -SNAPSHOT else it won't.

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

