### PR TITLE
fix: handle silent PowerShell exit in pr-review skill (v1.2.1)

### DIFF
--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-review
-version: "1.2.0"
+version: "1.2.1"
 description: >
   On-demand skill for reviewing GitHub Pull Requests and posting inline
   comments via the GitHub API. Activate when the user asks to: review a PR,
@@ -281,6 +281,14 @@ Use `event=APPROVE` only when explicitly asked to approve the PR.
 > ```
 >
 > The `line` field is still required even when using `in_reply_to`.
+
+> **Silent terminal output is not a failure signal**
+> On Windows (PowerShell), a `gh api --method POST` command that returns to the prompt
+> with **no output and no error** has likely succeeded — PowerShell does not always echo
+> HTTP responses unless `--jq` or `-q` is used. Do **not** retry the submission based on
+> a silent exit. Instead, immediately run the verification step below. Retrying a
+> submitted review creates an irrecoverable duplicate (GitHub returns HTTP 422 on
+> `DELETE` for non-pending reviews).
 
 After posting, verify the review was accepted:
 


### PR DESCRIPTION
## Related Issue

Closes #<!-- no issue — self-improvement fix discovered during PR review session -->

---

## What does this PR do?

Adds an explicit warning in the `pr-review` skill (Step 5, Branch B) for a
PowerShell-specific edge case: when `gh api --method POST` returns to the prompt
with no output and no error, the agent was incorrectly treating it as a failure
and retrying, creating an irrecoverable duplicate review on GitHub
(`DELETE` returns HTTP 422 for non-pending reviews).

The fix adds a callout block immediately before the post-submission verification
step, stating that a silent exit on Windows PowerShell is likely a success and
that the agent must run the GET verification before any retry.

Also bumps the skill version `1.2.0` → `1.2.1` (patch).

---

## Tests

No automated tests — this is a documentation/skill file. The fix was validated
by observing the exact failure it describes during a live PR review session
(PR #425).

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Naftiko - Claude Sonnet 4.6
tool: VS Code Copilot Chat
confidence: high
source_event: duplicate review posted on PR #425
discovery_method: runtime_observation
review_focus: .agents/skills/pr-review/SKILL.md
```
