### PR TITLE
fix: remove the duplicate SLF4J

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -436,6 +436,11 @@
                                     </excludes>
                                 </filter>
                             </filters>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>org.eclipse.jetty:jetty-slf4j-impl</exclude>
+                                </excludes>
+                            </artifactSet>
                         </configuration>
                     </execution>
                     <execution>
@@ -464,6 +469,23 @@
                                     </excludes>
                                 </filter>
                             </filters>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>org.graalvm.truffle:*</exclude>
+                                    <exclude>org.graalvm.polyglot:polyglot</exclude>
+                                    <exclude>org.graalvm.polyglot:js*</exclude>
+                                    <exclude>org.graalvm.polyglot:python*</exclude>
+                                    <exclude>org.graalvm.js:*</exclude>
+                                    <exclude>org.graalvm.python:*</exclude>
+                                    <exclude>org.graalvm.regex:*</exclude>
+                                    <exclude>org.graalvm.shadowed:*</exclude>
+                                    <exclude>org.graalvm.tools:*</exclude>
+                                    <exclude>org.graalvm.llvm:*</exclude>
+                                    <exclude>org.graalvm.sdk:*</exclude>
+                                    <exclude>org.apache.groovy:*</exclude>
+                                    <exclude>org.eclipse.jetty:jetty-slf4j-impl</exclude>
+                                </excludes>
+                            </artifactSet>
                         </configuration>
                     </execution>
                 </executions>
@@ -523,6 +545,7 @@
                                             <exclude>org.graalvm.llvm:*</exclude>
                                             <exclude>org.graalvm.sdk:*</exclude>
                                             <exclude>org.apache.groovy:*</exclude>
+                                            <exclude>org.eclipse.jetty:jetty-slf4j-impl</exclude>
                                         </excludes>
                                     </artifactSet>
                                 </configuration>


### PR DESCRIPTION
## Related Issue

No linked issue

---

## What does this PR do?

Each time the CLI command was used, a warn message was displayed:
SLF4J(W): Class path contains multiple SLF4J providers.
SLF4J(W): Found provider [org.eclipse.jetty.logging.JettyLoggingServiceProvider@5fee4254]
SLF4J(W): Found provider [ch.qos.logback.classic.spi.LogbackServiceProvider@72711096]
SLF4J(W): See [https://www.slf4j.org/codes.html#multiple_bindings](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) for an explanation.
SLF4J(I): Actual provider is of type [org.eclipse.jetty.logging.JettyLoggingServiceProvider@5fee4254]

This PR remove the duplicated SLF4J from pom.xml

---

## Tests

Tested manually and locally on my mac

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main`
- [ ] Small and focused — one concern per PR
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

<!-- If this PR was created or assisted by an AI agent, provide metadata below (YAML) -->

```yaml
# agent_name:
# llm:
# tool:
# confidence:          # low | medium | high
# source_event:
# discovery_method:    # runtime_observation | code_review | test_failure | user_report
# review_focus:        # e.g. ClassName.java:line-range
```
