### PR TITLE
fix: docker tag in wiki

### DIFF
--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -22,14 +22,6 @@ jobs:
         echo "VERSION_NO_V=$VERSION_NO_V" >> $GITHUB_ENV
         echo "Debug RELEASE_TAG: $RELEASE_TAG"
         echo "Debug VERSION_NO_V: $VERSION_NO_V"
-    - name: Compute Docker tag
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
-      run: |
-        DOCKER_TAG=$(gh api /orgs/naftiko/packages/container/framework/versions \
-          --jq '[.[] | select(.metadata.container.tags[] | startswith("sha-"))] | .[0].metadata.container.tags[] | select(startswith("sha-"))' \
-          2>/dev/null || echo "latest")
-        echo "DOCKER_TAG=$DOCKER_TAG" >> $GITHUB_ENV
     - name: Update wiki data
       env:
         GH_WIKI_PUBLISH_TOKEN: ${{ secrets.GH_WIKI_PUBLISH_TOKEN }}
@@ -48,11 +40,11 @@ jobs:
         echo "Copying files"
         cp -R "$WIKI_DIR"/. "$tmp_dir"
 
-        echo "Replacing release tag and docker tag"
+        echo "Replacing release tag"
         find "$tmp_dir" -name "*.md" -exec sed -i \
           -e "s|{{RELEASE_TAG}}|$RELEASE_TAG|g" \
           -e "s|{{VERSION_NO_V}}|$VERSION_NO_V|g" \
-          -e "s|{{DOCKER_TAG}}|$DOCKER_TAG|g" {} +
+          {} \;
 
         cd "$tmp_dir"
         git config user.name "$GITHUB_ACTOR"

--- a/src/main/resources/wiki/Installation.md
+++ b/src/main/resources/wiki/Installation.md
@@ -13,7 +13,7 @@ To use Naftiko Framework, you need to install and then run the Naftiko Engine, p
 * Naftiko provides a docker image hosted in GitHub packages platform. It is public, so you can easily pull it locally.
   ```bash
   # {{RELEASE_TAG}}
-  docker pull ghcr.io/naftiko/naftiko-framework:{{DOCKER_TAG}}
+  docker pull ghcr.io/naftiko/naftiko-framework:{{RELEASE_TAG}}
 
   # Or if you prefer to play with the last snapshot
   docker pull ghcr.io/naftiko/naftiko-framework:latest
@@ -50,10 +50,10 @@ You can use more complex capability files from [Tutorial - Part 1](https://githu
 Let's assume you downloaded [step-1-shipyard-first-capability.yml](https://raw.githubusercontent.com/naftiko/framework/refs/tags/v1.0.0-alpha1/src/main/resources/tutorial/step-1-shipyard-first-capability.yml) in your downloads folder. Then you should run:
 ```bash
 # For Linux and Mac
-docker run -p 8081:3001 -v ~/Downloads/step-1-shipyard-first-capability.yml:/app/test.capability.yaml ghcr.io/naftiko/naftiko-framework:{{DOCKER_TAG}} /app/test.capability.yaml
+docker run -p 8081:3001 -v ~/Downloads/step-1-shipyard-first-capability.yml:/app/test.capability.yaml ghcr.io/naftiko/naftiko-framework:{{RELEASE_TAG}} /app/test.capability.yaml
 
 # For windows
-docker run -p 8081:3001 -v %USERPROFILE%/Downloads/step-1-shipyard-first-capability.yml:/app/test.capability.yaml ghcr.io/naftiko/naftiko-framework:{{DOCKER_TAG}} /app/test.capability.yaml
+docker run -p 8081:3001 -v %USERPROFILE%/Downloads/step-1-shipyard-first-capability.yml:/app/test.capability.yaml ghcr.io/naftiko/naftiko-framework:{{RELEASE_TAG}} /app/test.capability.yaml
 ```
 Then you should be able to request your capability at http://localhost:8081 (the step-1-shipyard-first-capability.yml exposes an MCP tool adapter).
 
@@ -67,7 +67,7 @@ Then you should be able to request your capability at http://localhost:8081 (the
 * Run your capability with Naftiko Engine.\
   Given a capability configuration file 'test.capability.yaml' and an exposition on port 8081, here is the command you have to execute to run the Framework Engine:
   ```bash
-  docker run -p 8081:8081 -v full_path_to_your_capability_folder/test.capability.yaml:/app/test.capability.yaml ghcr.io/naftiko/framework:latest /app/test.capability.yaml
+  docker run -p 8081:8081 -v full_path_to_your_capability_folder/test.capability.yaml:/app/test.capability.yaml ghcr.io/naftiko/framework:latest/app/test.capability.yaml
   ```
 
 ## Naftiko CLI


### PR DESCRIPTION
## Related Issue

no related issue

---

## What does this PR do?

since we now tag the docker image with the release tag no need to reference a second variable and do extra work 

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
