### PR TITLE
fix: remove uri calls in java integration tests

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -35,6 +35,75 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "---" >> $GITHUB_STEP_SUMMARY
 
+      - name: Start Microcks
+        run: |
+          docker run -d \
+            -p 8080:8080 \
+            quay.io/microcks/microcks-uber:latest  
+
+      - name: Wait for Microcks
+        run: |
+          sleep 15
+          curl -sf http://localhost:8080/api/health || (echo "Microcks failed to start" && exit 1)
+
+
+      - name: Import OpenAPI specs into Microcks
+        run: |
+          for file in .github/microcks/*.yaml; do
+            echo "Importing $file"
+            curl -s -X POST "http://localhost:8080/api/artifact/upload" \
+              -F "file=@$file"
+          done
+
+      - name: Patch baseUri in capability files
+        run: |
+          TUTORIAL_DIR="src/main/resources/tutorial"
+
+          get_base_uri() {
+            case "$1" in
+              registry) echo "http://localhost:8080/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2" ;;
+              legacy)   echo "http://localhost:8080/rest/naftiko-shipyard-legacy-dockyard-api/1.0.0-alpha2" ;;
+              *)        echo "" ;;
+            esac
+          }
+
+          find "$TUTORIAL_DIR" -name "*.yaml" -o -name "*.yml" | while read file; do
+            COUNT=$(yq '.capability.consumes | length' "$file" 2>/dev/null)
+            { [ -z "$COUNT" ] || [ "$COUNT" = "0" ] || [ "$COUNT" = "null" ]; } && continue
+
+            for i in $(seq 0 $(($COUNT - 1))); do
+              IMPORT=$(yq -r ".capability.consumes[$i].import // \"\"" "$file")
+
+              if [ -n "$IMPORT" ]; then
+                # Import-style: patch the referenced shared file
+                LOCATION=$(yq -r ".capability.consumes[$i].location" "$file")
+                SHARED_FILE="$(dirname "$file")/$LOCATION"
+
+                [ ! -f "$SHARED_FILE" ] && echo "Warning: $SHARED_FILE not found, skipping" && continue
+
+                NAMESPACE=$(yq -r ".consumes[0].namespace" "$SHARED_FILE")
+                BASE_URI=$(get_base_uri "$NAMESPACE")
+                [ -z "$BASE_URI" ] && continue
+
+                echo "Patching shared file $SHARED_FILE: '$NAMESPACE' → $BASE_URI"
+                yq -i ".consumes[0].baseUri = \"$BASE_URI\"" "$SHARED_FILE"
+              else
+                # Inline-style: patch baseUri directly in the tutorial file
+                NAMESPACE=$(yq -r ".capability.consumes[$i].namespace // \"\"" "$file")
+                [ -z "$NAMESPACE" ] && continue
+
+                BASE_URI=$(get_base_uri "$NAMESPACE")
+                [ -z "$BASE_URI" ] && continue
+
+                echo "Patching $file inline: '$NAMESPACE' → $BASE_URI"
+                yq -i ".capability.consumes[$i].baseUri = \"$BASE_URI\"" "$file"
+              fi
+            done
+          done
+        
+      - name: Prepare shared path
+        run: ln -s src/main/resources/tutorial/shared shared
+
       - name: Run tests + JaCoCo coverage
         run: mvn clean test --no-transfer-progress
 

--- a/.github/workflows/validate-tuto-examples.yml
+++ b/.github/workflows/validate-tuto-examples.yml
@@ -75,7 +75,7 @@ jobs:
 
         find "$TUTORIAL_DIR" -name "*.yaml" -o -name "*.yml" | while read file; do
           COUNT=$(yq '.capability.consumes | length' "$file" 2>/dev/null)
-          [ -z "$COUNT" ] || [ "$COUNT" = "0" ] || [ "$COUNT" = "null" ] && continue
+          { [ -z "$COUNT" ] || [ "$COUNT" = "0" ] || [ "$COUNT" = "null" ]; } && continue
 
           for i in $(seq 0 $(($COUNT - 1))); do
             IMPORT=$(yq -r ".capability.consumes[$i].import // \"\"" "$file")

--- a/src/test/java/io/naftiko/tutorial/Step10ShipyardRestAdapterIntegrationTest.java
+++ b/src/test/java/io/naftiko/tutorial/Step10ShipyardRestAdapterIntegrationTest.java
@@ -32,12 +32,9 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import io.naftiko.Capability;
-import io.naftiko.engine.consumes.ConsumesImportResolver;
 import io.naftiko.engine.exposes.ServerAdapter;
 import io.naftiko.engine.exposes.skill.SkillServerAdapter;
 import io.naftiko.spec.NaftikoSpec;
-import io.naftiko.spec.consumes.ClientSpec;
-import io.naftiko.spec.consumes.http.HttpClientSpec;
 import io.naftiko.spec.exposes.rest.RestServerSpec;
 import io.naftiko.spec.exposes.skill.SkillServerSpec;
 
@@ -55,12 +52,6 @@ public class Step10ShipyardRestAdapterIntegrationTest
             "src/main/resources/tutorial/step-10-shipyard-rest-adapter.yml";
     private static final String SECRETS_FILE =
             "src/main/resources/tutorial/shared/secrets.yaml";
-    private static final String TUTORIAL_DIR =
-            "src/main/resources/tutorial";
-    private static final String REGISTRY_MOCK_URI =
-            "https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha1";
-    private static final String LEGACY_MOCK_URI =
-            "https://mocks.naftiko.net/rest/naftiko-shipyard-legacy-dockyard-api/1.0.0-alpha1";
 
     private int restPort;
     private List<ServerAdapter> allAdapters = new ArrayList<>();
@@ -81,23 +72,6 @@ public class Step10ShipyardRestAdapterIntegrationTest
         NaftikoSpec spec = loadSpec(CAPABILITY_FILE);
         useMcpServerToken(SECRETS_FILE);
 
-        String secretsAbsoluteUri = new File(SECRETS_FILE).getAbsoluteFile().toURI().toString();
-        spec.getBinds().get(0).setLocation(secretsAbsoluteUri);
-        spec.getBinds().get(1).setLocation(secretsAbsoluteUri);
-
-        String tutorialAbsoluteDir = new File(TUTORIAL_DIR).getAbsolutePath();
-        new ConsumesImportResolver().resolveImports(
-                spec.getCapability().getConsumes(), tutorialAbsoluteDir);
-
-        for (ClientSpec cs : spec.getCapability().getConsumes()) {
-            if (cs instanceof HttpClientSpec) {
-                if ("registry".equals(cs.getNamespace())) {
-                    ((HttpClientSpec) cs).setBaseUri(REGISTRY_MOCK_URI);
-                } else if ("legacy".equals(cs.getNamespace())) {
-                    ((HttpClientSpec) cs).setBaseUri(LEGACY_MOCK_URI);
-                }
-            }
-        }
 
         restPort = findFreePort();
         int mcpPort = findFreePort();
@@ -269,19 +243,6 @@ public class Step10ShipyardRestAdapterIntegrationTest
         spec.getBinds().get(0).setLocation(secretsAbsoluteUri);
         spec.getBinds().get(1).setLocation(secretsAbsoluteUri);
 
-        String tutorialAbsoluteDir = new File(TUTORIAL_DIR).getAbsolutePath();
-        new ConsumesImportResolver().resolveImports(
-                spec.getCapability().getConsumes(), tutorialAbsoluteDir);
-
-        for (ClientSpec cs : spec.getCapability().getConsumes()) {
-            if (cs instanceof HttpClientSpec) {
-                if ("registry".equals(cs.getNamespace())) {
-                    ((HttpClientSpec) cs).setBaseUri(REGISTRY_MOCK_URI);
-                } else if ("legacy".equals(cs.getNamespace())) {
-                    ((HttpClientSpec) cs).setBaseUri(LEGACY_MOCK_URI);
-                }
-            }
-        }
 
         return spec;
     }

--- a/src/test/java/io/naftiko/tutorial/Step11ShipyardFleetManifestIntegrationTest.java
+++ b/src/test/java/io/naftiko/tutorial/Step11ShipyardFleetManifestIntegrationTest.java
@@ -16,7 +16,6 @@ package io.naftiko.tutorial;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -31,12 +30,9 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import io.naftiko.Capability;
-import io.naftiko.engine.consumes.ConsumesImportResolver;
 import io.naftiko.engine.exposes.ServerAdapter;
 import io.naftiko.engine.exposes.skill.SkillServerAdapter;
 import io.naftiko.spec.NaftikoSpec;
-import io.naftiko.spec.consumes.ClientSpec;
-import io.naftiko.spec.consumes.http.HttpClientSpec;
 import io.naftiko.spec.exposes.rest.RestServerSpec;
 import io.naftiko.spec.exposes.skill.SkillServerSpec;
 
@@ -55,12 +51,6 @@ public class Step11ShipyardFleetManifestIntegrationTest
             "src/main/resources/tutorial/step-11-shipyard-fleet-manifest.yml";
     private static final String SECRETS_FILE =
             "src/main/resources/tutorial/shared/secrets.yaml";
-    private static final String TUTORIAL_DIR =
-            "src/main/resources/tutorial";
-    private static final String REGISTRY_MOCK_URI =
-            "https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha1";
-    private static final String LEGACY_MOCK_URI =
-            "https://mocks.naftiko.net/rest/naftiko-shipyard-legacy-dockyard-api/1.0.0-alpha1";
 
     private int restPort;
     private List<ServerAdapter> allAdapters = new ArrayList<>();
@@ -81,24 +71,6 @@ public class Step11ShipyardFleetManifestIntegrationTest
         NaftikoSpec spec = loadSpec(CAPABILITY_FILE);
         useMcpServerToken(SECRETS_FILE);
         disableMcpAuthentication(spec);
-
-        String secretsAbsoluteUri = new File(SECRETS_FILE).getAbsoluteFile().toURI().toString();
-        spec.getBinds().get(0).setLocation(secretsAbsoluteUri);
-        spec.getBinds().get(1).setLocation(secretsAbsoluteUri);
-
-        String tutorialAbsoluteDir = new File(TUTORIAL_DIR).getAbsolutePath();
-        new ConsumesImportResolver().resolveImports(
-                spec.getCapability().getConsumes(), tutorialAbsoluteDir);
-
-        for (ClientSpec cs : spec.getCapability().getConsumes()) {
-            if (cs instanceof HttpClientSpec) {
-                if ("registry".equals(cs.getNamespace())) {
-                    ((HttpClientSpec) cs).setBaseUri(REGISTRY_MOCK_URI);
-                } else if ("legacy".equals(cs.getNamespace())) {
-                    ((HttpClientSpec) cs).setBaseUri(LEGACY_MOCK_URI);
-                }
-            }
-        }
 
         restPort = findFreePort();
         int mcpPort = findFreePort();
@@ -227,23 +199,6 @@ public class Step11ShipyardFleetManifestIntegrationTest
         NaftikoSpec spec = loadSpec(CAPABILITY_FILE);
         disableMcpAuthentication(spec);
 
-        String secretsAbsoluteUri = new File(SECRETS_FILE).getAbsoluteFile().toURI().toString();
-        spec.getBinds().get(0).setLocation(secretsAbsoluteUri);
-        spec.getBinds().get(1).setLocation(secretsAbsoluteUri);
-
-        String tutorialAbsoluteDir = new File(TUTORIAL_DIR).getAbsolutePath();
-        new ConsumesImportResolver().resolveImports(
-                spec.getCapability().getConsumes(), tutorialAbsoluteDir);
-
-        for (ClientSpec cs : spec.getCapability().getConsumes()) {
-            if (cs instanceof HttpClientSpec) {
-                if ("registry".equals(cs.getNamespace())) {
-                    ((HttpClientSpec) cs).setBaseUri(REGISTRY_MOCK_URI);
-                } else if ("legacy".equals(cs.getNamespace())) {
-                    ((HttpClientSpec) cs).setBaseUri(LEGACY_MOCK_URI);
-                }
-            }
-        }
 
         return spec;
     }

--- a/src/test/java/io/naftiko/tutorial/Step2ShipyardMcpClientIntegrationTest.java
+++ b/src/test/java/io/naftiko/tutorial/Step2ShipyardMcpClientIntegrationTest.java
@@ -24,8 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-import io.naftiko.spec.NaftikoSpec;
-import io.naftiko.spec.consumes.http.HttpClientSpec;
+
 
 /**
  * End-to-end integration test for {@code step-2-shipyard-wiring.yml} exercised
@@ -55,14 +54,10 @@ public class Step2ShipyardMcpClientIntegrationTest
 
     private static final String CAPABILITY_FILE =
             "src/main/resources/tutorial/step-2-shipyard-wiring.yml";
-    private static final String MOCK_BASE_URI =
-            "https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha1";
 
     @BeforeEach
     public void startServer() throws Exception {
-        NaftikoSpec spec = loadSpec(CAPABILITY_FILE);
-        ((HttpClientSpec) spec.getCapability().getConsumes().get(0)).setBaseUri(MOCK_BASE_URI);
-        startServerFromSpec(spec);
+        startServerFromSpec(loadSpec(CAPABILITY_FILE));
     }
 
     // ── tools/list ───────────────────────────────────────────────────────────

--- a/src/test/java/io/naftiko/tutorial/Step3ShipyardMcpClientIntegrationTest.java
+++ b/src/test/java/io/naftiko/tutorial/Step3ShipyardMcpClientIntegrationTest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
 import java.net.http.HttpClient;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -27,7 +26,6 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import io.naftiko.spec.NaftikoSpec;
-import io.naftiko.spec.consumes.http.HttpClientSpec;
 
 /**
  * End-to-end integration test for {@code step-3-shipyard-auth-and-binds.yml} exercised
@@ -65,8 +63,6 @@ public class Step3ShipyardMcpClientIntegrationTest
 
     private static final String CAPABILITY_FILE =
         "src/main/resources/tutorial/step-3-shipyard-auth.yml";
-    private static final String MOCK_BASE_URI =
-            "https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha1";
     private static final String SECRETS_FILE =
             "src/main/resources/tutorial/shared/secrets.yaml";
 
@@ -75,16 +71,6 @@ public class Step3ShipyardMcpClientIntegrationTest
         NaftikoSpec spec = loadSpec(CAPABILITY_FILE);
         useMcpServerToken(SECRETS_FILE);
 
-        // Override the bind location to an absolute file URI so the BindingResolver finds it
-        // regardless of the Maven working directory (tutorial uses file:///./shared/secrets.yaml
-        // which would resolve relative to the project root, not the tutorial folder)
-        String secretsAbsoluteUri = new File(SECRETS_FILE).getAbsoluteFile().toURI().toString();
-        spec.getBinds().get(0).setLocation(secretsAbsoluteUri);
-
-        // Override the upstream baseUri (tutorial targets http://localhost:8080 as a local mock;
-        // tests hit the real mock server at mocks.naftiko.net)
-        HttpClientSpec registrySpec = (HttpClientSpec) spec.getCapability().getConsumes().get(0);
-        registrySpec.setBaseUri(MOCK_BASE_URI);
 
         startServerFromSpec(spec);
     }

--- a/src/test/java/io/naftiko/tutorial/Step4ShipyardMcpClientIntegrationTest.java
+++ b/src/test/java/io/naftiko/tutorial/Step4ShipyardMcpClientIntegrationTest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
 import java.net.http.HttpClient;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -25,7 +24,6 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-import io.naftiko.spec.consumes.http.HttpClientSpec;
 import io.naftiko.spec.NaftikoSpec;
 
 /**
@@ -61,8 +59,6 @@ public class Step4ShipyardMcpClientIntegrationTest
 
         private static final String CAPABILITY_FILE =
             "src/main/resources/tutorial/step-4-shipyard-output-shaping.yml";
-        private static final String MOCK_BASE_URI =
-            "https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha1";
     private static final String SECRETS_FILE =
             "src/main/resources/tutorial/shared/secrets.yaml";
 
@@ -71,13 +67,6 @@ public class Step4ShipyardMcpClientIntegrationTest
         NaftikoSpec spec = loadSpec(CAPABILITY_FILE);
         useMcpServerToken(SECRETS_FILE);
 
-        // Patch bind location to absolute URI — the tutorial uses file:///./shared/secrets.yaml
-        // which resolves relative to the project root, not the tutorial subdirectory
-        String secretsAbsoluteUri = new File(SECRETS_FILE).getAbsoluteFile().toURI().toString();
-        spec.getBinds().get(0).setLocation(secretsAbsoluteUri);
-
-        // Patch the consumed registry baseUri to the live mock endpoint used by this test.
-        ((HttpClientSpec) spec.getCapability().getConsumes().get(0)).setBaseUri(MOCK_BASE_URI);
 
         startServerFromSpec(spec);
     }

--- a/src/test/java/io/naftiko/tutorial/Step5ShipyardMcpClientIntegrationTest.java
+++ b/src/test/java/io/naftiko/tutorial/Step5ShipyardMcpClientIntegrationTest.java
@@ -17,24 +17,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
 import java.net.http.HttpClient;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.restlet.Application;
-import org.restlet.Component;
-import org.restlet.Restlet;
-import org.restlet.data.MediaType;
-import org.restlet.data.Protocol;
-import org.restlet.data.Status;
-import org.restlet.routing.Router;
+
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.naftiko.engine.consumes.ConsumesImportResolver;
 import io.naftiko.spec.NaftikoSpec;
-import io.naftiko.spec.consumes.ClientSpec;
 import io.naftiko.spec.consumes.http.HttpClientSpec;
 
 /**
@@ -79,95 +70,18 @@ public class Step5ShipyardMcpClientIntegrationTest
             "src/main/resources/tutorial/step-5-shipyard-multi-source.yml";
     private static final String SECRETS_FILE =
             "src/main/resources/tutorial/shared/secrets.yaml";
-    private static final String TUTORIAL_DIR =
-            "src/main/resources/tutorial";
-        private static final String REGISTRY_MOCK_URI =
-            "https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha1";
 
-    private static final String LEGACY_XML_RESPONSE = """
-            <vessels>
-              <vessel>
-                <vesselCode>LEGACY-4012</vesselCode>
-                <vesselName>Old Faithful</vesselName>
-                <category>cargo</category>
-                <flagState>GB</flagState>
-                <operationalStatus>active</operationalStatus>
-              </vessel>
-              <vessel>
-                <vesselCode>LEGACY-2087</vesselCode>
-                <vesselName>Iron Maiden</vesselName>
-                <category>bulk_carrier</category>
-                <flagState>PA</flagState>
-                <operationalStatus>laid_up</operationalStatus>
-              </vessel>
-            </vessels>
-            """;
 
-    private Component legacyMockServer;
 
     @BeforeEach
     public void startServer() throws Exception {
         NaftikoSpec spec = loadSpec(CAPABILITY_FILE);
         useMcpServerToken(SECRETS_FILE);
 
-        // Patch both bind locations to an absolute file URI
-        String secretsAbsoluteUri = new File(SECRETS_FILE).getAbsoluteFile().toURI().toString();
-        spec.getBinds().get(0).setLocation(secretsAbsoluteUri);
-        spec.getBinds().get(1).setLocation(secretsAbsoluteUri);
-
-        // Resolve imported consumes (./shared/*.yaml) against the tutorial directory.
-        // After this call the consumes list contains HttpClientSpec objects, so the
-        // subsequent Capability(spec) constructor finds nothing left to import.
-        String tutorialAbsoluteDir = new File(TUTORIAL_DIR).getAbsolutePath();
-        new ConsumesImportResolver().resolveImports(
-                spec.getCapability().getConsumes(), tutorialAbsoluteDir);
-
-        // Start a local XML mock for the legacy dockyard API
-        int legacyPort = findFreePort();
-        legacyMockServer = createLegacyXmlMock(legacyPort);
-        legacyMockServer.start();
-
-        // Patch baseUris: registry → remote mock, legacy → local XML mock
-        for (ClientSpec cs : spec.getCapability().getConsumes()) {
-            if (cs instanceof HttpClientSpec) {
-                if ("registry".equals(cs.getNamespace())) {
-                    ((HttpClientSpec) cs).setBaseUri(REGISTRY_MOCK_URI);
-                } else if ("legacy".equals(cs.getNamespace())) {
-                    ((HttpClientSpec) cs).setBaseUri("http://localhost:" + legacyPort);
-                }
-            }
-        }
 
         startServerFromSpec(spec);
     }
 
-    @AfterEach
-    public void stopLegacyMock() throws Exception {
-        if (legacyMockServer != null) {
-            legacyMockServer.stop();
-        }
-    }
-
-    private Component createLegacyXmlMock(int port) throws Exception {
-        Component component = new Component();
-        component.getServers().add(Protocol.HTTP, port);
-        component.getDefaultHost().attach(new Application() {
-            @Override
-            public Restlet createInboundRoot() {
-                Router router = new Router(getContext());
-                router.attach("/vessels", new Restlet() {
-                    @Override
-                    public void handle(org.restlet.Request request,
-                            org.restlet.Response response) {
-                        response.setStatus(Status.SUCCESS_OK);
-                        response.setEntity(LEGACY_XML_RESPONSE, MediaType.APPLICATION_XML);
-                    }
-                });
-                return router;
-            }
-        });
-        return component;
-    }
 
     // ── tools/list ────────────────────────────────────────────────────────────
 

--- a/src/test/java/io/naftiko/tutorial/Step6ShipyardMcpClientIntegrationTest.java
+++ b/src/test/java/io/naftiko/tutorial/Step6ShipyardMcpClientIntegrationTest.java
@@ -17,17 +17,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
 import java.net.http.HttpClient;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.naftiko.engine.consumes.ConsumesImportResolver;
 import io.naftiko.spec.NaftikoSpec;
-import io.naftiko.spec.consumes.ClientSpec;
-import io.naftiko.spec.consumes.http.HttpClientSpec;
+
 
 /**
  * End-to-end integration test for {@code step-6-shipyard-write-operations.yml}
@@ -44,35 +41,13 @@ public class Step6ShipyardMcpClientIntegrationTest
             "src/main/resources/tutorial/step-6-shipyard-write-operations.yml";
     private static final String SECRETS_FILE =
             "src/main/resources/tutorial/shared/secrets.yaml";
-    private static final String TUTORIAL_DIR =
-            "src/main/resources/tutorial";
-        private static final String REGISTRY_MOCK_URI =
-            "https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha1";
-    private static final String LEGACY_MOCK_URI =
-            "https://mocks.naftiko.net/rest/naftiko-shipyard-legacy-dockyard-api/1.0.0-alpha1";
+
 
     @BeforeEach
     public void startServer() throws Exception {
         NaftikoSpec spec = loadSpec(CAPABILITY_FILE);
         useMcpServerToken(SECRETS_FILE);
 
-        String secretsAbsoluteUri = new File(SECRETS_FILE).getAbsoluteFile().toURI().toString();
-        spec.getBinds().get(0).setLocation(secretsAbsoluteUri);
-        spec.getBinds().get(1).setLocation(secretsAbsoluteUri);
-
-        String tutorialAbsoluteDir = new File(TUTORIAL_DIR).getAbsolutePath();
-        new ConsumesImportResolver().resolveImports(
-                spec.getCapability().getConsumes(), tutorialAbsoluteDir);
-
-        for (ClientSpec cs : spec.getCapability().getConsumes()) {
-            if (cs instanceof HttpClientSpec) {
-                if ("registry".equals(cs.getNamespace())) {
-                    ((HttpClientSpec) cs).setBaseUri(REGISTRY_MOCK_URI);
-                } else if ("legacy".equals(cs.getNamespace())) {
-                    ((HttpClientSpec) cs).setBaseUri(LEGACY_MOCK_URI);
-                }
-            }
-        }
 
         startServerFromSpec(spec);
     }

--- a/src/test/java/io/naftiko/tutorial/Step7ShipyardMcpClientIntegrationTest.java
+++ b/src/test/java/io/naftiko/tutorial/Step7ShipyardMcpClientIntegrationTest.java
@@ -17,17 +17,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
 import java.net.http.HttpClient;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.naftiko.engine.consumes.ConsumesImportResolver;
 import io.naftiko.spec.NaftikoSpec;
-import io.naftiko.spec.consumes.ClientSpec;
-import io.naftiko.spec.consumes.http.HttpClientSpec;
 
 /**
  * End-to-end integration test for {@code step-7-shipyard-orchestrated-lookup.yml}
@@ -44,35 +40,13 @@ public class Step7ShipyardMcpClientIntegrationTest
             "src/main/resources/tutorial/step-7-shipyard-orchestrated-lookup.yml";
     private static final String SECRETS_FILE =
             "src/main/resources/tutorial/shared/secrets.yaml";
-    private static final String TUTORIAL_DIR =
-            "src/main/resources/tutorial";
-        private static final String REGISTRY_MOCK_URI =
-            "https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha1";
-    private static final String LEGACY_MOCK_URI =
-            "https://mocks.naftiko.net/rest/naftiko-shipyard-legacy-dockyard-api/1.0.0-alpha1";
+
 
     @BeforeEach
     public void startServer() throws Exception {
         NaftikoSpec spec = loadSpec(CAPABILITY_FILE);
         useMcpServerToken(SECRETS_FILE);
 
-        String secretsAbsoluteUri = new File(SECRETS_FILE).getAbsoluteFile().toURI().toString();
-        spec.getBinds().get(0).setLocation(secretsAbsoluteUri);
-        spec.getBinds().get(1).setLocation(secretsAbsoluteUri);
-
-        String tutorialAbsoluteDir = new File(TUTORIAL_DIR).getAbsolutePath();
-        new ConsumesImportResolver().resolveImports(
-                spec.getCapability().getConsumes(), tutorialAbsoluteDir);
-
-        for (ClientSpec cs : spec.getCapability().getConsumes()) {
-            if (cs instanceof HttpClientSpec) {
-                if ("registry".equals(cs.getNamespace())) {
-                    ((HttpClientSpec) cs).setBaseUri(REGISTRY_MOCK_URI);
-                } else if ("legacy".equals(cs.getNamespace())) {
-                    ((HttpClientSpec) cs).setBaseUri(LEGACY_MOCK_URI);
-                }
-            }
-        }
 
         startServerFromSpec(spec);
     }

--- a/src/test/java/io/naftiko/tutorial/Step8ShipyardMcpClientIntegrationTest.java
+++ b/src/test/java/io/naftiko/tutorial/Step8ShipyardMcpClientIntegrationTest.java
@@ -31,12 +31,9 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import io.naftiko.Capability;
-import io.naftiko.engine.consumes.ConsumesImportResolver;
 import io.naftiko.engine.exposes.ServerAdapter;
 import io.naftiko.engine.exposes.skill.SkillServerAdapter;
 import io.naftiko.spec.NaftikoSpec;
-import io.naftiko.spec.consumes.ClientSpec;
-import io.naftiko.spec.consumes.http.HttpClientSpec;
 import io.naftiko.spec.exposes.skill.SkillServerSpec;
 
 /**
@@ -53,35 +50,12 @@ public class Step8ShipyardMcpClientIntegrationTest
             "src/main/resources/tutorial/step-8-shipyard-skill-groups.yml";
     private static final String SECRETS_FILE =
             "src/main/resources/tutorial/shared/secrets.yaml";
-        private static final String TUTORIAL_DIR =
-            "src/main/resources/tutorial";
-        private static final String REGISTRY_MOCK_URI =
-            "https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha1";
-    private static final String LEGACY_MOCK_URI =
-            "https://mocks.naftiko.net/rest/naftiko-shipyard-legacy-dockyard-api/1.0.0-alpha1";
 
     @BeforeEach
     public void startServer() throws Exception {
         NaftikoSpec spec = loadSpec(CAPABILITY_FILE);
         useMcpServerToken(SECRETS_FILE);
 
-        String secretsAbsoluteUri = new File(SECRETS_FILE).getAbsoluteFile().toURI().toString();
-        spec.getBinds().get(0).setLocation(secretsAbsoluteUri);
-        spec.getBinds().get(1).setLocation(secretsAbsoluteUri);
-
-        String tutorialAbsoluteDir = new File(TUTORIAL_DIR).getAbsolutePath();
-        new ConsumesImportResolver().resolveImports(
-                spec.getCapability().getConsumes(), tutorialAbsoluteDir);
-
-        for (ClientSpec cs : spec.getCapability().getConsumes()) {
-            if (cs instanceof HttpClientSpec) {
-                if ("registry".equals(cs.getNamespace())) {
-                    ((HttpClientSpec) cs).setBaseUri(REGISTRY_MOCK_URI);
-                } else if ("legacy".equals(cs.getNamespace())) {
-                    ((HttpClientSpec) cs).setBaseUri(LEGACY_MOCK_URI);
-                }
-            }
-        }
 
         startServerFromSpec(spec);
     }
@@ -264,15 +238,6 @@ public class Step8ShipyardMcpClientIntegrationTest
         spec.getBinds().get(0).setLocation(secretsAbsoluteUri);
         spec.getBinds().get(1).setLocation(secretsAbsoluteUri);
 
-        String tutorialAbsoluteDir = new File(TUTORIAL_DIR).getAbsolutePath();
-        new ConsumesImportResolver().resolveImports(
-                spec.getCapability().getConsumes(), tutorialAbsoluteDir);
-
-        for (ClientSpec cs : spec.getCapability().getConsumes()) {
-            if (cs instanceof HttpClientSpec && "legacy".equals(cs.getNamespace())) {
-                ((HttpClientSpec) cs).setBaseUri(LEGACY_MOCK_URI);
-            }
-        }
 
         return spec;
     }


### PR DESCRIPTION
## Related Issue

no related issue

---

## What does this PR do?

This PR updates the CI strategy as well as the java tests for tutorial integration tests by replacing the external mock dependency with a locally managed Microcks instance running inside GitHub Actions.

---

## Tests

https://github.com/naftiko/framework/actions/runs/25489541283

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)


