### PR TITLE
fix: generic name for publish engine workflow

### DIFF
--- a/.github/workflows/publish-engine-image.yml
+++ b/.github/workflows/publish-engine-image.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-push:
+  build-and-push-to-ghcr:
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
## Related Issue

no related issue

---

## What does this PR do?

renames the workflow name to a generic one, patches the job build and publish to build and publish to github container registry 


---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
