### PR TITLE
feat: add field type migration rule to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,8 @@ If you still want to run the full pre-PR checks locally, install [Trivy](https:/
 
 **Method visibility** — prefer package-private (no modifier) over `private` for methods that implement non-trivial logic. This allows direct unit testing from the same package without reflection. Reserve `private` for truly internal helpers that are trivially covered by public API tests (e.g. one-liner formatters, simple getters).
 
+**Field type migration** — when changing the type of a field (e.g. `T` → `AtomicReference<T>`, plain `int` → `AtomicInteger`), grep the entire owning class for direct field accesses (`fieldName.someMethod()`, `fieldName.length`, etc.) before declaring the migration done. Updating only the getter and setter is not enough — every read inside the class becomes a compile error otherwise. The IDE may not flag these when the field name is also reused as a method parameter (shadowing). For long methods, snapshot the new wrapper into a local variable of the original type at the top of the method so the rest of the body stays unchanged and observes a consistent view for the call duration.
+
 Never modify CI/CD workflows (`.github/workflows/`), security configs, or branch protection rules.
 
 ## Test Writing Rules
@@ -215,4 +217,4 @@ When all three conditions are met, propose the specific Do/Don't entry and the s
 
 When the conditions are **not** met, do not propose anything — avoid noise. Most corrections are one-off and do not need a rule.
 
-For reference, the Test Writing Rules and Method Visibility sections in this file were both added through this process.
+For reference, the Test Writing Rules, Method Visibility, and Field Type Migration sections in this file were all added through this process.


### PR DESCRIPTION
## Summary

Adds a **Field type migration** rule to the Code Style section of `AGENTS.md`. The rule was derived from a real correction made during the Phase 3 Sonar bug remediation work (PR #425) and meets all three Self-Improvement criteria: structural, generalizable, and triggered by an agent-generated mistake.

## What changed

A new bullet under `## Code Style`, immediately after **Method visibility**, telling agents to grep the entire owning class for direct field accesses (`field.someMethod()`, `field.length`, etc.) whenever they change the type of a field — e.g. `T` → `AtomicReference<T>`, plain `int` → `AtomicInteger`. Updating only getters and setters is not enough: every read inside the class becomes a compile error otherwise. Recommends snapshotting into a local variable of the original type at the top of long methods so the rest of the body stays unchanged and observes a consistent view for the call duration.

The cross-reference paragraph at the end of `## Self-Improvement` was updated to mention this new section alongside the existing Test Writing Rules and Method Visibility entries.

## Why now

During PR #425 (Phase 3 — engine S3077 migration), the `ScriptStepExecutor.scriptingSpec` migration initially missed 14 direct field accesses inside `execute()`. The IDE's quick-error checker did not flag them because the field name `scriptingSpec` is also reused as a method parameter elsewhere in the class (shadowing). The mistake only surfaced at `mvn test` time as 46 cascading `Unresolved compilation problems` test failures. The fix was straightforward (snapshot once at method entry) and the lesson is generalizable to any future field type migration.

## Self-Improvement check

- ✅ **Structural** — targets a refactoring discipline, not a one-off domain bug.
- ✅ **Generalizable** — the same mistake could recur on any class where a field type changes (any `volatile` → `Atomic*` migration, any boxed → primitive holder change).
- ✅ **Agent-generated** — the original mistake was made by the agent during PR #425.

## Test plan

Documentation-only change; no code or tests touched. Local `mvn test` still passes the same 926/14-known-flaky baseline as `main`.
