### PR TITLE
feat: automating version bumping after release

### DIFF
--- a/.github/workflows/automate-version-bumping.yml
+++ b/.github/workflows/automate-version-bumping.yml
@@ -1,0 +1,16 @@
+name: Detect Snapshot Bump
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'pom.xml'
+  workflow_dispatch:
+
+jobs:
+  say-hello:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Print Hello World
+        run: echo "Hello world"


### PR DESCRIPTION
## Related Issue

No related issue

---

## What does this PR do?

Triggers the sync github actions and therefore all their patching PRs across our repos.

---

## Tests

tested on the feat/automate-version-bumping 
from 1.0.0-alpha3 to 1.0.0-alpha4-SNAPSHOT.

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

