### PR TITLE
fix: resolve MAJOR Sonar bugs in HttpClientAdapter and OasImportConverter

### DIFF
--- a/src/main/java/io/naftiko/engine/consumes/http/HttpClientAdapter.java
+++ b/src/main/java/io/naftiko/engine/consumes/http/HttpClientAdapter.java
@@ -100,7 +100,7 @@ public class HttpClientAdapter extends ClientAdapter {
                     challengeResponse.setIdentifier(
                             Resolver.resolveMustacheTemplate(basicAuth.getUsername(), parameters));
                     challengeResponse.setSecret(Resolver
-                            .resolveMustacheTemplate(basicAuth.getPassword().toString(), parameters)
+                            .resolveMustacheTemplate(new String(basicAuth.getPassword()), parameters)
                             .toCharArray());
                     clientRequest.setChallengeResponse(challengeResponse);
                     break;
@@ -112,7 +112,7 @@ public class HttpClientAdapter extends ClientAdapter {
                     challengeResponse.setIdentifier(
                             Resolver.resolveMustacheTemplate(digestAuth.getUsername(), parameters));
                     challengeResponse.setSecret(Resolver.resolveMustacheTemplate(
-                            digestAuth.getPassword().toString(), parameters).toCharArray());
+                            new String(digestAuth.getPassword()), parameters).toCharArray());
                     clientRequest.setChallengeResponse(challengeResponse);
                     break;
 

