### PR TITLE
fix: migrate auth spec credentials to AtomicReference + defensive copies (S3077, Phase 4)

### DIFF
--- a/src/main/java/io/naftiko/spec/consumes/http/BasicAuthenticationSpec.java
+++ b/src/main/java/io/naftiko/spec/consumes/http/BasicAuthenticationSpec.java
@@ -13,13 +13,22 @@
  */
 package io.naftiko.spec.consumes.http;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 /**
- * HTTP Basic Authentication Specification Element
+ * HTTP Basic Authentication Specification Element.
+ *
+ * <h2>Thread safety</h2>
+ * Credential fields are stored in {@link AtomicReference}s so they can be rotated atomically
+ * at runtime (token refresh, Control-port credential update). The {@code char[]} password is
+ * defensively cloned on both {@code set} and {@code get} so callers cannot mutate the stored
+ * credential in place. This satisfies SonarQube rule {@code java:S3077} and aligns with the
+ * blueprint's "atomic password storage" pattern.
  */
 public class BasicAuthenticationSpec extends AuthenticationSpec {
 
-    private volatile String username;
-    private volatile char[] password;
+    private final AtomicReference<String> username = new AtomicReference<>();
+    private final AtomicReference<char[]> password = new AtomicReference<>();
 
     public BasicAuthenticationSpec() {
         this(null, null);
@@ -27,24 +36,25 @@ public class BasicAuthenticationSpec extends AuthenticationSpec {
 
     public BasicAuthenticationSpec(String username, char[] password) {
         super("basic");
-        this.username = username;
-        this.password = password;
+        this.username.set(username);
+        this.password.set(password == null ? null : password.clone());
     }
 
     public String getUsername() {
-        return username;
+        return username.get();
     }
 
     public void setUsername(String username) {
-        this.username = username;
+        this.username.set(username);
     }
 
     public char[] getPassword() {
-        return password;
+        char[] current = password.get();
+        return current == null ? null : current.clone();
     }
 
     public void setPassword(char[] password) {
-        this.password = password;
+        this.password.set(password == null ? null : password.clone());
     }
 
 }

--- a/src/main/java/io/naftiko/spec/consumes/http/DigestAuthenticationSpec.java
+++ b/src/main/java/io/naftiko/spec/consumes/http/DigestAuthenticationSpec.java
@@ -13,13 +13,22 @@
  */
 package io.naftiko.spec.consumes.http;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 /**
- * HTTP Digest Authentication Specification Element
+ * HTTP Digest Authentication Specification Element.
+ *
+ * <h2>Thread safety</h2>
+ * Credential fields are stored in {@link AtomicReference}s so they can be rotated atomically
+ * at runtime (token refresh, Control-port credential update). The {@code char[]} password is
+ * defensively cloned on both {@code set} and {@code get} so callers cannot mutate the stored
+ * credential in place. This satisfies SonarQube rule {@code java:S3077} and aligns with the
+ * blueprint's "atomic password storage" pattern.
  */
 public class DigestAuthenticationSpec extends AuthenticationSpec {
 
-    private volatile String username;
-    private volatile char[] password;
+    private final AtomicReference<String> username = new AtomicReference<>();
+    private final AtomicReference<char[]> password = new AtomicReference<>();
 
     public DigestAuthenticationSpec() {
         this(null, null);
@@ -27,24 +36,25 @@ public class DigestAuthenticationSpec extends AuthenticationSpec {
 
     public DigestAuthenticationSpec(String username, char[] password) {
         super("digest");
-        this.username = username;
-        this.password = password;
+        this.username.set(username);
+        this.password.set(password == null ? null : password.clone());
     }
 
     public String getUsername() {
-        return username;
+        return username.get();
     }
 
     public void setUsername(String username) {
-        this.username = username;
+        this.username.set(username);
     }
 
     public char[] getPassword() {
-        return password;
+        char[] current = password.get();
+        return current == null ? null : current.clone();
     }
 
     public void setPassword(char[] password) {
-        this.password = password;
+        this.password.set(password == null ? null : password.clone());
     }
 
 }

--- a/src/test/java/io/naftiko/spec/consumes/http/AuthenticationSpecThreadSafetyTest.java
+++ b/src/test/java/io/naftiko/spec/consumes/http/AuthenticationSpecThreadSafetyTest.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.naftiko.spec.consumes.http;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Phase 4 of the Sonar bug remediation blueprint — verifies that the credential fields
+ * on {@link BasicAuthenticationSpec} and {@link DigestAuthenticationSpec} are migrated
+ * away from {@code volatile} (Sonar {@code java:S3077}) and that the {@code char[]}
+ * password is defensively copied on both set and get to prevent silent in-place mutation
+ * of stored credentials by callers.
+ *
+ * <p>The defensive-copy assertions are not just a hygiene concern: without them, a caller
+ * doing {@code spec.getPassword()[0] = 'x'} silently rewrites the stored credential —
+ * which is exactly what the blueprint's "atomic password storage" pattern guards against.
+ */
+class AuthenticationSpecThreadSafetyTest {
+
+    private static Stream<Class<?>> phase4AuthClasses() {
+        return Stream.of(BasicAuthenticationSpec.class, DigestAuthenticationSpec.class);
+    }
+
+    @ParameterizedTest(name = "{0} should declare no volatile fields")
+    @MethodSource("phase4AuthClasses")
+    @DisplayName("Phase 4 authentication specs must not use volatile (S3077)")
+    void authSpecShouldNotDeclareVolatileFields(Class<?> authClass) {
+        List<String> volatileFields = new ArrayList<>();
+        for (Field field : authClass.getDeclaredFields()) {
+            if (Modifier.isVolatile(field.getModifiers())) {
+                volatileFields.add(field.getName() + " : " + field.getType().getSimpleName());
+            }
+        }
+        assertEquals(
+                List.of(),
+                volatileFields,
+                () -> authClass.getSimpleName()
+                        + " still declares volatile fields (S3077). "
+                        + "Migrate each one to AtomicReference<T>; the char[] password must "
+                        + "be defensively cloned on set and get. "
+                        + "See sonar-bug-remediation.md, Phase 4.");
+    }
+
+    @Test
+    @DisplayName("BasicAuth setPassword should defensively clone the input array")
+    void basicAuthSetPasswordShouldDefensivelyCloneInput() {
+        BasicAuthenticationSpec spec = new BasicAuthenticationSpec();
+        char[] caller = {'s', 'e', 'c', 'r', 'e', 't'};
+        spec.setPassword(caller);
+        caller[0] = 'X';
+        assertArrayEquals(new char[]{'s', 'e', 'c', 'r', 'e', 't'}, spec.getPassword(),
+                "setPassword must clone — caller mutation must not affect the stored value");
+    }
+
+    @Test
+    @DisplayName("BasicAuth getPassword should defensively clone the stored array")
+    void basicAuthGetPasswordShouldDefensivelyCloneOutput() {
+        BasicAuthenticationSpec spec = new BasicAuthenticationSpec();
+        spec.setPassword(new char[]{'s', 'e', 'c', 'r', 'e', 't'});
+        char[] firstRead = spec.getPassword();
+        char[] secondRead = spec.getPassword();
+        assertNotSame(firstRead, secondRead,
+                "getPassword must return a fresh copy each call");
+        firstRead[0] = 'X';
+        assertArrayEquals(new char[]{'s', 'e', 'c', 'r', 'e', 't'}, spec.getPassword(),
+                "getPassword must clone — caller mutation must not affect the stored value");
+    }
+
+    @Test
+    @DisplayName("BasicAuth setPassword(null) should be supported and read back as null")
+    void basicAuthSetPasswordShouldAcceptNull() {
+        BasicAuthenticationSpec spec = new BasicAuthenticationSpec("user",
+                new char[]{'p', 'w'});
+        spec.setPassword(null);
+        assertNull(spec.getPassword());
+    }
+
+    @Test
+    @DisplayName("DigestAuth setPassword should defensively clone the input array")
+    void digestAuthSetPasswordShouldDefensivelyCloneInput() {
+        DigestAuthenticationSpec spec = new DigestAuthenticationSpec();
+        char[] caller = {'s', 'e', 'c', 'r', 'e', 't'};
+        spec.setPassword(caller);
+        caller[0] = 'X';
+        assertArrayEquals(new char[]{'s', 'e', 'c', 'r', 'e', 't'}, spec.getPassword(),
+                "setPassword must clone — caller mutation must not affect the stored value");
+    }
+
+    @Test
+    @DisplayName("DigestAuth getPassword should defensively clone the stored array")
+    void digestAuthGetPasswordShouldDefensivelyCloneOutput() {
+        DigestAuthenticationSpec spec = new DigestAuthenticationSpec();
+        spec.setPassword(new char[]{'s', 'e', 'c', 'r', 'e', 't'});
+        char[] firstRead = spec.getPassword();
+        char[] secondRead = spec.getPassword();
+        assertNotSame(firstRead, secondRead,
+                "getPassword must return a fresh copy each call");
+        firstRead[0] = 'X';
+        assertArrayEquals(new char[]{'s', 'e', 'c', 'r', 'e', 't'}, spec.getPassword(),
+                "getPassword must clone — caller mutation must not affect the stored value");
+    }
+
+    @Test
+    @DisplayName("DigestAuth setPassword(null) should be supported and read back as null")
+    void digestAuthSetPasswordShouldAcceptNull() {
+        DigestAuthenticationSpec spec = new DigestAuthenticationSpec("user",
+                new char[]{'p', 'w'});
+        spec.setPassword(null);
+        assertNull(spec.getPassword());
+    }
+}

--- a/src/test/java/io/naftiko/spec/consumes/http/AuthenticationSpecThreadSafetyTest.java
+++ b/src/test/java/io/naftiko/spec/consumes/http/AuthenticationSpecThreadSafetyTest.java
@@ -101,6 +101,14 @@ class AuthenticationSpecThreadSafetyTest {
     }
 
     @Test
+    @DisplayName("BasicAuth setUsername should round-trip the value")
+    void basicAuthSetUsernameShouldRoundTrip() {
+        BasicAuthenticationSpec spec = new BasicAuthenticationSpec();
+        spec.setUsername("alice");
+        assertEquals("alice", spec.getUsername());
+    }
+
+    @Test
     @DisplayName("DigestAuth setPassword should defensively clone the input array")
     void digestAuthSetPasswordShouldDefensivelyCloneInput() {
         DigestAuthenticationSpec spec = new DigestAuthenticationSpec();


### PR DESCRIPTION
## Summary

Phase 4 (final phase) of the [Sonar bug remediation blueprint](https://github.com/naftiko/blueprints/blob/main/sonar-bug-remediation.md). Migrates the credential fields on `BasicAuthenticationSpec` and `DigestAuthenticationSpec` away from `volatile` to `AtomicReference<T>`, with the `char[]` password **defensively cloned** on both set and get.

This is the third and final S3077 PR, after #423 (Phase 2 — spec POJOs) and #425 (Phase 3 — engine layer). The blueprint's bug count drops from 59 → 0 once Phases 1–4 land.

Closes #427.

## What changed

| File | Fields migrated | Pattern |
|---|---|---|
| `io.naftiko.spec.consumes.http.BasicAuthenticationSpec` | `username` (String), `password` (char[]) | `AtomicReference<String>` (Pattern A) + `AtomicReference<char[]>` with defensive clone on set/get |
| `io.naftiko.spec.consumes.http.DigestAuthenticationSpec` | `username` (String), `password` (char[]) | same |

Each `setPassword(char[])` clones the input before storing; each `getPassword()` clones the stored array before returning. Constructors do the same. The public API stays exactly as `String` / `char[]` — Jackson and existing callers are unaffected.

## Why defensive clone, not just `AtomicReference<char[]>`

The blueprint's "Atomic Password Storage" pattern is explicit: defensive copies on set and get are **not optional**. Without them, `getPassword()` hands out the live internal array — a caller doing `spec.getPassword()[0] = 'x'` silently rewrites the stored credential. The new test suite exercises this exact scenario and would have caught it before this PR.

This pairs naturally with `AtomicReference` because both are about safe handoff of a credential value across threads or callers: atomic-swap for the reference itself, defensive-copy for the array contents.

## Test plan

New `AuthenticationSpecThreadSafetyTest` (8 cases, **two-tier**):

1. **Meta-tests (2)** — reflection-based, parameterized over both classes; assert no field is `volatile`. Same regression-guard style as `SpecFieldThreadSafetyTest` (#423) and `EngineFieldThreadSafetyTest` (#425).
2. **Behavioral tests (6)** — assert `setPassword`/`getPassword` defensively clone, and `setPassword(null)` round-trips correctly. These test a **real bug**: on `main`, callers can mutate the stored credential in place via the live array reference.

Bug Workflow followed strictly:
- Failing test committed first (commit `b3d00d6`) — 6/8 fail on `main` as expected (2 meta + 4 defensive-copy)
- Migration committed second (commit `b55a70b`) — all 8 now pass

Full local suite: **929 tests, 14 failures, 0 errors**. The 14 are the pre-existing LLM-flaky `Step{2-8,10}Shipyard*IntegrationTest` cases — same set as on `main` and unrelated.

## Notes for reviewers

- The blueprint scope was the 2 `volatile char[] password` fields. I also migrated the 2 `volatile String username` fields in the same classes for internal consistency — same approach as Phase 2 (which migrated 27 files for 44 hits) and Phase 3 (which migrated 13 fields for 9 explicit hits).
- `OasImportConverter` is the only production caller of `setPassword(char[])` outside tests — both call sites pass freshly-allocated `"{{PASSWORD}}".toCharArray()` and discard the reference, so the new defensive clone has no observable effect on them.
- Phase 1 (#420) already fixed `HttpClientAdapter`'s `char[].toString()` bug (S2116), so the read path now sees the correct password value through `new String(password)`.
