### PR TITLE
fix: migrate engine fields to AtomicReference snapshots (S3077, Phase 3)

### DIFF
--- a/src/main/java/io/naftiko/Capability.java
+++ b/src/main/java/io/naftiko/Capability.java
@@ -148,6 +148,14 @@ public class Capability {
             throw new IllegalArgumentException("Capability must expose at least one endpoint.");
         }
 
+        // NOTE: `this` escapes to adapter constructors below before clientAdapters
+        // and serverAdapters are published via AtomicReference.set() at the end of
+        // this constructor. Adapter constructors MUST NOT call getClientAdapters()
+        // or getServerAdapters() — those references are still null/unset at this
+        // point. Defer any such cross-adapter lookup to a post-construction
+        // lifecycle method (e.g. start()/init()) that runs after the constructor
+        // returns. The AtomicReference migration (S3077) addresses field-level
+        // visibility, not this construction-time publication ordering.
         for (ServerSpec serverSpec : spec.getCapability().getExposes()) {
             if ("rest".equals(serverSpec.getType())) {
                 serverList.add(new RestServerAdapter(this, (RestServerSpec) serverSpec));

--- a/src/main/java/io/naftiko/Capability.java
+++ b/src/main/java/io/naftiko/Capability.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -61,13 +62,23 @@ public class Capability {
 
     private static final Logger logger = LoggerFactory.getLogger(Capability.class);
 
-    private volatile NaftikoSpec spec;
-    private volatile List<ServerAdapter> serverAdapters;
-    private volatile List<ClientAdapter> clientAdapters;
-    private volatile List<Aggregate> aggregates;
-    private volatile Map<String, Object> bindings;
-    private volatile ScriptingManagementSpec scriptingSpec;
-    private volatile StepHandlerRegistry stepHandlerRegistry;
+    /**
+     * Mutable runtime state held in {@link AtomicReference}s. This satisfies SonarQube rule
+     * {@code java:S3077} (volatile on non-thread-safe types) and prepares the engine for the
+     * Control-port "hot reload" feature, where a new {@code NaftikoSpec} can be swapped in
+     * atomically while request threads observe a consistent snapshot.
+     *
+     * <p>The list-typed slots (server/client adapters, aggregates) hold
+     * {@link CopyOnWriteArrayList} instances internally so that iteration during request
+     * handling is lock-free and safe even if a future hot-reload mutates the slot.</p>
+     */
+    private final AtomicReference<NaftikoSpec> spec = new AtomicReference<>();
+    private final AtomicReference<List<ServerAdapter>> serverAdapters = new AtomicReference<>();
+    private final AtomicReference<List<ClientAdapter>> clientAdapters = new AtomicReference<>();
+    private final AtomicReference<List<Aggregate>> aggregates = new AtomicReference<>();
+    private final AtomicReference<Map<String, Object>> bindings = new AtomicReference<>();
+    private final AtomicReference<ScriptingManagementSpec> scriptingSpec = new AtomicReference<>();
+    private final AtomicReference<StepHandlerRegistry> stepHandlerRegistry = new AtomicReference<>();
 
     public Capability(NaftikoSpec spec) throws Exception {
         this(spec, null);
@@ -81,7 +92,7 @@ public class Capability {
      * @throws Exception if bindings cannot be resolved
      */
     public Capability(NaftikoSpec spec, String capabilityDir) throws Exception {
-        this.spec = spec;
+        this.spec.set(spec);
 
         // Resolve consumes imports early before initializing adapters
         if (spec.getCapability() != null && spec.getCapability().getConsumes() != null) {
@@ -94,25 +105,26 @@ public class Capability {
         aggregateRefResolver.resolve(spec);
 
         // Find ScriptingManagementSpec from control adapter (if any) before building executors
-        ScriptingManagementSpec scriptingSpec = null;
+        ScriptingManagementSpec resolvedScriptingSpec = null;
         for (ServerSpec serverSpec : spec.getCapability().getExposes()) {
             if (serverSpec instanceof ControlServerSpec controlSpec
                     && controlSpec.getManagement() != null
                     && controlSpec.getManagement().getScripting() != null) {
-                scriptingSpec = controlSpec.getManagement().getScripting();
+                resolvedScriptingSpec = controlSpec.getManagement().getScripting();
                 break;
             }
         }
-        this.scriptingSpec = scriptingSpec;
+        this.scriptingSpec.set(resolvedScriptingSpec);
 
         // Build runtime aggregates (must happen after imports are resolved)
-        this.aggregates = new CopyOnWriteArrayList<>();
+        List<Aggregate> aggregateList = new CopyOnWriteArrayList<>();
         if (spec.getCapability() != null && !spec.getCapability().getAggregates().isEmpty()) {
             OperationStepExecutor sharedExecutor = new OperationStepExecutor(this);
             for (AggregateSpec aggSpec : spec.getCapability().getAggregates()) {
-                this.aggregates.add(new Aggregate(aggSpec, sharedExecutor));
+                aggregateList.add(new Aggregate(aggSpec, sharedExecutor));
             }
         }
+        this.aggregates.set(aggregateList);
 
         // Resolve bindings early for injection into adapters
         BindingResolver bindingResolver = new BindingResolver();
@@ -124,13 +136,13 @@ public class Capability {
         };
         Map<String, String> resolvedBinds = bindingResolver.resolve(spec.getBinds(), context);
         // Convert Map<String, String> to Map<String, Object> for compatibility
-        this.bindings = new HashMap<>(resolvedBinds);
+        this.bindings.set(new HashMap<>(resolvedBinds));
 
         // Initialize client adapters first
-        this.clientAdapters = new CopyOnWriteArrayList<>();
+        List<ClientAdapter> clientList = new CopyOnWriteArrayList<>();
 
         // Then initialize server adapters with reference to source adapters
-        this.serverAdapters = new CopyOnWriteArrayList<>();
+        List<ServerAdapter> serverList = new CopyOnWriteArrayList<>();
 
         if (spec.getCapability().getExposes().isEmpty()) {
             throw new IllegalArgumentException("Capability must expose at least one endpoint.");
@@ -138,53 +150,56 @@ public class Capability {
 
         for (ServerSpec serverSpec : spec.getCapability().getExposes()) {
             if ("rest".equals(serverSpec.getType())) {
-                this.serverAdapters.add(new RestServerAdapter(this, (RestServerSpec) serverSpec));
+                serverList.add(new RestServerAdapter(this, (RestServerSpec) serverSpec));
             } else if ("mcp".equals(serverSpec.getType())) {
-                this.serverAdapters.add(new McpServerAdapter(this, (McpServerSpec) serverSpec));
+                serverList.add(new McpServerAdapter(this, (McpServerSpec) serverSpec));
             } else if ("skill".equals(serverSpec.getType())) {
-                this.serverAdapters.add(new SkillServerAdapter(this, (SkillServerSpec) serverSpec));
+                serverList.add(new SkillServerAdapter(this, (SkillServerSpec) serverSpec));
             } else if ("control".equals(serverSpec.getType())) {
-                this.serverAdapters.add(new ControlServerAdapter(this, (ControlServerSpec) serverSpec));
+                serverList.add(new ControlServerAdapter(this, (ControlServerSpec) serverSpec));
             }
         }
 
         for (ClientSpec clientSpec : spec.getCapability().getConsumes()) {
             if ("http".equals(clientSpec.getType())) {
-                this.clientAdapters.add(new HttpClientAdapter(this, (HttpClientSpec) clientSpec));
+                clientList.add(new HttpClientAdapter(this, (HttpClientSpec) clientSpec));
             }
         }
+
+        this.clientAdapters.set(clientList);
+        this.serverAdapters.set(serverList);
     }
 
     public NaftikoSpec getSpec() {
-        return spec;
+        return spec.get();
     }
 
     public void setSpec(NaftikoSpec config) {
-        this.spec = config;
+        this.spec.set(config);
     }
 
     public List<ClientAdapter> getClientAdapters() {
-        return clientAdapters;
+        return clientAdapters.get();
     }
 
     public List<ServerAdapter> getServerAdapters() {
-        return serverAdapters;
+        return serverAdapters.get();
     }
 
     public List<Aggregate> getAggregates() {
-        return aggregates;
+        return aggregates.get();
     }
 
     public ScriptingManagementSpec getScriptingSpec() {
-        return scriptingSpec;
+        return scriptingSpec.get();
     }
 
     public StepHandlerRegistry getStepHandlerRegistry() {
-        return stepHandlerRegistry;
+        return stepHandlerRegistry.get();
     }
 
     public void setStepHandlerRegistry(StepHandlerRegistry registry) {
-        this.stepHandlerRegistry = registry;
+        this.stepHandlerRegistry.set(registry);
     }
 
     /**
@@ -204,7 +219,7 @@ public class Capability {
         String namespace = ref.substring(0, dot);
         String functionName = ref.substring(dot + 1);
 
-        for (Aggregate agg : aggregates) {
+        for (Aggregate agg : aggregates.get()) {
             if (agg.getNamespace().equals(namespace)) {
                 AggregateFunction fn = agg.findFunction(functionName);
                 if (fn != null) {
@@ -222,7 +237,7 @@ public class Capability {
      * @return Map of variable name to resolved value
      */
     public Map<String, Object> getBindings() {
-        return bindings;
+        return bindings.get();
     }
 
     public void start() throws Exception {
@@ -234,14 +249,16 @@ public class Capability {
             adapter.start();
         }
 
-        String capabilityName = spec.getInfo() != null && spec.getInfo().getLabel() != null
-                ? spec.getInfo().getLabel() : "unknown";
+        NaftikoSpec currentSpec = spec.get();
+        String capabilityName = currentSpec.getInfo() != null && currentSpec.getInfo().getLabel() != null
+                ? currentSpec.getInfo().getLabel() : "unknown";
         TelemetryBootstrap.get().getMetrics().capabilityStarted(capabilityName);
     }
 
     public void stop() throws Exception {
-        String capabilityName = spec.getInfo() != null && spec.getInfo().getLabel() != null
-                ? spec.getInfo().getLabel() : "unknown";
+        NaftikoSpec currentSpec = spec.get();
+        String capabilityName = currentSpec.getInfo() != null && currentSpec.getInfo().getLabel() != null
+                ? currentSpec.getInfo().getLabel() : "unknown";
         TelemetryBootstrap.get().getMetrics().capabilityStopped(capabilityName);
 
         for (ServerAdapter adapter : getServerAdapters()) {

--- a/src/main/java/io/naftiko/engine/consumes/ClientAdapter.java
+++ b/src/main/java/io/naftiko/engine/consumes/ClientAdapter.java
@@ -13,39 +13,46 @@
  */
 package io.naftiko.engine.consumes;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import io.naftiko.Capability;
 import io.naftiko.engine.Adapter;
 import io.naftiko.spec.consumes.ClientSpec;
 import io.naftiko.spec.consumes.http.HttpClientSpec;
 
 /**
- * Client Adapter implementation
+ * Client Adapter implementation.
+ *
+ * <h2>Thread safety</h2>
+ * The {@code capability} and {@code spec} references are held in {@link AtomicReference}s so
+ * that a future Control-port "hot reload" feature can replace them atomically while request
+ * threads read them. This satisfies SonarQube rule {@code java:S3077}.
  */
 public abstract class ClientAdapter extends Adapter {
 
-    private volatile Capability capability;
+    private final AtomicReference<Capability> capability = new AtomicReference<>();
 
-    private volatile ClientSpec spec;
+    private final AtomicReference<ClientSpec> spec = new AtomicReference<>();
 
     public ClientAdapter(Capability capability, ClientSpec spec) {
-        this.capability = capability;
-        this.spec = spec;
+        this.capability.set(capability);
+        this.spec.set(spec);
     }
 
     public Capability getCapability() {
-        return capability;
+        return capability.get();
     }
 
     public void setCapability(Capability capability) {
-        this.capability = capability;
+        this.capability.set(capability);
     }
 
     public ClientSpec getSpec() {
-        return spec;
+        return spec.get();
     }
 
     public void setSpec(HttpClientSpec spec) {
-        this.spec = spec;
+        this.spec.set(spec);
     }
 
 }

--- a/src/main/java/io/naftiko/engine/exposes/mcp/McpServerAdapter.java
+++ b/src/main/java/io/naftiko/engine/exposes/mcp/McpServerAdapter.java
@@ -19,6 +19,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import org.restlet.Context;
 import org.restlet.Restlet;
@@ -47,9 +48,13 @@ import io.naftiko.spec.exposes.mcp.McpToolHintsSpec;
  */
 public class McpServerAdapter extends ServerAdapter {
 
-    /** Stdio handler and thread — only initialized for stdio transport */
-    private volatile StdioJsonRpcHandler stdioHandler;
-    private volatile Thread stdioThread;
+    /**
+     * Stdio handler and thread — only initialized for stdio transport. Held in
+     * {@link AtomicReference} so {@code start()} and {@code stop()} can publish/observe them
+     * safely (see SonarQube {@code java:S3077}).
+     */
+    private final AtomicReference<StdioJsonRpcHandler> stdioHandler = new AtomicReference<>();
+    private final AtomicReference<Thread> stdioThread = new AtomicReference<>();
 
     private final ToolHandler toolHandler;
     private final List<McpSchema.Tool> tools;
@@ -132,7 +137,7 @@ public class McpServerAdapter extends ServerAdapter {
      */
     private void initStdioTransport() {
         ProtocolDispatcher dispatcher = new ProtocolDispatcher(this);
-        this.stdioHandler = new StdioJsonRpcHandler(dispatcher);
+        this.stdioHandler.set(new StdioJsonRpcHandler(dispatcher));
     }
 
     /**
@@ -229,9 +234,10 @@ public class McpServerAdapter extends ServerAdapter {
     @Override
     public void start() throws Exception {
         if (getMcpServerSpec().isStdio()) {
-            stdioThread = new Thread(stdioHandler, "mcp-stdio");
-            stdioThread.setDaemon(true);
-            stdioThread.start();
+            Thread thread = new Thread(stdioHandler.get(), "mcp-stdio");
+            thread.setDaemon(true);
+            thread.start();
+            stdioThread.set(thread);
             System.err.println("MCP Server started on stdio" + " (namespace: "
                     + getMcpServerSpec().getNamespace() + ")");
             Context.getCurrentLogger().log(Level.INFO, "MCP Server started on stdio"
@@ -251,9 +257,13 @@ public class McpServerAdapter extends ServerAdapter {
     @Override
     public void stop() throws Exception {
         if (getMcpServerSpec().isStdio()) {
-            if (stdioHandler != null) {
-                stdioHandler.shutdown();
-                stdioThread.join(5000); // Wait for the stdio thread to finish
+            StdioJsonRpcHandler handler = stdioHandler.get();
+            if (handler != null) {
+                handler.shutdown();
+                Thread thread = stdioThread.get();
+                if (thread != null) {
+                    thread.join(5000); // Wait for the stdio thread to finish
+                }
                 Context.getCurrentLogger().log(Level.INFO, "MCP Server stopped on stdio");
             }
         } else {

--- a/src/main/java/io/naftiko/engine/observability/TelemetryBootstrap.java
+++ b/src/main/java/io/naftiko/engine/observability/TelemetryBootstrap.java
@@ -25,6 +25,7 @@ import io.opentelemetry.api.common.Attributes;
 import io.naftiko.spec.observability.ObservabilitySpec;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
 
 /**
@@ -57,7 +58,13 @@ public class TelemetryBootstrap {
 
     private static final TelemetryBootstrap NOOP = new TelemetryBootstrap(OpenTelemetry.noop());
 
-    private static volatile TelemetryBootstrap instance;
+    /**
+     * Holds the current global instance. Replaced atomically by {@link #init(String, ObservabilitySpec)},
+     * {@link #init(OpenTelemetry)}, and {@link #reset()}. Reads are lock-free via {@link #get()}.
+     * {@code null} means "not initialized" — readers fall back to {@link #NOOP}.
+     * (See SonarQube {@code java:S3077}.)
+     */
+    private static final AtomicReference<TelemetryBootstrap> INSTANCE = new AtomicReference<>();
 
     private final OpenTelemetry openTelemetry;
     private final Tracer tracer;
@@ -113,21 +120,23 @@ public class TelemetryBootstrap {
     public static TelemetryBootstrap init(String serviceName, ObservabilitySpec observabilitySpec) {
         if (observabilitySpec != null && !observabilitySpec.isEnabled()) {
             logger.info("Observability disabled via spec — telemetry off");
-            instance = NOOP;
-            return instance;
+            INSTANCE.set(NOOP);
+            return NOOP;
         }
+        TelemetryBootstrap newInstance;
         try {
             Class.forName(AUTOCONFIGURE_CLASS);
-            instance = buildAutoConfigured(serviceName, observabilitySpec);
+            newInstance = buildAutoConfigured(serviceName, observabilitySpec);
         } catch (ClassNotFoundException e) {
             logger.info("OpenTelemetry SDK not on classpath — telemetry disabled");
-            instance = NOOP;
+            newInstance = NOOP;
         } catch (LinkageError | RuntimeException e) {
             logger.warning("OpenTelemetry SDK initialization failed \u2014 telemetry disabled: "
                     + e.getMessage());
-            instance = NOOP;
+            newInstance = NOOP;
         }
-        return instance;
+        INSTANCE.set(newInstance);
+        return newInstance;
     }
 
     /**
@@ -201,15 +210,16 @@ public class TelemetryBootstrap {
      * Initialize with a provided OpenTelemetry instance (for testing).
      */
     public static TelemetryBootstrap init(OpenTelemetry openTelemetry) {
-        instance = new TelemetryBootstrap(openTelemetry, null, null, true);
-        return instance;
+        TelemetryBootstrap newInstance = new TelemetryBootstrap(openTelemetry, null, null, true);
+        INSTANCE.set(newInstance);
+        return newInstance;
     }
 
     /**
      * Get the global instance, or a no-op instance if not initialized.
      */
     public static TelemetryBootstrap get() {
-        TelemetryBootstrap current = instance;
+        TelemetryBootstrap current = INSTANCE.get();
         return current != null ? current : NOOP;
     }
 
@@ -217,7 +227,7 @@ public class TelemetryBootstrap {
      * Reset the global instance. <strong>Test-only</strong> — do not call from production code.
      */
     public static void reset() {
-        instance = null;
+        INSTANCE.set(null);
     }
 
     public OpenTelemetry getOpenTelemetry() {

--- a/src/main/java/io/naftiko/engine/scripting/ScriptStepExecutor.java
+++ b/src/main/java/io/naftiko/engine/scripting/ScriptStepExecutor.java
@@ -99,7 +99,8 @@ public class ScriptStepExecutor {
             !"false".equalsIgnoreCase(System.getenv("NAFTIKO_SCRIPTING"));
 
     private final ObjectMapper mapper = new ObjectMapper();
-    private volatile ScriptingManagementSpec scriptingSpec;
+    private final java.util.concurrent.atomic.AtomicReference<ScriptingManagementSpec> scriptingSpec =
+            new java.util.concurrent.atomic.AtomicReference<>();
 
     /**
      * Called by the capability loader when a capability containing script steps is being
@@ -118,15 +119,19 @@ public class ScriptStepExecutor {
     }
 
     public void setScriptingSpec(ScriptingManagementSpec scriptingSpec) {
-        this.scriptingSpec = scriptingSpec;
+        this.scriptingSpec.set(scriptingSpec);
     }
 
     public ScriptingManagementSpec getScriptingSpec() {
-        return scriptingSpec;
+        return scriptingSpec.get();
     }
 
     public JsonNode execute(OperationStepScriptSpec scriptStep, Map<String, Object> runtimeParameters,
             StepExecutionContext stepContext) {
+
+        // Snapshot the spec once so we observe a consistent view for the duration of this call,
+        // even if a future hot-reload swaps the AtomicReference mid-execution.
+        ScriptingManagementSpec scriptingSpec = this.scriptingSpec.get();
 
         // Resolve language — step-level overrides default
         String language = scriptStep.getLanguage();

--- a/src/test/java/io/naftiko/engine/EngineFieldThreadSafetyTest.java
+++ b/src/test/java/io/naftiko/engine/EngineFieldThreadSafetyTest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.naftiko.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.naftiko.Capability;
+import io.naftiko.engine.consumes.ClientAdapter;
+import io.naftiko.engine.exposes.mcp.McpServerAdapter;
+import io.naftiko.engine.observability.TelemetryBootstrap;
+import io.naftiko.engine.scripting.ScriptStepExecutor;
+
+/**
+ * Meta-test for SonarQube rule {@code java:S3077} — Phase 3 of the Sonar bug remediation
+ * blueprint. Verifies that every engine-layer class listed in issue #424 has migrated away
+ * from the {@code volatile} keyword to {@link java.util.concurrent.atomic.AtomicReference}
+ * (or the initialization-on-demand holder idiom for true singletons).
+ *
+ * <p>This test deliberately uses reflection because the migration target is a structural
+ * property of the class itself (no field may be {@code volatile}), not a behavioral
+ * outcome of any single method. It guards against regressions where a future contributor
+ * re-introduces {@code volatile} on a non-thread-safe type.
+ *
+ * <p>Behavioral assertions for the migrated classes are covered by the existing extensive
+ * test suite — every touched class is exercised by at least one engine integration test.
+ */
+class EngineFieldThreadSafetyTest {
+
+    /**
+     * The 5 engine classes covered by Phase 3 (issue #424). Spec POJOs (Phase 2) and
+     * {@code char[]} auth password fields (Phase 4) are tracked separately.
+     */
+    private static Stream<Class<?>> phase3EngineClasses() {
+        return Stream.of(
+                Capability.class,
+                ClientAdapter.class,
+                McpServerAdapter.class,
+                TelemetryBootstrap.class,
+                ScriptStepExecutor.class);
+    }
+
+    @ParameterizedTest(name = "{0} should declare no volatile fields")
+    @MethodSource("phase3EngineClasses")
+    @DisplayName("Phase 3 engine classes must not use volatile (S3077)")
+    void engineClassShouldNotDeclareVolatileFields(Class<?> engineClass) {
+        List<String> volatileFields = new ArrayList<>();
+        for (Field field : engineClass.getDeclaredFields()) {
+            if (Modifier.isVolatile(field.getModifiers())) {
+                volatileFields.add(field.getName() + " : " + field.getType().getSimpleName());
+            }
+        }
+        assertEquals(
+                List.of(),
+                volatileFields,
+                () -> engineClass.getSimpleName()
+                        + " still declares volatile fields (S3077). "
+                        + "Migrate each one to AtomicReference<T> with an immutable snapshot, or "
+                        + "use the initialization-on-demand holder idiom for true singletons. "
+                        + "See sonar-bug-remediation.md, Phase 3.");
+    }
+}


### PR DESCRIPTION
## Summary

Phase 3 of the [Sonar bug remediation blueprint](../tree/main/../../../blueprints/sonar-bug-remediation.md). Migrates the remaining 13 `volatile` fields across 5 engine-layer classes from the `volatile` keyword to `AtomicReference<T>` (or static `AtomicReference` for resettable singletons) holding immutable snapshots.

This is the engine-layer counterpart to [#423](https://github.com/naftiko/framework/pull/423) (spec POJOs), and addresses the same SonarQube rule [`java:S3077`](https://rules.sonarsource.com/java/RSPEC-3077). The two PRs touch disjoint files and can land in any order.

Closes #424.

## Files migrated

| File | Fields | Pattern |
|---|---|---|
| `io.naftiko.Capability` | `spec`, `serverAdapters`, `clientAdapters`, `aggregates`, `bindings`, `scriptingSpec`, `stepHandlerRegistry` | A (scalar), B (List wrapping `CopyOnWriteArrayList`), C (Map snapshot) |
| `io.naftiko.engine.consumes.ClientAdapter` | `capability`, `spec` | A |
| `io.naftiko.engine.exposes.mcp.McpServerAdapter` | `stdioHandler`, `stdioThread` | A |
| `io.naftiko.engine.scripting.ScriptStepExecutor` | `scriptingSpec` | A + per-call snapshot in `execute()` |
| `io.naftiko.engine.observability.TelemetryBootstrap` | static `instance` | static `AtomicReference` (singleton is reset at runtime by `init`/`forTesting`/`reset`, so the IODH idiom does not fit) |

## Why `AtomicReference` and not the holder idiom

- All instance fields are mutated post-construction (setters, hot-reload-ready).
- `TelemetryBootstrap.instance` is explicitly reset at runtime by `init(String, ObservabilitySpec)`, `init(OpenTelemetry)` and `reset()` — the initialization-on-demand holder idiom assumes a write-once singleton, which does not match this lifecycle.

## Notes for reviewers

- `ScriptStepExecutor.execute()` now snapshots `scriptingSpec` once at entry into a local of the same name, so all subsequent reads in the method observe a consistent view for the duration of the call (avoids races with a future hot-reload setter).
- `Capability` constructor builds local list variables fully before publishing them via `AtomicReference#set` — avoids partial-state observation if the constructor throws.
- List slots wrap `CopyOnWriteArrayList` inside the `AtomicReference` so request-handling iteration remains lock-free even if a future hot-reload swaps the slot.
- `ClientAdapter#setSpec(HttpClientSpec)` keeps its subtype-narrowing parameter (intentional, predates this PR).

## Test plan

- New meta-test `EngineFieldThreadSafetyTest` (5 parameterized cases) — reflects over each migrated class and asserts no field is `volatile`. Acts as a regression guard.
- Full local suite: **926 tests, 14 failures, 0 errors**. The 14 failures are the pre-existing LLM-flaky tutorial integration tests (`Step{2-8,10}Shipyard*IntegrationTest`) that return prose like `"The..."` instead of JSON, causing `Unrecognized token 'The'` — same set as on `main` and unaffected by this change.
- Bug Workflow followed: failing test committed first (`test: add failing meta-test...`), then fix (`fix: migrate engine fields...`).