--- a/src/main/java/io/naftiko/spec/openapi/OasImportConverter.java
+++ b/src/main/java/io/naftiko/spec/openapi/OasImportConverter.java
@@ -208,8 +208,16 @@ public class OasImportConverter {
     }
 
     String deriveResourceName(String path) {
+        // Defensive: fall back to "root" when the input path is null
+        // (fixes S2259: dereferencing path.replaceAll without a null guard).
+        if (path == null) {
+            return "root";
+        }
         // Use the path template without parameter placeholders as resource name
         String slug = toKebabCase(path.replaceAll("[{}]", ""));
+        if (slug == null) {
+            return "root";
+        }
         // Remove leading hyphen from the leading slash
         if (slug.startsWith("-")) {
             slug = slug.substring(1);
@@ -502,7 +510,9 @@ public class OasImportConverter {
                 // Collapse multiple hyphens
                 .replaceAll("-+", "-")
                 // Trim leading/trailing hyphens
-                .replaceAll("^-|-$", "")
+                // Use explicit grouping to avoid ambiguity (S5850):
+                // the regex "^-|-$" is parsed as "(^-)|(-$)" but reads ambiguously.
+                .replaceAll("(^-)|(-$)", "")
                 .toLowerCase();
     }
 

--- a/src/test/java/io/naftiko/engine/consumes/http/HttpClientAdapterTest.java
+++ b/src/test/java/io/naftiko/engine/consumes/http/HttpClientAdapterTest.java
@@ -50,7 +50,12 @@ public class HttpClientAdapterTest {
 
         assertNotNull(clientRequest.getChallengeResponse());
         assertEquals("alice", clientRequest.getChallengeResponse().getIdentifier());
-                assertNotNull(clientRequest.getChallengeResponse().getSecret());
+        // Previously this only asserted non-null, which let bug S2116 slip through:
+        // calling toString() on a char[] returned the array identity (e.g. "[C@1a2b3c")
+        // instead of resolving the {{password}} Mustache placeholder. Compare the actual
+        // resolved secret to guard against that regression.
+        assertEquals("secret",
+                String.valueOf(clientRequest.getChallengeResponse().getSecret()));
     }
 
     @Test
@@ -70,7 +75,12 @@ public class HttpClientAdapterTest {
 
         assertNotNull(clientRequest.getChallengeResponse());
         assertEquals("digest-user", clientRequest.getChallengeResponse().getIdentifier());
-        assertNotNull(clientRequest.getChallengeResponse().getSecret());
+        // Previously this only asserted non-null, which let bug S2116 slip through:
+        // calling toString() on a char[] returned the array identity (e.g. "[C@1a2b3c")
+        // instead of the literal password. Compare the actual secret content to guard
+        // against that regression.
+        assertEquals("digest-pass",
+                String.valueOf(clientRequest.getChallengeResponse().getSecret()));
     }
 
     @Test

--- a/src/test/java/io/naftiko/spec/openapi/OasImportConverterTest.java
+++ b/src/test/java/io/naftiko/spec/openapi/OasImportConverterTest.java
@@ -192,6 +192,14 @@ public class OasImportConverterTest {
         assertEquals("/users/{{id}}", result.getHttpClient().getResources().get(0).getPath());
     }
 
+    // Non-regression test for bug S2259: deriveResourceName must not throw NPE when
+    // the path is null. Before the fix, calling path.replaceAll(...) on a null path
+    // produced a NullPointerException. After the fix, the method falls back to "root".
+    @Test
+    void deriveResourceNameShouldFallBackToRootWhenPathIsNull() {
+        assertEquals("root", converter.deriveResourceName(null));
+    }
+
     // ── Operation name derivation ──
 
     @Test
@@ -594,6 +602,18 @@ public class OasImportConverterTest {
     @Test
     void toKebabCaseShouldConvertSpacesAndSpecialChars() {
         assertEquals("petstore-api", OasImportConverter.toKebabCase("Petstore API"));
+    }
+
+    // Non-regression test for bug S5850: toKebabCase must trim BOTH leading and trailing
+    // hyphens. The original regex `^-|-$` is ambiguous; the explicitly-grouped form
+    // `(^-)|(-$)` is unambiguous and trims both ends consistently.
+    @Test
+    void toKebabCaseShouldTrimLeadingAndTrailingHyphens() {
+        // Input that produces leading and trailing hyphens after non-alphanumeric replacement
+        assertEquals("foo-bar", OasImportConverter.toKebabCase("-foo-bar-"));
+        assertEquals("only", OasImportConverter.toKebabCase("-only-"));
+        // Single hyphen on each side via special chars
+        assertEquals("api", OasImportConverter.toKebabCase(" api "));
     }
 
     // ── Helper: mapSchemaType ──


### PR DESCRIPTION
## Related Issue

Closes #417, closes #418, closes #419

---

## What does this PR do?

Phase 1 of the [Sonar Bug Remediation blueprint](https://github.com/naftiko/blueprints/blob/main/sonar-bug-remediation.md) — resolve all 4 MAJOR bugs reported by the SonarQube quality gate (run #1516, `main @ dcfd01c`):

| Rule | File | Lines | Fix |
|---|---|---|---|
| `java:S2116` | `HttpClientAdapter.java` | 103, 115 | Replace `getPassword().toString()` with `new String(getPassword())` |
| `java:S2259` | `OasImportConverter.deriveResourceName` | 211–219 | Guard `path` and `slug` against `null`; fall back to `"root"` |
| `java:S5850` | `OasImportConverter.toKebabCase` | 513 | Replace ambiguous `"^-\|-$"` with explicitly-grouped `"(^-)\|(-$)"` |

The `S2116` fix is the only one with **runtime impact** — before this change, every Basic and Digest authenticated outbound HTTP call was sending the JVM array identity (e.g. `[C@5a3b7c`) as the secret instead of the configured password. The two existing auth tests masked the bug because they only asserted `assertNotNull(getSecret())`.

---

## Tests

- **`HttpClientAdapterTest.basicAuthenticationShouldSetIdentifierAndSecret`** and **`digestAuthenticationShouldSetIdentifierAndSecret`**: strengthened from `assertNotNull(getSecret())` to `assertEquals("<expected>", String.valueOf(getSecret()))`. These strengthened assertions **fail on `main`** (proving the S2116 bug), and pass after the fix. A comment in each test explains why this assertion strengthening is itself the non-regression guard.
- **`OasImportConverterTest.deriveResourceNameShouldFallBackToRootWhenPathIsNull`** (new): verifies the null-path fallback. Fails with NPE before the fix.
- **`OasImportConverterTest.toKebabCaseShouldTrimLeadingAndTrailingHyphens`** (new): verifies the regex still trims both ends. Passes against both old and new regex (S5850 is a code-quality issue, not a behavioral bug); kept as a defensive regression test for the new explicitly-grouped form.

### Verification

```text
HttpClientAdapterTest:  5 tests, 0 failures (was 2 failing before fix)
OasImportConverterTest: 41 tests, 0 failures (was 1 failing before fix)
Full suite:             923 tests, 16 pre-existing flaky failures
                        (Step2-8 MCP client and Step10 REST adapter
                        tutorial tests — verified pre-existing on main,
                        unrelated to these fixes)
```

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR (4 MAJOR Sonar bugs as Phase 1 of the blueprint)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: claude-opus-4.7
tool: copilot-chat
confidence: high
source_event: SonarQube quality gate run #1516
discovery_method: code_review
review_focus: HttpClientAdapter.java:90-118 and OasImportConverter.java:210-225, 503-516
```
