### PR TITLE
feat: improve pr-review skill with no-ghost-review and multi-OS rules

### DIFF
--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-review
-version: "1.1.0"
+version: "1.2.0"
 description: >
   On-demand skill for reviewing GitHub Pull Requests and posting inline
   comments via the GitHub API. Activate when the user asks to: review a PR,
@@ -249,6 +249,38 @@ gh api repos/{owner}/{repo}/pulls/<number>/reviews \
 Use `event=COMMENT` for a non-approving review.
 Use `event=REQUEST_CHANGES` when at least one finding is blocking (🔴 HIGH).
 Use `event=APPROVE` only when explicitly asked to approve the PR.
+
+> **Never post thread replies before the review**
+> Posting individual replies via `pulls/comments/{id}/replies` before the main review
+> creates a separate "ghost" review per reply on GitHub. Always bundle all inline
+> comments — including follow-up answers to existing threads — into a **single**
+> `POST /reviews` call. To reply to an existing thread, use the `in_reply_to` field:
+>
+> ```powershell
+> # Windows (PowerShell)
+> gh api repos/{owner}/{repo}/pulls/<number>/reviews `
+>   --method POST `
+>   --field event=REQUEST_CHANGES `
+>   --field 'body=Overall summary.' `
+>   --field 'comments[][path]=src/main/java/io/naftiko/Foo.java' `
+>   --field 'comments[][line]=42' `
+>   --field 'comments[][in_reply_to]=<existing_comment_id>' `
+>   --field 'comments[][body]=Reply text.'
+> ```
+>
+> ```bash
+> # Linux / macOS
+> gh api repos/{owner}/{repo}/pulls/<number>/reviews \
+>   --method POST \
+>   --field event=REQUEST_CHANGES \
+>   --field "body=Overall summary." \
+>   --field "comments[][path]=src/main/java/io/naftiko/Foo.java" \
+>   --field "comments[][line]=42" \
+>   --field "comments[][in_reply_to]=<existing_comment_id>" \
+>   --field "comments[][body]=Reply text."
+> ```
+>
+> The `line` field is still required even when using `in_reply_to`.
 
 After posting, verify the review was accepted:
 


### PR DESCRIPTION
## Related Issue

Closes #413

---

## What does this PR do?

Improves the `pr-review` skill to prevent two mistakes observed in practice during the PR #395 review:

**1. Ghost reviews from individual thread replies**
Posting replies via `pulls/comments/{id}/replies` individually before the main review creates a separate `ghost` review object per reply on GitHub. The skill now explicitly forbids this pattern and documents how to bundle thread replies inside a single `POST /reviews` call using the `in_reply_to` field.

**2. Multi-OS coverage for the `in_reply_to` example**
Both PowerShell (Windows) and bash (Linux/macOS) variants are provided, consistent with the rest of the skill.

Version bumped: `1.1.0` -> `1.2.0`.

---

## Tests

No automated tests -- this is a documentation/skill file change. The ghost-review pattern was observed in practice during PR #395 and the fix was validated against the GitHub API.

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused -- one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Claude Sonnet 4.6
tool: VS Code Chat
confidence: high
source_event: ghost reviews observed during PR #395 review session
discovery_method: runtime_observation
review_focus: .agents/skills/pr-review/SKILL.md
```
