### PR TITLE
feat: update documentation and agent instructions for Ikanos rename

### DIFF
--- a/.agents/skills/ikanos-capability/SKILL.md
+++ b/.agents/skills/ikanos-capability/SKILL.md
@@ -1,14 +1,14 @@
 ---
-name: naftiko-capability
+name: ikanos-capability
 version: "1.0.0-alpha1"
 description: >
-  Skill for authoring, validating, and debugging Naftiko Capability YAML files
+  Skill for authoring, validating, and debugging Ikanos Capability YAML files
   (spec v1.0.0-alpha1). Activate when the user wants to: write a new capability
   document, add or change authentication on a consumed API, configure orchestration
   steps or parameter mappings, set up a forward proxy, expose an MCP server or Skill
   server, configure external references for secrets, add a control port for health
   checks and metrics, enable OpenTelemetry observability, or run the Spectral linter.
-  The Naftiko Specification defines modular, composable capabilities that consume
+  The Ikanos Specification defines modular, composable capabilities that consume
   external APIs and expose REST, MCP, Skill, or Control adapters.
 allowed-tools:
   - Read
@@ -19,9 +19,9 @@ allowed-tools:
 
 ## Overview
 
-The Naftiko Framework lets you declare **capabilities** — functional units that
+Ikanos lets you declare **capabilities** — functional units that
 **consume** external APIs and **expose** adapters (REST, MCP, Skill). A capability
-is a single YAML file validated against the Naftiko JSON Schema (v1.0.0-alpha1).
+is a single YAML file validated against the Ikanos JSON Schema (v1.0.0-alpha1).
 
 Key spec objects you will work with:
 
@@ -37,14 +37,14 @@ Key spec objects you will work with:
 
 Canonical sources (read these, never duplicate them):
 
-- Specification: `src/main/resources/wiki/Specification.md`
-- JSON Schema: `src/main/resources/schemas/capability-schema.json`
-- Spectral Ruleset: `src/main/resources/schemas/naftiko-rules.yml`
+- Specification: `ikanos-docs/wiki/Specification.md`
+- JSON Schema: `ikanos-spec/src/main/resources/schemas/ikanos-schema.json`
+- Polychro Ruleset: `ikanos-spec/src/main/resources/rules/ikanos-rules.yml`
 
 ## Decision Framework
 
 Match the user's situation to a story reference. Each story explains *why*
-(the user's problem), *what* (the Naftiko pattern), and points to the spec
+(the user's problem), *what* (the Ikanos pattern), and points to the spec
 for *how*.
 
 | Situation | Action |
@@ -74,7 +74,7 @@ Specification directly.
    files, existing capabilities). Read that story file, then present a
    capability outline for the user to validate. Only ask what you cannot infer.
 2. **Scaffold.** Copy `assets/capability-template.yml`. The document must
-   begin with `naftiko: "1.0.0-alpha1"`.
+   begin with `ikanos: "1.0.0-alpha1"`.
 3. **Fill exposes.** Choose the adapter type (REST, MCP, or Skill) and
    follow the pattern from the story. For REST operations, use `call` +
    `with` (simple) or `steps` + `mappings` (orchestrated) — never both.
@@ -94,15 +94,15 @@ Specification directly.
        bash scripts/lint-capability.sh path/to/capability.yml
    Do NOT regenerate or modify this script.
 2. Spectral reports errors and warnings with rule names. Common rules:
-   - `naftiko-namespaces-unique` (error) — duplicate namespace
-   - `naftiko-consumes-baseuri-no-trailing-slash` (warn) — trailing `/`
-   - `naftiko-consumed-resource-no-query-in-path` (warn) — query in path
-   - `naftiko-rest-resource-path-no-trailing-slash` (warn)
-   - `naftiko-baseuri-not-example` (warn) — placeholder URI
-   - `naftiko-no-script-tags-in-markdown` (error) — XSS in descriptions
-   - `naftiko-consumes-description` (warn) — missing description
-   - `naftiko-control-port-singleton-and-unique` (error) — more than one control adapter, or port collision
-   - `naftiko-control-address-localhost-warning` (warn) — control port bound to non-localhost
+   - `ikanos-namespaces-unique` (error) — duplicate namespace
+   - `ikanos-consumes-baseuri-no-trailing-slash` (warn) — trailing `/`
+   - `ikanos-consumed-resource-no-query-in-path` (warn) — query in path
+   - `ikanos-rest-resource-path-no-trailing-slash` (warn)
+   - `ikanos-baseuri-not-example` (warn) — placeholder URI
+   - `ikanos-no-script-tags-in-markdown` (error) — XSS in descriptions
+   - `ikanos-consumes-description` (warn) — missing description
+   - `ikanos-control-port-singleton-and-unique` (error) — more than one control adapter, or port collision
+   - `ikanos-control-address-localhost-warning` (warn) — control port bound to non-localhost
    For the full rule list, read the Spectral ruleset file directly.
 3. Fix and re-lint. Repeat until clean.
 

--- a/.agents/skills/ikanos-capability/assets/capability-example.yml
+++ b/.agents/skills/ikanos-capability/assets/capability-example.yml
@@ -1,5 +1,5 @@
 ---
-naftiko: "1.0.0-alpha1"
+ikanos: "1.0.0-alpha1"
 
 binds:
   - namespace: "registry-env"

--- a/.agents/skills/ikanos-capability/references/chain-api-calls.md
+++ b/.agents/skills/ikanos-capability/references/chain-api-calls.md
@@ -177,5 +177,5 @@ Before considering “chain-api-calls” complete:
 
 ## References
 
-- Naftiko JSON Schema: `src/main/resources/schemas/naftiko-schema.json`
-- Spectral Rules: `src/main/resources/rules/naftiko-rules.yml`
+- Ikanos JSON Schema: `ikanos-spec/src/main/resources/schemas/ikanos-schema.json`
+- Polychro Rules: `ikanos-spec/src/main/resources/rules/ikanos-rules.yml`

--- a/.agents/skills/ikanos-capability/references/control-port-observability.md
+++ b/.agents/skills/ikanos-capability/references/control-port-observability.md
@@ -1,8 +1,8 @@
 ---
 name: control-port-observability-reference
 description: >
-  Reference for adding a control port and OpenTelemetry observability to a
-  Naftiko capability. Use when the user wants health checks, Prometheus metrics,
+  Reference for adding a control port and OpenTelemetry observability to an
+  Ikanos capability. Use when the user wants health checks, Prometheus metrics,
   trace inspection, or distributed tracing with OTLP export.
 
 ---
@@ -16,7 +16,7 @@ Every production capability needs:
 - **Trace inspection** for debugging request flows without an external collector.
 - **Distributed tracing** with W3C context propagation for end-to-end visibility.
 
-Naftiko provides all of this declaratively via `type: "control"` (the management
+Ikanos provides all of this declaratively via `type: "control"` (the management
 adapter) and `capability.observability` (the OTel configuration).
 
 ## Control Port (type: "control")
@@ -129,10 +129,10 @@ capability:
 ### CLI
 
 ```bash
-naftiko scripting                          # Display current config and stats
-naftiko scripting --set timeout=60000      # Update a setting
-naftiko scripting --set enabled=false      # Disable scripting at runtime
-naftiko scripting --set allowedLanguages=javascript,python  # Restrict languages
+ikanos scripting                          # Display current config and stats
+ikanos scripting --set timeout=60000      # Update a setting
+ikanos scripting --set enabled=false      # Disable scripting at runtime
+ikanos scripting --set allowedLanguages=javascript,python  # Restrict languages
 ```
 
 Requires a running Control Port with `management.scripting` configured.
@@ -187,13 +187,13 @@ binds:
 
 | Metric | Type | Description |
 |---|---|---|
-| `naftiko.request.total` | Counter | Requests by adapter, operation, status |
-| `naftiko.request.duration.seconds` | Histogram | Request duration |
-| `naftiko.request.errors` | Counter | Errors by adapter, operation, error type |
-| `naftiko.step.duration.seconds` | Histogram | Step duration by type and namespace |
-| `naftiko.http.client.total` | Counter | Outbound HTTP calls by method, host, status |
-| `naftiko.http.client.duration.seconds` | Histogram | Outbound HTTP call duration |
-| `naftiko.capability.active` | UpDownCounter | Active capability count |
+| `ikanos.request.total` | Counter | Requests by adapter, operation, status |
+| `ikanos.request.duration.seconds` | Histogram | Request duration |
+| `ikanos.request.errors` | Counter | Errors by adapter, operation, error type |
+| `ikanos.step.duration.seconds` | Histogram | Step duration by type and namespace |
+| `ikanos.http.client.total` | Counter | Outbound HTTP calls by method, host, status |
+| `ikanos.http.client.duration.seconds` | Histogram | Outbound HTTP call duration |
+| `ikanos.capability.active` | UpDownCounter | Active capability count |
 
 ### Combining control port + observability
 
@@ -244,7 +244,7 @@ Prometheus scrapes the control port's `/metrics` automatically.
    absent, metrics and traces default to enabled but return 503 if the OTel SDK
    is not on the classpath.
 2. **Port collision** — using the same port for control and a business adapter.
-   The linter catches this via `naftiko-control-port-singleton-and-unique`.
+   The linter catches this via `ikanos-control-port-singleton-and-unique`.
 3. **Binding control to `0.0.0.0` in dev** — exposes management endpoints on
    all interfaces. Use `localhost` (the default) unless inside a container.
 4. **Forgetting binds for OTLP endpoint** — hardcoding `http://localhost:4318`
@@ -253,9 +253,9 @@ Prometheus scrapes the control port's `/metrics` automatically.
 ## References
 
 - Schema: `ExposesControl`, `ControlManagementSpec`, `ObservabilitySpec` in
-  `src/main/resources/schemas/naftiko-schema.json`
-- Spectral rules: `naftiko-control-port-singleton-and-unique`,
-  `naftiko-control-address-localhost-warning`
+  `ikanos-spec/src/main/resources/schemas/ikanos-schema.json`
+- Polychro Rules: `ikanos-control-port-singleton-and-unique`,
+  `ikanos-control-address-localhost-warning`
 - Blueprint: `src/main/resources/blueprints/control-port.md`
 - Blueprint: `src/main/resources/blueprints/opentelemetry-observability.md`
 - Blueprint: `src/main/resources/blueprints/inline-script-step.md`

--- a/.agents/skills/ikanos-capability/references/design-guidelines.md
+++ b/.agents/skills/ikanos-capability/references/design-guidelines.md
@@ -1,7 +1,7 @@
 ---
 name: design-guidelines-reference
 description: >
-  Design guidelines for authoring Naftiko capability documents that are easy to
+  Design guidelines for authoring Ikanos capability documents that are easy to
   maintain, safe to run, and easy for agents to discover and use. Use this reference
   when the user asks “what should I check before shipping?” or when reviewing a
   capability for quality beyond schema validity (style, consistency, ergonomics).
@@ -12,7 +12,7 @@ description: >
 
 These guidelines complement:
 
-- the Naftiko JSON Schema (structural correctness),
+- the Ikanos JSON Schema (structural correctness),
 - the Spectral ruleset (cross-object consistency, hygiene, and security checks).
 
 They focus on:
@@ -217,5 +217,5 @@ Before shipping a capability:
 
 ## References
 
-- Naftiko JSON Schema: `src/main/resources/schemas/naftiko-schema.json`
-- Spectral Rules: `src/main/resources/rules/naftiko-rules.yml`
+- Ikanos JSON Schema: `ikanos-spec/src/main/resources/schemas/ikanos-schema.json`
+- Polychro Rules: `ikanos-spec/src/main/resources/rules/ikanos-rules.yml`

--- a/.agents/skills/ikanos-capability/references/dev-to-production.md
+++ b/.agents/skills/ikanos-capability/references/dev-to-production.md
@@ -36,7 +36,7 @@ Before adding dev/prod secret handling:
 
 ## Core concept: `binds` = external variable injection
 
-Naftiko uses `binds` to declare external sources of variables (secrets/config). Variables declared in `binds[*].keys` are injected using mustache-style expressions.
+Ikanos uses `binds` to declare external sources of variables (secrets/config). Variables declared in `binds[*].keys` are injected using mustache-style expressions.
 
 ### What a binding provides
 
@@ -171,5 +171,5 @@ Before calling dev→prod done:
 
 ## References
 
-- Naftiko JSON Schema: `src/main/resources/schemas/naftiko-schema.json`
-- Spectral Rules: `src/main/resources/rules/naftiko-rules.yml`
+- Ikanos JSON Schema: `ikanos-spec/src/main/resources/schemas/ikanos-schema.json`
+- Polychro Rules: `ikanos-spec/src/main/resources/rules/ikanos-rules.yml`

--- a/.agents/skills/ikanos-capability/references/inline-script-step.md
+++ b/.agents/skills/ikanos-capability/references/inline-script-step.md
@@ -1,7 +1,7 @@
 ---
 name: inline-script-step-reference
 description: >
-  Reference for adding inline script steps to a Naftiko capability. Use when the
+  Reference for adding inline script steps to a Ikanos capability. Use when the
   user wants to transform, filter, aggregate, or reshape data between API calls
   using JavaScript, Python, or Groovy — without building a separate microservice.
 
@@ -142,7 +142,7 @@ bound as variables, and the script must assign to `result` to produce output.
 
 When `location` is omitted on the step, the engine falls back to
 `management.scripting.defaultLocation` on the Control Port. If neither is set,
-the Spectral rule `naftiko-script-defaults-required` reports an error.
+the Spectral rule `ikanos-script-defaults-required` reports an error.
 
 ## Control Port Governance
 
@@ -187,9 +187,9 @@ The Control Port exposes a `/scripting` endpoint for runtime governance:
 The CLI also provides access:
 
 ```bash
-naftiko scripting                          # Display current config and stats
-naftiko scripting --set timeout=60000      # Update a setting at runtime
-naftiko scripting --set enabled=false      # Disable scripting
+ikanos scripting                          # Display current config and stats
+ikanos scripting --set timeout=60000      # Update a setting at runtime
+ikanos scripting --set enabled=false      # Disable scripting
 ```
 
 ## Security Model
@@ -209,7 +209,7 @@ Script execution is sandboxed:
    subsequent mappings referencing the step return null.
 2. **Omitting `language` and `location` without Control Port defaults** — the
    engine cannot determine which language or directory to use. The Spectral rule
-   `naftiko-script-defaults-required` catches this at lint time.
+   `ikanos-script-defaults-required` catches this at lint time.
 3. **Using `..` in file paths** — the engine rejects path traversal attempts.
    All paths must be relative within the `location` directory.
 4. **Exceeding statement limit** — long-running or infinite scripts are
@@ -220,8 +220,8 @@ Script execution is sandboxed:
 ## References
 
 - Schema: `OperationStepScript`, `ScriptingManagementSpec` in
-  `src/main/resources/schemas/naftiko-schema.json`
-- Spectral rule: `naftiko-script-defaults-required` in
-  `src/main/resources/rules/naftiko-rules.yml`
+  `ikanos-spec/src/main/resources/schemas/ikanos-schema.json`
+- Spectral rule: `ikanos-script-defaults-required` in
+  `ikanos-spec/src/main/resources/rules/ikanos-rules.yml`
 - Example: `src/main/resources/schemas/examples/script-step.yml`
 - Blueprint: `src/main/resources/blueprints/inline-script-step.md`

--- a/.agents/skills/ikanos-capability/references/mock-capability.md
+++ b/.agents/skills/ikanos-capability/references/mock-capability.md
@@ -7,7 +7,7 @@ design — defining the exposed shape before any upstream service is available.
 You need the MCP tool or REST endpoint to return realistic, shaped data so
 consumers (agents, developers, tests) can start integrating immediately.
 
-## Naftiko pattern
+## Ikanos pattern
 
 A **mock capability** is a capability that omits `consumes`, `call`, and
 `steps`. Output parameters carry a `value` field instead of a `mapping` field.
@@ -33,7 +33,7 @@ parameter shape works for both adapter types.
 ## Minimal MCP mock example
 
 ```yaml
-naftiko: "1.0.0-alpha1"
+ikanos: "1.0.0-alpha1"
 
 capability:
   exposes:
@@ -58,7 +58,7 @@ capability:
 ## Minimal REST mock example
 
 ```yaml
-naftiko: "1.0.0-alpha1"
+ikanos: "1.0.0-alpha1"
 
 capability:
   exposes:

--- a/.agents/skills/ikanos-capability/references/proxy-then-customize.md
+++ b/.agents/skills/ikanos-capability/references/proxy-then-customize.md
@@ -147,5 +147,5 @@ Before merging a “proxy then customize” iteration:
 
 ## References
 
-- Naftiko JSON Schema: `src/main/resources/schemas/naftiko-schema.json`
-- Spectral Rules: `src/main/resources/rules/naftiko-rules.yml`
+- Ikanos JSON Schema: `ikanos-spec/src/main/resources/schemas/ikanos-schema.json`
+- Polychro Rules: `ikanos-spec/src/main/resources/rules/ikanos-rules.yml`

--- a/.agents/skills/ikanos-capability/references/reusable-capability.md
+++ b/.agents/skills/ikanos-capability/references/reusable-capability.md
@@ -132,5 +132,5 @@ Before considering the composition complete:
 
 ## References
 
-- Naftiko JSON Schema: `src/main/resources/schemas/naftiko-schema.json`
-- Spectral Rules: `src/main/resources/rules/naftiko-rules.yml`
+- Ikanos JSON Schema: `ikanos-spec/src/main/resources/schemas/ikanos-schema.json`
+- Polychro Rules: `ikanos-spec/src/main/resources/rules/ikanos-rules.yml`

--- a/.agents/skills/ikanos-capability/references/wrap-api-as-mcp.md
+++ b/.agents/skills/ikanos-capability/references/wrap-api-as-mcp.md
@@ -39,7 +39,7 @@ Before writing MCP exposition:
 - Recommended hygiene:
     - every `consumes` entry should have a meaningful `description` (helps discovery and avoids Spectral warnings).
 
-## Core concept: MCP exposition in Naftiko
+## Core concept: MCP exposition in Ikanos
 
 MCP exposition is declared under:
 
@@ -187,5 +187,5 @@ Before considering the MCP wrapper complete:
 
 ## References
 
-- Naftiko JSON Schema: `src/main/resources/schemas/naftiko-schema.json`
-- Spectral Rules: `src/main/resources/rules/naftiko-rules.yml`
+- Ikanos JSON Schema: `ikanos-spec/src/main/resources/schemas/ikanos-schema.json`
+- Polychro Rules: `ikanos-spec/src/main/resources/rules/ikanos-rules.yml`

--- a/.agents/skills/ikanos-capability/scripts/lint-capability.sh
+++ b/.agents/skills/ikanos-capability/scripts/lint-capability.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# Validate a Naftiko capability YAML file against:
-#   1. The Naftiko JSON Schema (naftiko-schema.json)
-#   2. The Naftiko Spectral Rules (naftiko-rules.yml)
+# Validate an Ikanos capability YAML file against:
+#   1. The Ikanos JSON Schema (ikanos-schema.json)
+#   2. The Ikanos Polychro Rules (ikanos-rules.yml)
 #
 # Usage: ./lint-capability.sh <path-to-capability.yml>
 
@@ -26,8 +26,8 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../../../" && pwd)"
 
-SCHEMA_FILE="$PROJECT_ROOT/src/main/resources/schemas/naftiko-schema.json"
-RULES_FILE="$PROJECT_ROOT/src/main/resources/rules/naftiko-rules.yml"
+SCHEMA_FILE="$PROJECT_ROOT/ikanos-spec/src/main/resources/schemas/ikanos-schema.json"
+RULES_FILE="$PROJECT_ROOT/ikanos-spec/src/main/resources/rules/ikanos-rules.yml"
 
 if [[ ! -f "$SCHEMA_FILE" ]]; then
   echo "Error: JSON Schema file not found: $SCHEMA_FILE" >&2
@@ -43,7 +43,7 @@ EXIT_CODE=0
 
 # ── Step 1: JSON Schema validation ──────────────────────────────
 # Uses ajv-cli v5, same as .github/workflows/validate-schemas.yml
-echo "==> Validating against JSON Schema (naftiko-schema.json)..."
+echo "==> Validating against JSON Schema (ikanos-schema.json)..."
 
 if ! npx -y ajv-cli@5 validate \
   -s "$SCHEMA_FILE" \
@@ -57,7 +57,7 @@ else
 fi
 
 # ── Step 2: Spectral linting ────────────────────────────────────
-echo "==> Running Spectral rules (naftiko-rules.yml)..."
+echo "==> Running Spectral rules (ikanos-rules.yml)..."
 
 if command -v spectral &> /dev/null; then
   spectral lint "$CAPABILITY_FILE" --ruleset "$RULES_FILE" || EXIT_CODE=1

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -158,7 +158,7 @@ $review = @{
     event    = "REQUEST_CHANGES"   # or COMMENT, APPROVE
     body     = "Overall summary — see inline comments."
     comments = @(
-        @{ path = "src/main/java/io/naftiko/Foo.java"; line = 42;   body = "Comment text." }
+        @{ path = "ikanos-engine/src/main/java/io/ikanos/Foo.java"; line = 42;   body = "Comment text." }
         @{ path = "src/.../Bar.java";                  line = 17;   body = "Another comment." }
     )
 } | ConvertTo-Json -Depth 5
@@ -177,7 +177,7 @@ cat > /tmp/review-<number>.json <<'EOF'
   "event": "REQUEST_CHANGES",
   "body": "Overall summary — see inline comments.",
   "comments": [
-    { "path": "src/main/java/io/naftiko/Foo.java", "line": 42, "body": "Comment text." },
+    { "path": "ikanos-engine/src/main/java/io/ikanos/Foo.java", "line": 42, "body": "Comment text." },
     { "path": "src/.../Bar.java", "line": 17, "body": "Another comment." }
   ]
 }

--- a/.agents/skills/pr-review/pr-submit-review.ps1
+++ b/.agents/skills/pr-review/pr-submit-review.ps1
@@ -46,12 +46,12 @@
       "body": "Two findings — see inline comments.",
       "comments": [
         {
-          "path": "src/test/java/io/naftiko/engine/EngineFieldThreadSafetyTest.java",
+          "path": "ikanos-engine/src/test/java/io/ikanos/engine/EngineFieldThreadSafetyTest.java",
           "line": 68,
           "body": "This uses getDeclaredFields() via reflection..."
         },
         {
-          "path": "src/main/java/io/naftiko/Capability.java",
+          "path": "ikanos-engine/src/main/java/io/ikanos/Capability.java",
           "line": 152,
           "body": "`this` escapes here before clientAdapters/serverAdapters are published..."
         }

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug Report
-description: Report a bug or unexpected behavior in the Naftiko Framework
+description: Report a bug or unexpected behavior in Ikanos
 labels: ["bug"]
 body:
   - type: dropdown
@@ -67,8 +67,8 @@ body:
     id: version
     attributes:
       label: Version
-      description: Framework version
-      placeholder: Run `naftiko --version` or check the release tag (e.g. v0.4.1)
+      description: Ikanos version
+      placeholder: Run `ikanos --version` or check the release tag (e.g. v0.4.1)
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: 💬 Discussions
-    url: https://github.com/naftiko/framework/discussions
+    url: https://github.com/naftiko/ikanos/discussions
     about: Questions, ideas, or general feedback? Start a discussion.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: Feature Request
-description: Suggest a new feature or improvement for the Naftiko Framework
+description: Suggest a new feature or improvement for Ikanos
 labels: ["enhancement"]
 body:
   - type: dropdown

--- a/.github/workflows/mega-linter-validate.yml
+++ b/.github/workflows/mega-linter-validate.yml
@@ -1,4 +1,4 @@
-name: Lint Naftiko Capabilities
+name: Lint Ikanos Capabilities
 
 on:
   push:

--- a/.github/workflows/synchronize-ikanos-version-in-framework.yml
+++ b/.github/workflows/synchronize-ikanos-version-in-framework.yml
@@ -1,4 +1,4 @@
-name: Synchronize Naftiko Version in Framework
+name: Synchronize Ikanos Version in Repository
 
 on:
   workflow_dispatch:
@@ -28,7 +28,7 @@ jobs:
 
       - name: Run version sync script
         run: |
-          python3 src/main/resources/scripts/sync-naftiko-version.py
+          python3 scripts/sync-ikanos-version.py
 
       - name: Check for changes
         id: git-check
@@ -45,9 +45,9 @@ jobs:
         with:
           token: ${{ secrets.FRAMEWORK_CONTENTS_WRITE_PR_WRITE }}
           base: ${{ github.ref_name }}
-          branch: "chore/sync-naftiko-version"
-          commit-message: "chore: sync Naftiko version from pom.xml [skip ci]"
-          title: "chore: sync Naftiko version"
+          branch: "chore/sync-ikanos-version"
+          commit-message: "chore: sync Ikanos version from pom.xml [skip ci]"
+          title: "chore: sync Ikanos version"
           body: |
             ## No related issue
 
@@ -55,8 +55,8 @@ jobs:
 
             ## What does this PR do?
 
-            Automatically synchronizes the Naftiko version across the repository:
-            - Updates `naftiko` version in YAML files
+            Automatically synchronizes the Ikanos version across the repository:
+            - Updates `ikanos` version in YAML files
             - Updates `const` in JSON schema
             - Updates `$id` schema URL
 

--- a/.github/workflows/synchronize-ikanos-version-in-other-repos.yml
+++ b/.github/workflows/synchronize-ikanos-version-in-other-repos.yml
@@ -1,4 +1,4 @@
-name: Synchronize Naftiko Version in Other Repos
+name: Synchronize Ikanos Version in Other Repos
 
 on:
   push:
@@ -15,10 +15,10 @@ jobs:
     if: github.ref_name == 'main'
 
     steps:
-      - name: Checkout framework
+      - name: Checkout ikanos
         uses: actions/checkout@v4
         with:
-          path: framework
+          path: ikanos
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -32,11 +32,11 @@ jobs:
           token: ${{ secrets.BACKSTAGE_CONTENTS_WRITE_PR_WRITE }}
           path: backstage
 
-      - name: Sync Naftiko version to backstage
+      - name: Sync Ikanos version to backstage
         id: sync
         run: |
-          VERSION=$(python3 framework/src/main/resources/scripts/sync-naftiko-version-to-backstage.py \
-            --pom framework/pom.xml \
+          VERSION=$(python3 ikanos/scripts/sync-ikanos-version-to-backstage.py \
+            --pom ikanos/pom.xml \
             --target backstage/templates/skeletons/capabilities)
           echo "value=${VERSION}" >> $GITHUB_OUTPUT
 
@@ -57,11 +57,11 @@ jobs:
           token: ${{ secrets.BACKSTAGE_CONTENTS_WRITE_PR_WRITE }}
           path: backstage
           base: main
-          branch: "chore/sync-naftiko-version"
-          commit-message: "chore: sync Naftiko version to ${{ steps.sync.outputs.value }} [skip ci]"
-          title: "chore: sync Naftiko version to ${{ steps.sync.outputs.value }}"
+          branch: "chore/sync-ikanos-version"
+          commit-message: "chore: sync Ikanos version to ${{ steps.sync.outputs.value }} [skip ci]"
+          title: "chore: sync Ikanos version to ${{ steps.sync.outputs.value }}"
           body: |
-            Automated sync from [framework@${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}).
+            Automated sync from [ikanos@${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}).
 
             Updated files:
             - `templates/skeletons/capabilities/*.naftiko.yml`
@@ -74,10 +74,10 @@ jobs:
     needs: sync-backstage-version
 
     steps:
-      - name: Checkout framework
+      - name: Checkout ikanos
         uses: actions/checkout@v4
         with:
-          path: framework
+          path: ikanos
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -91,11 +91,11 @@ jobs:
           token: ${{ secrets.VSCODE_CONTENTS_WRITE_PR_WRITE }}
           path: vscode
 
-      - name: Sync Naftiko version to vscode
+      - name: Sync Ikanos version to vscode
         id: sync
         run: |
-          VERSION=$(python3 framework/src/main/resources/scripts/sync-naftiko-version-to-vscode.py \
-            --pom framework/pom.xml \
+          VERSION=$(python3 ikanos/scripts/sync-ikanos-version-to-vscode.py \
+            --pom ikanos/pom.xml \
             --target vscode/extensions/naftiko-vscode/package.json)
           echo "value=${VERSION}" >> $GITHUB_OUTPUT
 
@@ -116,11 +116,11 @@ jobs:
           token: ${{ secrets.VSCODE_CONTENTS_WRITE_PR_WRITE }}
           path: vscode
           base: main
-          branch: "chore/sync-naftiko-version"
-          commit-message: "chore: sync Naftiko version to ${{ steps.sync.outputs.value }} [skip ci]"
-          title: "chore: sync Naftiko version to ${{ steps.sync.outputs.value }}"
+          branch: "chore/sync-ikanos-version"
+          commit-message: "chore: sync Ikanos version to ${{ steps.sync.outputs.value }} [skip ci]"
+          title: "chore: sync Ikanos version to ${{ steps.sync.outputs.value }}"
           body: |
-            Automated sync from [framework@${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}).
+            Automated sync from [ikanos@${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}).
 
             Updated files:
             - `extensions/naftiko-vscode/package.json`

--- a/.github/workflows/validate-tuto-examples.yml
+++ b/.github/workflows/validate-tuto-examples.yml
@@ -63,7 +63,7 @@ jobs:
 
     - name: Patch baseUri in capability files
       run: |
-        TUTORIAL_DIR="src/main/resources/tutorial"
+        TUTORIAL_DIR="ikanos-engine/src/test/resources/tutorial"
 
         get_base_uri() {
           case "$1" in

--- a/.github/workflows/validate-tuto-examples.yml
+++ b/.github/workflows/validate-tuto-examples.yml
@@ -154,7 +154,7 @@ jobs:
           TYPE=$(yq -r ".tests[$i].type // \"mcp\"" $TEST_FILE)
 
           # Start server with a timeout guard
-          timeout 120 java -jar target/capability.jar src/main/resources/tutorial/$FILE &
+          timeout 120 java -jar ikanos-engine/target/capability.jar ikanos-engine/src/test/resources/tutorial/$FILE &
           PID=$!
 
           echo "Waiting for server on port $PORT (type: $TYPE)..."

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -4,7 +4,7 @@ ENABLE_LINTERS:
   - YAML_V8R
 
 POST_COMMANDS:
-  - name: Ikanos Polychro Validation
+  - name: Spectral Validation
     command: "spectral lint -r .spectral.yaml 'src/main/resources/schemas/examples/*.yml' 'src/main/resources/tutorial/**/*.yml' 'src/test/resources/*.yaml'"
     continue_on_error: false
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,44 +1,45 @@
-# Naftiko Framework — Agent Guidelines
+# Ikanos — Agent Guidelines
 
 ## Project Context
 
-**Naftiko Framework** is the engine for [Spec-Driven Integration](https://github.com/naftiko/framework/wiki/Spec%E2%80%90Driven-Integration). Capabilities are declared entirely in YAML — no Java required. The framework parses them and exposes them via MCP, SKILL, or REST servers.
+**Ikanos** is the engine for [Spec-Driven Integration](https://github.com/naftiko/ikanos/wiki/Spec%E2%80%90Driven-Integration). Capabilities are declared entirely in YAML — no Java required. The framework parses them and exposes them via MCP, SKILL, or REST servers.
 
-- **Language**: Java 21, Maven build system
-- **Specification**: `src/main/resources/schemas/naftiko-schema.json` — keep this as first-class citizen in your context
-- **Wiki**: https://github.com/naftiko/framework/wiki (Specification, Tutorial, Use Cases, FAQ)
+- **Language**: Java 21, Maven build system (multi-module: `ikanos-spec`, `ikanos-engine`, `ikanos-cli`, `ikanos-docs`)
+- **Specification**: `ikanos-spec/src/main/resources/schemas/ikanos-schema.json` — keep this as first-class citizen in your context
+- **Wiki**: https://github.com/naftiko/ikanos/wiki (Specification, Tutorial, Use Cases, FAQ)
 
 ## Key Files
 
 | Path | Purpose |
 |---|---|
-| `src/main/resources/schemas/naftiko-schema.json` | Naftiko JSON Schema (source of truth) |
-| `src/main/resources/schemas/examples/` | Capability examples (`cir.yml`, `notion.yml`, `skill-adapter.yml`, ...) |
-| `src/main/resources/tutorial/` | Shipyard Track tutorial (`step-1-shipyard-` to `step-10-shipyard-`) |
-| `src/test/resources/` | Test fixtures (not examples) |
-| `src/main/resources/scripts/pr-check-wind.ps1` | Local pre-PR validation (Windows) |
-| `src/main/resources/scripts/pr-check-mac-linux.sh` | Local pre-PR validation (Unix/macOS) |
+| `ikanos-spec/src/main/resources/schemas/ikanos-schema.json` | Ikanos JSON Schema (source of truth) |
+| `ikanos-spec/src/main/resources/schemas/examples/` | Capability examples (`cir.yml`, `notion.yml`, `skill-adapter.yml`, ...) |
+| `ikanos-spec/src/main/resources/rules/ikanos-rules.yml` | Polychro ruleset (cross-object consistency, quality, security) |
+| `ikanos-docs/tutorial/` | Shipyard Track tutorial (`step-1-shipyard-` to `step-10-shipyard-`) |
+| `ikanos-engine/src/test/resources/` and `ikanos-cli/src/test/resources/` | Test fixtures (not examples) |
+| `scripts/pr-check-wind.ps1` | Local pre-PR validation (Windows) |
+| `scripts/pr-check-mac-linux.sh` | Local pre-PR validation (Unix/macOS) |
 | `CONTRIBUTING.md` | Full contribution workflow |
 
 ## Build & Test
 
-All commands must be run from the repository root (`framework/`).
+All commands must be run from the repository root (`ikanos/`).
 
 ```bash
 # Run unit tests (standard local workflow — requires JDK 21)
 mvn clean test --no-transfer-progress
 
 # Build Docker image (Maven runs inside Docker — no local Maven needed)
-docker build -f src/main/resources/deployment/Dockerfile -t naftiko .
+docker build -f deployment/Dockerfile -t ikanos .
 
 # Build native CLI binary (requires GraalVM 21 — triggered by version tags in CI)
-mvn -B clean package -Pnative
+mvn -B clean package -Pnative -pl ikanos-cli -am
 
 # Pre-PR validation (Windows)
-.\src\main\resources\scripts\pr-check-wind.ps1
+.\scripts\pr-check-wind.ps1
 
 # Pre-PR validation (Unix)
-bash ./src/main/resources/scripts/pr-check-mac-linux.sh
+bash ./scripts/pr-check-mac-linux.sh
 ```
 
 ## Local Bootstrap
@@ -92,8 +93,8 @@ When writing or generating tests, follow these rules:
 When designing or modifying a Capability:
 
 **Do:**
-- Keep the [Naftiko Specification](src/main/resources/schemas/naftiko-schema.json) and the [Naftiko Rules](src/main/resources/rules/naftiko-rules.yml) as first-class citizens — the schema enforces structure, the rules enforce cross-object consistency, quality, and security
-- Look at `src/main/resources/schemas/examples/` for patterns before writing new capabilities
+- Keep the [Ikanos Specification](ikanos-spec/src/main/resources/schemas/ikanos-schema.json) and the [Ikanos Rules](ikanos-spec/src/main/resources/rules/ikanos-rules.yml) as first-class citizens — the schema enforces structure, the rules enforce cross-object consistency, quality, and security
+- Look at `ikanos-spec/src/main/resources/schemas/examples/` for patterns before writing new capabilities
 - When renaming a consumed field for a lookup `match`, also add a `ConsumedOutputParameter` on the consumed operation to map the raw field name to a kebab-case name — otherwise the lookup has nothing to match against
 - Use `aggregates` to define reusable domain functions when the same operation is exposed through multiple adapters (REST and MCP) — this follows the DDD Aggregate pattern: one definition, multiple projections
 - Declare `semantics` (safe, idempotent, cacheable) on aggregate functions to describe domain behavior — the engine derives MCP `hints` automatically
@@ -179,7 +180,7 @@ For every bug fix, two tests are required:
 
 **Unit test** — targets the smallest unit of code that contains the bug (method or class level). Place it in the test class corresponding to the fixed class (e.g. `ConverterTest`, `ResolverTest`). If the class has no test file yet, create one. If a test already covers the scenario but is wrong, fix the test first and explain why in a comment.
 
-**Integration test** — validates the fix end-to-end, typically loading a YAML capability fixture and exercising the full chain (deserialization → engine → output). Place the fixture in `src/test/resources/` and the test class in the package closest to the integration point (e.g. `io.naftiko.engine.exposes.mcp`).
+**Integration test** — validates the fix end-to-end, typically loading a YAML capability fixture and exercising the full chain (deserialization → engine → output). Place the fixture under the appropriate module (`ikanos-engine/src/test/resources/` or `ikanos-cli/src/test/resources/`) and the test class in the package closest to the integration point (e.g. `io.ikanos.engine.exposes.mcp`).
 
 Run the full test suite before committing:
 
@@ -188,9 +189,9 @@ mvn test
 ```
 
 **Ordering:**
-1. Write the tests first — only modify files under `src/test/` (and `src/test/resources/`)
+1. Write the tests first — only modify files under `src/test/` (and `src/test/resources/`) of the relevant module
 2. Run `mvn test` and confirm the new tests **fail** (proving the bug exists)
-3. Only then implement the fix in `src/main/`
+3. Only then implement the fix in `src/main/` of the relevant module
 4. Run `mvn test` again and confirm all tests **pass**
 
 Do not edit production code (`src/main/`) and test code (`src/test/`) in the same phase.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Naftiko Framework
+# Contributing to Ikanos
 
-> We welcome **all** contributions to Naftiko Framework, from the smallest to the largest — they all make a positive impact. This guide applies to both human developers and AI-assisted coding agents.
+> We welcome **all** contributions to Ikanos, from the smallest to the largest — they all make a positive impact. This guide applies to both human developers and AI-assisted coding agents.
 
 ---
 
@@ -10,7 +10,7 @@
 2. Fork the repo and branch from `main` (`feat/`, `fix/`, `chore/`)
 3. Keep PRs **atomic**, rebased on `main`, with CI green
 4. A **maintainer** will review and merge your PR
-5. All contributions are accepted under the [Apache 2.0 License](https://github.com/naftiko/framework/blob/main/LICENSE)
+5. All contributions are accepted under the [Apache 2.0 License](https://github.com/naftiko/ikanos/blob/main/LICENSE)
 
 ---
 
@@ -31,17 +31,17 @@ If you still want to run the full pre-PR checks locally, install [Trivy](https:/
 
 ```bash
 # Unix/macOS
-bash ./src/main/resources/scripts/pr-check-mac-linux.sh
+bash ./scripts/pr-check-mac-linux.sh
 
 # Windows (PowerShell)
-.\src\main\resources\scripts\pr-check-wind.ps1
+.\scripts\pr-check-wind.ps1
 ```
 
 ---
 
 ## Bugs & Features
 
-- Report bugs and suggest features in the [Issue Tracker](https://github.com/naftiko/framework/issues)
+- Report bugs and suggest features in the [Issue Tracker](https://github.com/naftiko/ikanos/issues)
 - Please **search existing issues** before creating a new one to avoid duplicates
 - When opening an issue, select the appropriate **template** — GitHub will guide you through the required fields:
   - **Bug Report** — for unexpected behavior or broken functionality
@@ -76,14 +76,14 @@ bash ./src/main/resources/scripts/pr-check-mac-linux.sh
 - Run the local validation script before opening your PR:
 
         # Unix/macOS
-        bash ./src/main/resources/scripts/pr-check-mac-linux.sh
+        bash ./scripts/pr-check-mac-linux.sh
 
         # Windows (PowerShell)
-        .\src\main\resources\scripts\pr-check-wind.ps1
+        .\scripts\pr-check-wind.ps1
 
 ### 3. Open a Pull Request
 
-Submit your work via a [Pull Request](https://github.com/naftiko/framework/pulls):
+Submit your work via a [Pull Request](https://github.com/naftiko/ikanos/pulls):
 
 - [ ] Fill in the **PR template** (`.github/PULL_REQUEST_TEMPLATE.md`, loaded automatically by GitHub)
 - [ ] Link the related Issue
@@ -107,11 +107,11 @@ This section provides **machine-readable guidance** for AI coding agents contrib
 
 ### Repository context
 
-- **Language**: Java 21 (Maven build system)
-- **Specification**: The Naftiko Specification defines the capability schema. See `src/main/resources/schemas/naftiko-schema.json` for the latest JSON Schema.
-- **Examples**: `src/main/resources/schemas/examples/` contains capability examples. `src/main/resources/tutorial/` contains step-by-step tutorial capabilities.
-- **Test fixtures**: `src/test/resources/` contains YAML capabilities used for unit tests.
-- **Wiki**: the [project wiki](https://github.com/naftiko/framework/wiki) contains the full specification, tutorial, FAQ, and use cases.
+- **Language**: Java 21, Maven (multi-module: `ikanos-spec`, `ikanos-engine`, `ikanos-cli`, `ikanos-docs`)
+- **Specification**: The Ikanos Specification defines the capability schema. See `ikanos-spec/src/main/resources/schemas/ikanos-schema.json` for the latest JSON Schema.
+- **Examples**: `ikanos-spec/src/main/resources/schemas/examples/` contains capability examples. `ikanos-docs/tutorial/` contains step-by-step tutorial capabilities.
+- **Test fixtures**: `ikanos-engine/src/test/resources/` and `ikanos-cli/src/test/resources/` contain YAML capabilities used for unit tests.
+- **Wiki**: the [project wiki](https://github.com/naftiko/ikanos/wiki) contains the full specification, tutorial, FAQ, and use cases.
 
 ### Agent contribution rules
 
@@ -121,25 +121,26 @@ This section provides **machine-readable guidance** for AI coding agents contrib
 - Keep changes **atomic**: one logical change per PR
 - Always include a clear PR description explaining the problem and solution
 - Do **not** modify CI/CD workflows, security configs, or branch protection rules
-- Keep the Naftiko Specification as a **first-class citizen** in your context
+- Keep the Ikanos Specification as a **first-class citizen** in your context
 
 ### Key files for agent context
 
 | File / Path | Purpose |
 |---|---|
-| `src/main/resources/schemas/naftiko-schema.json` | Naftiko Specification JSON Schema (latest) |
-| `src/main/resources/schemas/examples/` | Capability examples: `cir.yml`, `notion.yml`, `skill-adapter.yml`, `multi-consumes-*.yml`... |
-| `src/main/resources/tutorial/` | Step-by-step tutorial capabilities (`step-1-` to `step-10-`) |
-| `src/test/resources/` | Test fixtures (not examples) |
+| `ikanos-spec/src/main/resources/schemas/ikanos-schema.json` | Ikanos Specification JSON Schema (latest) |
+| `ikanos-spec/src/main/resources/schemas/examples/` | Capability examples: `cir.yml`, `notion.yml`, `skill-adapter.yml`, `multi-consumes-*.yml`... |
+| `ikanos-spec/src/main/resources/rules/ikanos-rules.yml` | Polychro ruleset (cross-object consistency, quality, security) |
+| `ikanos-docs/tutorial/` | Step-by-step tutorial capabilities (`step-1-` to `step-10-`) |
+| `ikanos-engine/src/test/resources/` and `ikanos-cli/src/test/resources/` | Test fixtures (not examples) |
 | `.github/workflows/` | CI/CD pipelines |
-| `src/main/resources/scripts/pr-check-wind.ps1` | Local pre-PR validation (Windows) |
-| `src/main/resources/scripts/pr-check-mac-linux.sh` | Local pre-PR validation (Unix/macOS) |
+| `scripts/pr-check-wind.ps1` | Local pre-PR validation (Windows) |
+| `scripts/pr-check-mac-linux.sh` | Local pre-PR validation (Unix/macOS) |
 | `CONTRIBUTING.md` | This file |
 
 ---
 
 ## License
 
-All contributions are accepted under the [Apache 2.0 License](https://github.com/naftiko/framework/blob/main/LICENSE).
+All contributions are accepted under the [Apache 2.0 License](https://github.com/naftiko/ikanos/blob/main/LICENSE).
 
-> ⚠️ You must ensure you have **full rights** on the code you are submitting, for example from your employer. 
+> ⚠️ You must ensure you have **full rights** on the code you are submitting, for example from your employer.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# Naftiko Framework
+# Ikanos
 
-[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/farah-t-trigui/50bfcb34f6512cbad2dd4f460bfc6526/raw/framework-coverage.json)](https://github.com/naftiko/framework/actions/workflows/quality-gate.yml)
-[![Bugs](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/farah-t-trigui/50bfcb34f6512cbad2dd4f460bfc6526/raw/framework-bugs.json)](https://github.com/naftiko/framework/actions/workflows/quality-gate.yml)
-[![Trivy](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/farah-t-trigui/50bfcb34f6512cbad2dd4f460bfc6526/raw/framework-trivy.json)](https://github.com/naftiko/framework/actions/workflows/quality-gate.yml)
-[![Gitleaks](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/farah-t-trigui/50bfcb34f6512cbad2dd4f460bfc6526/raw/framework-gitleaks.json)](https://github.com/naftiko/framework/actions/workflows/quality-gate.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/farah-t-trigui/50bfcb34f6512cbad2dd4f460bfc6526/raw/framework-coverage.json)](https://github.com/naftiko/ikanos/actions/workflows/quality-gate.yml)
+[![Bugs](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/farah-t-trigui/50bfcb34f6512cbad2dd4f460bfc6526/raw/framework-bugs.json)](https://github.com/naftiko/ikanos/actions/workflows/quality-gate.yml)
+[![Trivy](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/farah-t-trigui/50bfcb34f6512cbad2dd4f460bfc6526/raw/framework-trivy.json)](https://github.com/naftiko/ikanos/actions/workflows/quality-gate.yml)
+[![Gitleaks](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/farah-t-trigui/50bfcb34f6512cbad2dd4f460bfc6526/raw/framework-gitleaks.json)](https://github.com/naftiko/ikanos/actions/workflows/quality-gate.yml)
 
-Welcome to Naftiko Framework, the first Open Source project for [Spec-Driven Integration](https://github.com/naftiko/framework/wiki/Spec%E2%80%90Driven-Integration) reinventing API integration for the AI era with governed and versatile capabilities that streamline API sprawl from massive SaaS and microservices growth.
+Welcome to Ikanos, the first Open Source project for [Spec-Driven Integration](https://github.com/naftiko/ikanos/wiki/Spec%E2%80%90Driven-Integration) reinventing API integration for the AI era with governed and versatile capabilities that streamline API sprawl from massive SaaS and microservices growth.
 
 <img src="https://naftiko.github.io/docs/images/technology/architecture_capability.png" width="600">
 
-Each capability is a coarse piece of domain that consumes existing HTTP-based APIs then exposes them in several protocols to enable AI integration and self-integrating agents. Naftiko Framework includes a specification, an engine and a CLI.
+Each capability is a coarse piece of domain that consumes existing HTTP-based APIs then exposes them in several protocols to enable AI integration and self-integrating agents. Ikanos includes a specification, an engine and a CLI.
 
 | Feature | Description |
 |---|---|
@@ -31,22 +31,22 @@ Each capability is a coarse piece of domain that consumes existing HTTP-based AP
 
 Here are additional documents to learn more:
 
-- :compass: [Spec-Driven Integration](https://github.com/naftiko/framework/wiki/Spec%E2%80%90Driven-Integration)
-- :rowboat: [Installation](https://github.com/naftiko/framework/wiki/Installation)
-- :sailboat: [Tutorial - Part 1](https://github.com/naftiko/framework/wiki/Tutorial-%E2%80%90-Part-1)
-- :speedboat: [Tutorial - Part 2](https://github.com/naftiko/framework/wiki/Tutorial-%E2%80%90-Part-2)
-- :ship: [Guide - Use Cases](https://github.com/naftiko/framework/wiki/Guide-%E2%80%90-Use-Cases)
-- :mag: [Guide - Linting](https://github.com/naftiko/framework/wiki/Guide-%E2%80%90-Linting)
-- :anchor: [Specification - Schema](https://github.com/naftiko/framework/wiki/Specification-%E2%80%90-Schema)
-- :triangular_ruler: [Specification - Rules](https://github.com/naftiko/framework/wiki/Specification-%E2%80%90-Rules)
-- :ocean: [FAQ](https://github.com/naftiko/framework/wiki/FAQ)
-- :mega: [Releases](https://github.com/naftiko/framework/wiki/Releases)
-- :telescope: [Roadmap](https://github.com/naftiko/framework/wiki/Roadmap)
-- :nut_and_bolt: [Contribute](https://github.com/naftiko/framework/blob/main/CONTRIBUTING.md)
+- :compass: [Spec-Driven Integration](https://github.com/naftiko/ikanos/wiki/Spec%E2%80%90Driven-Integration)
+- :rowboat: [Installation](https://github.com/naftiko/ikanos/wiki/Installation)
+- :sailboat: [Tutorial - Part 1](https://github.com/naftiko/ikanos/wiki/Tutorial-%E2%80%90-Part-1)
+- :speedboat: [Tutorial - Part 2](https://github.com/naftiko/ikanos/wiki/Tutorial-%E2%80%90-Part-2)
+- :ship: [Guide - Use Cases](https://github.com/naftiko/ikanos/wiki/Guide-%E2%80%90-Use-Cases)
+- :mag: [Guide - Linting](https://github.com/naftiko/ikanos/wiki/Guide-%E2%80%90-Linting)
+- :anchor: [Specification - Schema](https://github.com/naftiko/ikanos/wiki/Specification-%E2%80%90-Schema)
+- :triangular_ruler: [Specification - Rules](https://github.com/naftiko/ikanos/wiki/Specification-%E2%80%90-Rules)
+- :ocean: [FAQ](https://github.com/naftiko/ikanos/wiki/FAQ)
+- :mega: [Releases](https://github.com/naftiko/ikanos/wiki/Releases)
+- :telescope: [Roadmap](https://github.com/naftiko/ikanos/wiki/Roadmap)
+- :nut_and_bolt: [Contribute](https://github.com/naftiko/ikanos/blob/main/CONTRIBUTING.md)
 
 ***
 
-Naftiko Framework is part of [Naftiko Fleet (Community Edition)](https://github.com/naftiko/fleet), which adds free complementary tools:
+Ikanos is part of [Naftiko Fleet (Community Edition)](https://github.com/naftiko/fleet), which adds free complementary tools:
 
 | Tool | What it does |
 |---|---|

--- a/ikanos-docs/wiki/FAQ.md
+++ b/ikanos-docs/wiki/FAQ.md
@@ -40,8 +40,8 @@ You don't need to write Java or other code unless you want to extend the framewo
 
 1. **Docker (recommended)**  
    ```bash
-  docker pull ghcr.io/Ikanos/framework:v1.0.0-alpha1
-  docker run -p 8081:8081 -v /path/to/capability.yaml:/app/capability.yaml ghcr.io/Ikanos/framework:v1.0.0-alpha1 /app/capability.yaml
+  docker pull ghcr.io/naftiko/ikanos:v1.0.0-alpha1
+  docker run -p 8081:8081 -v /path/to/capability.yaml:/app/capability.yaml ghcr.io/naftiko/ikanos:v1.0.0-alpha1 /app/capability.yaml
    ```
 
 2. **CLI tool** (for configuration and validation)  
@@ -638,11 +638,11 @@ This enables distributed tracing and RED metrics (Rate, Errors, Duration) for al
 ### Q: What metrics does Ikanos expose?
 **A:** The engine emits three histogram metrics following the RED method:
 
-- `Ikanos.request.duration.seconds` — end-to-end request duration by tool/operation name and status
-- `Ikanos.step.duration.seconds` — individual orchestration step duration
-- `Ikanos.http.client.duration.seconds` — outbound HTTP call duration by namespace, method, and status code
+- `ikanos.request.duration.seconds` — end-to-end request duration by tool/operation name and status
+- `ikanos.step.duration.seconds` — individual orchestration step duration
+- `ikanos.http.client.duration.seconds` — outbound HTTP call duration by namespace, method, and status code
 
-A counter `Ikanos.request.errors` tracks failed requests. All metrics are available in Prometheus text format on the control port's `/metrics` endpoint.
+A counter `ikanos.request.errors` tracks failed requests. All metrics are available in Prometheus text format on the control port's `/metrics` endpoint.
 
 ### Q: How do I connect Prometheus and Grafana?
 **A:** Point Prometheus at the control port's `/metrics` endpoint:
@@ -650,13 +650,13 @@ A counter `Ikanos.request.errors` tracks failed requests. All metrics are availa
 ```yaml
 # prometheus.yml
 scrape_configs:
-  - job_name: Ikanos
+  - job_name: ikanos
     metrics_path: /metrics
     static_configs:
       - targets: ['localhost:9090']
 ```
 
-A sample Grafana dashboard is provided in `demo/shared/observability/grafana-Ikanos.json`.
+A sample Grafana dashboard is provided in `demo/shared/observability/grafana-ikanos.json`.
 
 ---
 
@@ -672,7 +672,7 @@ A sample Grafana dashboard is provided in `demo/shared/observability/grafana-Ika
 
 2. **Check the Docker logs:**
    ```bash
-  docker run ... ghcr.io/Ikanos/framework:v1.0.0-alpha1 /app/capability.yaml
+  docker run ... ghcr.io/naftiko/ikanos:v1.0.0-alpha1 /app/capability.yaml
    # Look for error messages in the output
    ```
 
@@ -750,7 +750,7 @@ A sample Grafana dashboard is provided in `demo/shared/observability/grafana-Ika
 ```bash
 # Clone the repository
 git clone https://github.com/naftiko/ikanos.git
-cd framework
+cd ikanos
 
 # Build the project
 mvn clean install
@@ -759,13 +759,13 @@ mvn clean install
 mvn test
 
 # Build Docker image
-docker build -t Ikanos:local .
+docker build -t ikanos:local .
 ```
 
 Key directories:
-- `src/main/java/io/Ikanos/`  Core engine code
+- `ikanos-engine/src/main/java/io/ikanos/`  Core engine code
 - `ikanos-spec/src/main/resources/schemas/`  JSON Schema definitions
-- `src/test/`  Unit and integration tests
+- `ikanos-engine/src/test/` and `ikanos-cli/src/test/`  Unit and integration tests
 - `ikanos-spec/src/main/resources/schemas/examples/`  Capability examples
 - `ikanos-docs/tutorial/`  Tutorial capability files
 
@@ -899,14 +899,14 @@ For production workloads:
    apiVersion: apps/v1
    kind: Deployment
    metadata:
-     name: Ikanos-engine
+     name: ikanos-engine
    spec:
      replicas: 3
      template:
        spec:
          containers:
-         - name: Ikanos
-           image: ghcr.io/Ikanos/framework:v1.0.0-alpha1
+         - name: ikanos
+           image: ghcr.io/naftiko/ikanos:v1.0.0-alpha1
            volumeMounts:
            - name: capability
              mountPath: /app/capability.yaml
@@ -915,7 +915,7 @@ For production workloads:
            - name: GITHUB_TOKEN
              valueFrom:
                secretKeyRef:
-                 name: Ikanos-secrets
+                 name: ikanos-secrets
                  key: github-token
    ```
 
@@ -962,7 +962,7 @@ Check the Ikanos field in your YAML to specify the version.
 
 ### Q: Where can I ask questions or discuss ideas?
 **A:** Join the community at:
-- **[GitHub Discussions](https://github.com/orgs/Ikanos/discussions)** - Ask questions and share ideas
+- **[GitHub Discussions](https://github.com/orgs/naftiko/discussions)** - Ask questions and share ideas
 - **[GitHub Issues](https://github.com/naftiko/ikanos/issues)** - Report bugs or request features
 - **Pull Requests** - Review and discuss code changes
 
@@ -1028,7 +1028,7 @@ This is Ikanos's core strength for managing API sprawl.
 -  **[Releases](https://github.com/naftiko/ikanos/wiki/Releases)** - Version history
 -  **[Roadmap](https://github.com/naftiko/ikanos/wiki/Roadmap)** - Future plans
 -  **[Contribute](https://github.com/naftiko/ikanos/wiki/Contribute)** - Become a contributor
--  **[Discussions](https://github.com/orgs/Ikanos/discussions)** - Community Q&A
+-  **[Discussions](https://github.com/orgs/naftiko/discussions)** - Community Q&A
 
 ---
 
@@ -1036,5 +1036,5 @@ This is Ikanos's core strength for managing API sprawl.
 
 Did this FAQ help you? Have questions not covered here? 
 - **Add an issue** - [GitHub Issues](https://github.com/naftiko/ikanos/issues)
-- **Start a discussion** - [GitHub Discussions](https://github.com/orgs/Ikanos/discussions)
+- **Start a discussion** - [GitHub Discussions](https://github.com/orgs/naftiko/discussions)
 - **Submit a PR** - Help us improve this FAQ!

--- a/ikanos-docs/wiki/FAQ.md
+++ b/ikanos-docs/wiki/FAQ.md
@@ -1,11 +1,11 @@
-Welcome to the Naftiko Framework FAQ! This guide answers common questions from developers who are learning, using, and contributing to Naftiko. For comprehensive technical details, see the [Specification - Schema](https://github.com/naftiko/framework/wiki/Specification-Schema) and [Specification - Rules](https://github.com/naftiko/framework/wiki/Specification-Rules).
+Welcome to the Ikanos FAQ! This guide answers common questions from developers who are learning, using, and contributing to Ikanos. For comprehensive technical details, see the [Specification - Schema](https://github.com/naftiko/ikanos/wiki/Specification-Schema) and [Specification - Rules](https://github.com/naftiko/ikanos/wiki/Specification-Rules).
 
 ---
 
 ## ⛵ Getting Started
 
-### Q: What is Naftiko Framework and why would I use it?
-**A:** Naftiko Framework is the first open-source platform for **Spec-Driven Integration**. Instead of writing boilerplate code to consume HTTP APIs and expose unified interfaces, you declare them in YAML. This enables:
+### Q: What is Ikanos and why would I use it?
+**A:** Ikanos is the first open-source platform for **Spec-Driven Integration**. Instead of writing boilerplate code to consume HTTP APIs and expose unified interfaces, you declare them in YAML. This enables:
 - **API composability**: Combine multiple APIs into a single capability
 - **Format conversion**: Convert between JSON, XML, Avro, Protobuf, CSV, TSV, PSV, HTML, Markdown, and YAML
 - **AI-ready integration**: Better context engineering for AI systems
@@ -21,11 +21,11 @@ Use it when you need to integrate multiple APIs, standardize data formats, or ex
 
 You don't need to write Java or other code unless you want to extend the framework itself.
 
-### Q: Is Naftiko a code generator or a runtime engine?
-**A:** It's a **runtime engine**. The Naftiko Engine, provided as a Docker container, reads your YAML capability file at startup and immediately exposes HTTP or MCP interfaces. There's no compilation step - declare your capability, start the engine, and it works.
+### Q: Is Ikanos a code generator or a runtime engine?
+**A:** It's a **runtime engine**. The Ikanos Engine, provided as a Docker container, reads your YAML capability file at startup and immediately exposes HTTP or MCP interfaces. There's no compilation step - declare your capability, start the engine, and it works.
 
-### Q: Are there other tools that complement Naftiko Framework?
-**A:** Yes. Naftiko Framework is part of [Naftiko Fleet (Community Edition)](https://github.com/naftiko/fleet), which includes free complementary tools:
+### Q: Are there other tools that complement Ikanos?
+**A:** Yes. Ikanos is part of [Naftiko Fleet (Community Edition)](https://github.com/naftiko/fleet), which includes free complementary tools:
 
 - **[Naftiko Extension for VS Code](https://github.com/naftiko/fleet/wiki/Naftiko-Extension-for-VS-Code)** — Inline structure and rules validation while editing capability files (`.naftiko.yaml`)
 - **[Naftiko Templates for Backstage](https://github.com/naftiko/fleet/wiki/Naftiko-Templates-for-Backstage)** — Scaffold new capabilities and catalog them from CNCF Backstage
@@ -35,35 +35,35 @@ You don't need to write Java or other code unless you want to extend the framewo
 
 ## :rowboat: Installation & Setup
 
-### Q: How do I install Naftiko?
+### Q: How do I install Ikanos?
 **A:** There are two ways:
 
 1. **Docker (recommended)**  
    ```bash
-  docker pull ghcr.io/naftiko/framework:v1.0.0-alpha1
-  docker run -p 8081:8081 -v /path/to/capability.yaml:/app/capability.yaml ghcr.io/naftiko/framework:v1.0.0-alpha1 /app/capability.yaml
+  docker pull ghcr.io/Ikanos/framework:v1.0.0-alpha1
+  docker run -p 8081:8081 -v /path/to/capability.yaml:/app/capability.yaml ghcr.io/Ikanos/framework:v1.0.0-alpha1 /app/capability.yaml
    ```
 
 2. **CLI tool** (for configuration and validation)  
-  Download the binary for [macOS](https://github.com/naftiko/framework/releases/download/v1.0.0-alpha1/naftiko-cli-macos-arm64), [Linux](https://github.com/naftiko/framework/releases/download/v1.0.0-alpha1/naftiko-cli-linux-amd64), or [Windows](https://github.com/naftiko/framework/releases/download/v1.0.0-alpha1/naftiko-cli-windows-amd64.exe)
+  Download the binary for [macOS](https://github.com/naftiko/ikanos/releases/download/v1.0.0-alpha1/ikanos-cli-macos-arm64), [Linux](https://github.com/naftiko/ikanos/releases/download/v1.0.0-alpha1/ikanos-cli-linux-amd64), or [Windows](https://github.com/naftiko/ikanos/releases/download/v1.0.0-alpha1/ikanos-cli-windows-amd64.exe)
 
-See the [Installation guide](https://github.com/naftiko/framework/wiki/Installation) for detailed setup instructions.
+See the [Installation guide](https://github.com/naftiko/ikanos/wiki/Installation) for detailed setup instructions.
 
 ### Q: How do I validate my capability file before running it?
 **A:** Use the CLI validation command:
 ```bash
-naftiko validate path/to/capability.yaml
-naftiko validate path/to/capability.yaml 1.0.0-alpha1  # Specify schema version
+ikanos validate path/to/capability.yaml
+ikanos validate path/to/capability.yaml 1.0.0-alpha1  # Specify schema version
 ```
 
-This checks your YAML against the Naftiko schema and reports any errors.
+This checks your YAML against the Ikanos schema and reports any errors.
 
 ### Q: Which version of the schema should I use?
 **A:** Use the current framework schema version: **1.0.0-alpha1**.
 
 Set it in your YAML:
 ```yaml
-naftiko: "1.0.0-alpha1"
+ikanos: "1.0.0-alpha1"
 ```
 
 ---
@@ -307,7 +307,7 @@ outputParameters:
     type: number
 ```
 
-Mappings tell Naftiko how to wire step outputs to your final response.
+Mappings tell Ikanos how to wire step outputs to your final response.
 
 ---
 
@@ -316,18 +316,18 @@ Mappings tell Naftiko how to wire step outputs to your final response.
 ### Q: Can I bootstrap a capability from an existing OpenAPI specification?
 **A:** Yes. Use the CLI import command:
 ```bash
-naftiko import openapi petstore.yaml
-naftiko import openapi petstore.yaml -o my-capability.yaml
+ikanos import openapi petstore.yaml
+ikanos import openapi petstore.yaml -o my-capability.yaml
 ```
-This parses an OAS 3.0 or 3.1 document and generates a Naftiko capability YAML with a pre-filled `consumes` HTTP adapter — including authentication, resources, operations, input parameters, and output parameters.
+This parses an OAS 3.0 or 3.1 document and generates a Ikanos capability YAML with a pre-filled `consumes` HTTP adapter — including authentication, resources, operations, input parameters, and output parameters.
 
 ### Q: Can I export my REST adapter as an OpenAPI document?
 **A:** Yes. Use the CLI export command:
 ```bash
-naftiko export openapi capability.yaml
-naftiko export openapi capability.yaml --spec-version 3.1 -f json
+ikanos export openapi capability.yaml
+ikanos export openapi capability.yaml --spec-version 3.1 -f json
 ```
-This reads a Naftiko capability and generates an OpenAPI document from its REST `exposes` adapter.
+This reads a Ikanos capability and generates an OpenAPI document from its REST `exposes` adapter.
 
 ### Q: Which OpenAPI versions are supported?
 **A:** OAS **3.0** and **3.1** are fully supported for both import and export. OAS 3.2 support is deferred until the upstream Java libraries (`swagger-parser`, `swagger-core`) add it.
@@ -335,7 +335,7 @@ This reads a Naftiko capability and generates an OpenAPI document from its REST 
 ### Q: What if my capability has multiple REST adapters?
 **A:** Use the `--adapter` option to target a specific namespace:
 ```bash
-naftiko export openapi capability.yaml --adapter public-api
+ikanos export openapi capability.yaml --adapter public-api
 ```
 When omitted, the first REST adapter found is exported.
 
@@ -635,14 +635,14 @@ capability:
 
 This enables distributed tracing and RED metrics (Rate, Errors, Duration) for all capability operations. Metrics are exposed in Prometheus format on the control port's `/metrics` endpoint.
 
-### Q: What metrics does Naftiko expose?
+### Q: What metrics does Ikanos expose?
 **A:** The engine emits three histogram metrics following the RED method:
 
-- `naftiko.request.duration.seconds` — end-to-end request duration by tool/operation name and status
-- `naftiko.step.duration.seconds` — individual orchestration step duration
-- `naftiko.http.client.duration.seconds` — outbound HTTP call duration by namespace, method, and status code
+- `Ikanos.request.duration.seconds` — end-to-end request duration by tool/operation name and status
+- `Ikanos.step.duration.seconds` — individual orchestration step duration
+- `Ikanos.http.client.duration.seconds` — outbound HTTP call duration by namespace, method, and status code
 
-A counter `naftiko.request.errors` tracks failed requests. All metrics are available in Prometheus text format on the control port's `/metrics` endpoint.
+A counter `Ikanos.request.errors` tracks failed requests. All metrics are available in Prometheus text format on the control port's `/metrics` endpoint.
 
 ### Q: How do I connect Prometheus and Grafana?
 **A:** Point Prometheus at the control port's `/metrics` endpoint:
@@ -650,13 +650,13 @@ A counter `naftiko.request.errors` tracks failed requests. All metrics are avail
 ```yaml
 # prometheus.yml
 scrape_configs:
-  - job_name: naftiko
+  - job_name: Ikanos
     metrics_path: /metrics
     static_configs:
       - targets: ['localhost:9090']
 ```
 
-A sample Grafana dashboard is provided in `demo/shared/observability/grafana-naftiko.json`.
+A sample Grafana dashboard is provided in `demo/shared/observability/grafana-Ikanos.json`.
 
 ---
 
@@ -667,12 +667,12 @@ A sample Grafana dashboard is provided in `demo/shared/observability/grafana-naf
 
 1. **Validate your YAML first:**
    ```bash
-   naftiko validate capability.yaml
+   ikanos validate capability.yaml
    ```
 
 2. **Check the Docker logs:**
    ```bash
-  docker run ... ghcr.io/naftiko/framework:v1.0.0-alpha1 /app/capability.yaml
+  docker run ... ghcr.io/Ikanos/framework:v1.0.0-alpha1 /app/capability.yaml
    # Look for error messages in the output
    ```
 
@@ -727,13 +727,13 @@ A sample Grafana dashboard is provided in `demo/shared/observability/grafana-naf
 
 ## 🚣 Contributing
 
-### Q: How do I contribute to Naftiko Framework?
+### Q: How do I contribute to Ikanos?
 **A:** We welcome all contributions! Here's how:
 
-1. **Report bugs or request features** - [GitHub Issues](https://github.com/naftiko/framework/issues)
+1. **Report bugs or request features** - [GitHub Issues](https://github.com/naftiko/ikanos/issues)
    - Search for existing issues first to avoid duplicates
    
-2. **Submit code changes** - [GitHub Pull Requests](https://github.com/naftiko/framework/pulls)
+2. **Submit code changes** - [GitHub Pull Requests](https://github.com/naftiko/ikanos/pulls)
    - Create a local branch
    - Ensure your code passes all build validation
    - Rebase on `main` before submitting
@@ -745,11 +745,11 @@ A sample Grafana dashboard is provided in `demo/shared/observability/grafana-naf
 4. **Improve documentation** - Fix typos, clarify docs, add examples
 
 ### Q: What's the code structure and how do I set up a development environment?
-**A:** Naftiko is a **Java project** using Maven. To build and develop:
+**A:** Ikanos is a **Java project** using Maven. To build and develop:
 
 ```bash
 # Clone the repository
-git clone https://github.com/naftiko/framework.git
+git clone https://github.com/naftiko/ikanos.git
 cd framework
 
 # Build the project
@@ -759,20 +759,20 @@ mvn clean install
 mvn test
 
 # Build Docker image
-docker build -t naftiko:local .
+docker build -t Ikanos:local .
 ```
 
 Key directories:
-- `src/main/java/io/naftiko/`  Core engine code
-- `src/main/resources/schemas/`  JSON Schema definitions
+- `src/main/java/io/Ikanos/`  Core engine code
+- `ikanos-spec/src/main/resources/schemas/`  JSON Schema definitions
 - `src/test/`  Unit and integration tests
-- `src/main/resources/schemas/examples/`  Capability examples
-- `src/main/resources/tutorial/`  Tutorial capability files
+- `ikanos-spec/src/main/resources/schemas/examples/`  Capability examples
+- `ikanos-docs/tutorial/`  Tutorial capability files
 
 ### Q: What are the design guidelines for creating capabilities?
 **A:**
 
-1. **Keep the Naftiko Specification as a first-class citizen** - refer to it often
+1. **Keep the Ikanos Specification as a first-class citizen** - refer to it often
 2. **Don't expose unused input parameters** - every parameter should be used in steps
 3. **Don't declare consumed outputs you don't use** - be precise in mappings
 4. **Don't prefix variables unnecessarily** - let scope provide clarity
@@ -805,11 +805,11 @@ outputParameters:
 
 1. **Unit tests** - Add tests in `src/test/java`
 2. **Integration tests** - Test against real or mock APIs
-3. **Validation** - Use the CLI tool: `naftiko validate capability.yaml`
+3. **Validation** - Use the CLI tool: `ikanos validate capability.yaml`
 4. **Docker testing** - Build and run the Docker image with your capability
 
 ### Q: Which version of Java is required?
-**A:** Naftiko requires **Java 21 or later**. This is specified in the Maven configuration.
+**A:** Ikanos requires **Java 21 or later**. This is specified in the Maven configuration.
 
 ---
 
@@ -849,12 +849,12 @@ consumes:
 This way, Capability B can combine Capability A with other APIs.
 
 ### Q: How do I handle errors or retries?
-**A:** Naftiko currently doesn't have built-in retry logic in v1.0.0-alpha1. Options:
+**A:** Ikanos currently doesn't have built-in retry logic in v1.0.0-alpha1. Options:
 
 1. **At the HTTP client level** - use an API gateway with retry policies
 2. **In future versions** - this is on the roadmap
 
-Check the [Roadmap](https://github.com/naftiko/framework/wiki/Roadmap) for planned features.
+Check the [Roadmap](https://github.com/naftiko/ikanos/wiki/Roadmap) for planned features.
 
 ### Q: Can I expose the same capability on both REST and MCP?
 **A:** Yes! Add multiple entries to `exposes`:
@@ -880,18 +880,18 @@ Both adapters consume the same sources but expose different interfaces.
 
 ## 💨 Performance & Deployment
 
-### Q: How scalable is Naftiko for high-load scenarios?
-**A:** Naftiko is suitable for moderate to high loads depending on:
-- **Your consumed APIs' performance** - Naftiko's overhead is minimal
+### Q: How scalable is Ikanos for high-load scenarios?
+**A:** Ikanos is suitable for moderate to high loads depending on:
+- **Your consumed APIs' performance** - Ikanos's overhead is minimal
 - **Docker/Kubernetes scaling** - deploy multiple instances behind a load balancer
 - **Orchestration complexity** - simpler capabilities (forward, single calls) are faster
 
 For production workloads:
 - Use Kubernetes for auto-scaling
 - Monitor consuming/consumed API latencies
-- Consider caching strategies above Naftiko
+- Consider caching strategies above Ikanos
 
-### Q: How do I deploy Naftiko to production?
+### Q: How do I deploy Ikanos to production?
 **A:** 
 
 1. **Kubernetes** (recommended):
@@ -899,14 +899,14 @@ For production workloads:
    apiVersion: apps/v1
    kind: Deployment
    metadata:
-     name: naftiko-engine
+     name: Ikanos-engine
    spec:
      replicas: 3
      template:
        spec:
          containers:
-         - name: naftiko
-           image: ghcr.io/naftiko/framework:v1.0.0-alpha1
+         - name: Ikanos
+           image: ghcr.io/Ikanos/framework:v1.0.0-alpha1
            volumeMounts:
            - name: capability
              mountPath: /app/capability.yaml
@@ -915,22 +915,22 @@ For production workloads:
            - name: GITHUB_TOKEN
              valueFrom:
                secretKeyRef:
-                 name: naftiko-secrets
+                 name: Ikanos-secrets
                  key: github-token
    ```
 
 2. **Docker Compose** - for simpler setups
 3. **Environment Variables** - inject secrets via `binds` (omit `location` for runtime injection)
 
-### Q: Can I use Naftiko behind a reverse proxy (nginx, Envoy)?
-**A:** Yes, absolutely. Naftiko exposes standard HTTP endpoints, so it works with any reverse proxy.
+### Q: Can I use Ikanos behind a reverse proxy (nginx, Envoy)?
+**A:** Yes, absolutely. Ikanos exposes standard HTTP endpoints, so it works with any reverse proxy.
 
 Example (nginx):
 ```nginx
 server {
     listen 80;
     location / {
-        proxy_pass http://naftiko:8081;
+        proxy_pass http://Ikanos:8081;
     }
 }
 ```
@@ -939,22 +939,22 @@ server {
 
 ## 📜 Specifications & Standards
 
-### Q: How does Naftiko compare to OpenAPI, AsyncAPI, or Arazzo?
-**A:** Naftiko is **complementary** to these specifications and combines their strengths into a single runtime model:
+### Q: How does Ikanos compare to OpenAPI, AsyncAPI, or Arazzo?
+**A:** Ikanos is **complementary** to these specifications and combines their strengths into a single runtime model:
 - **Consume/expose duality** - like OpenAPI's interface description, but bidirectional
 - **Orchestration** - like Arazzo's workflow sequencing
 - **AI-driven discovery** - beyond what all three cover natively
-- **Namespace-based routing** - unique to Naftiko's runtime approach
+- **Namespace-based routing** - unique to Ikanos's runtime approach
 
-See the [Spec-Driven Integration](https://github.com/naftiko/framework/wiki/Spec-Driven-Integration) overview and the [Specification - Schema](https://github.com/naftiko/framework/wiki/Specification-Schema) for the formal model.
+See the [Spec-Driven Integration](https://github.com/naftiko/ikanos/wiki/Spec-Driven-Integration) overview and the [Specification - Schema](https://github.com/naftiko/ikanos/wiki/Specification-Schema) for the formal model.
 
-### Q: Is the Naftiko Specification stable?
+### Q: Is the Ikanos Specification stable?
 **A:** The current public version is **1.0.0-alpha1**. Because this is an alpha release, minor schema adjustments can still happen before stable 1.0.0. The specification follows semantic versioning:
 - **Major versions** (1.x.x) - breaking changes
 - **Minor versions** (x.1.0) - new features, backward-compatible
 - **Patch versions** (x.x.1) - bug fixes
 
-Check the naftiko field in your YAML to specify the version.
+Check the Ikanos field in your YAML to specify the version.
 
 ---
 
@@ -962,21 +962,21 @@ Check the naftiko field in your YAML to specify the version.
 
 ### Q: Where can I ask questions or discuss ideas?
 **A:** Join the community at:
-- **[GitHub Discussions](https://github.com/orgs/naftiko/discussions)** - Ask questions and share ideas
-- **[GitHub Issues](https://github.com/naftiko/framework/issues)** - Report bugs or request features
+- **[GitHub Discussions](https://github.com/orgs/Ikanos/discussions)** - Ask questions and share ideas
+- **[GitHub Issues](https://github.com/naftiko/ikanos/issues)** - Report bugs or request features
 - **Pull Requests** - Review and discuss code changes
 
 ### Q: Are there examples I can reference?
 **A:** Yes! Several resources:
 
-- **[Tutorial - Part 1](https://github.com/naftiko/framework/wiki/Tutorial-MCP-Part-1)** - MCP foundations and step-by-step guide
-- **[Tutorial - Part 2](https://github.com/naftiko/framework/wiki/Tutorial-MCP-Part-2)** - Agent Skills, REST, and fleet manifest
-- **[Use Cases](https://github.com/naftiko/framework/wiki/Guide-Use-Cases)** - Real-world examples
-- **Repository examples** - In `src/main/resources/schemas/examples/`, `src/main/resources/tutorial/`, and test resources
-- **Specification examples** - In the [Specification - Schema](https://github.com/naftiko/framework/wiki/Specification-Schema#4-complete-examples) (Section 4)
+- **[Tutorial - Part 1](https://github.com/naftiko/ikanos/wiki/Tutorial-MCP-Part-1)** - MCP foundations and step-by-step guide
+- **[Tutorial - Part 2](https://github.com/naftiko/ikanos/wiki/Tutorial-MCP-Part-2)** - Agent Skills, REST, and fleet manifest
+- **[Use Cases](https://github.com/naftiko/ikanos/wiki/Guide-Use-Cases)** - Real-world examples
+- **Repository examples** - In `ikanos-spec/src/main/resources/schemas/examples/`, `ikanos-docs/tutorial/`, and test resources
+- **Specification examples** - In the [Specification - Schema](https://github.com/naftiko/ikanos/wiki/Specification-Schema#4-complete-examples) (Section 4)
 
-### Q: How often is Naftiko updated?
-**A:** Check the [Releases](https://github.com/naftiko/framework/wiki/Releases) page for version history. The project follows a regular release cadence with security updates prioritized.
+### Q: How often is Ikanos updated?
+**A:** Check the [Releases](https://github.com/naftiko/ikanos/wiki/Releases) page for version history. The project follows a regular release cadence with security updates prioritized.
 
 ---
 
@@ -1001,9 +1001,9 @@ Check the naftiko field in your YAML to specify the version.
 5. **Test with Claude** - configure Claude Desktop with your MCP server
 6. **Publish** - share your capability spec with the community
 
-See [Tutorial - Part 1](https://github.com/naftiko/framework/wiki/Tutorial-MCP-Part-1) for a full MCP example, then continue with [Tutorial - Part 2](https://github.com/naftiko/framework/wiki/Tutorial-MCP-Part-2) for Skill and REST exposure.
+See [Tutorial - Part 1](https://github.com/naftiko/ikanos/wiki/Tutorial-MCP-Part-1) for a full MCP example, then continue with [Tutorial - Part 2](https://github.com/naftiko/ikanos/wiki/Tutorial-MCP-Part-2) for Skill and REST exposure.
 
-### Q: I want to standardize data from multiple SaaS tools. How do I use Naftiko?
+### Q: I want to standardize data from multiple SaaS tools. How do I use Ikanos?
 **A:**
 
 1. **Consume multiple SaaS APIs** - define each in `consumes`
@@ -1011,30 +1011,30 @@ See [Tutorial - Part 1](https://github.com/naftiko/framework/wiki/Tutorial-MCP-P
 3. **Expose unified interface** - create a single API with harmonized formats
 4. **Use orchestration** - combine data from multiple sources if needed
 
-This is Naftiko's core strength for managing API sprawl.
+This is Ikanos's core strength for managing API sprawl.
 
 ---
 
 ## 🏝️ Additional Resources
 
--  **[Installation](https://github.com/naftiko/framework/wiki/Installation)** - Setup instructions
--  **[Spec-Driven Integration](https://github.com/naftiko/framework/wiki/Spec-Driven-Integration)** - Methodology overview
--  **[Tutorial - Part 1](https://github.com/naftiko/framework/wiki/Tutorial-MCP-Part-1)** - MCP foundations
--  **[Tutorial - Part 2](https://github.com/naftiko/framework/wiki/Tutorial-MCP-Part-2)** - Skills, REST, and fleet manifest
--  **[Guide - Use Cases](https://github.com/naftiko/framework/wiki/Guide-Use-Cases)** - Real-world examples
--  **[Guide - Linting](https://github.com/naftiko/framework/wiki/Guide-Linting)** - Validation workflow and CLI usage
--  **[Specification - Schema](https://github.com/naftiko/framework/wiki/Specification-Schema)** - Complete technical reference
--  **[Specification - Rules](https://github.com/naftiko/framework/wiki/Specification-Rules)** - Validation and linting rules
--  **[Releases](https://github.com/naftiko/framework/wiki/Releases)** - Version history
--  **[Roadmap](https://github.com/naftiko/framework/wiki/Roadmap)** - Future plans
--  **[Contribute](https://github.com/naftiko/framework/wiki/Contribute)** - Become a contributor
--  **[Discussions](https://github.com/orgs/naftiko/discussions)** - Community Q&A
+-  **[Installation](https://github.com/naftiko/ikanos/wiki/Installation)** - Setup instructions
+-  **[Spec-Driven Integration](https://github.com/naftiko/ikanos/wiki/Spec-Driven-Integration)** - Methodology overview
+-  **[Tutorial - Part 1](https://github.com/naftiko/ikanos/wiki/Tutorial-MCP-Part-1)** - MCP foundations
+-  **[Tutorial - Part 2](https://github.com/naftiko/ikanos/wiki/Tutorial-MCP-Part-2)** - Skills, REST, and fleet manifest
+-  **[Guide - Use Cases](https://github.com/naftiko/ikanos/wiki/Guide-Use-Cases)** - Real-world examples
+-  **[Guide - Linting](https://github.com/naftiko/ikanos/wiki/Guide-Linting)** - Validation workflow and CLI usage
+-  **[Specification - Schema](https://github.com/naftiko/ikanos/wiki/Specification-Schema)** - Complete technical reference
+-  **[Specification - Rules](https://github.com/naftiko/ikanos/wiki/Specification-Rules)** - Validation and linting rules
+-  **[Releases](https://github.com/naftiko/ikanos/wiki/Releases)** - Version history
+-  **[Roadmap](https://github.com/naftiko/ikanos/wiki/Roadmap)** - Future plans
+-  **[Contribute](https://github.com/naftiko/ikanos/wiki/Contribute)** - Become a contributor
+-  **[Discussions](https://github.com/orgs/Ikanos/discussions)** - Community Q&A
 
 ---
 
 ## 🔔 Feedback
 
 Did this FAQ help you? Have questions not covered here? 
-- **Add an issue** - [GitHub Issues](https://github.com/naftiko/framework/issues)
-- **Start a discussion** - [GitHub Discussions](https://github.com/orgs/naftiko/discussions)
+- **Add an issue** - [GitHub Issues](https://github.com/naftiko/ikanos/issues)
+- **Start a discussion** - [GitHub Discussions](https://github.com/orgs/Ikanos/discussions)
 - **Submit a PR** - Help us improve this FAQ!

--- a/ikanos-docs/wiki/Guide-‐-Linting.md
+++ b/ikanos-docs/wiki/Guide-‐-Linting.md
@@ -10,7 +10,7 @@
   - [Run Locally](#run-locally)
   - [GitHub Actions Workflow](#github-actions-workflow)
 - [What Gets Validated](#what-gets-validated)
-- [Extending the Naftiko Ruleset](#extending-the-naftiko-ruleset)
+- [Extending the Ikanos Ruleset](#extending-the-ikanos-ruleset)
   - [Adding Custom Rules](#adding-custom-rules)
   - [Overriding Built-in Rules](#overriding-built-in-rules)
   - [Adding Custom Functions](#adding-custom-functions)
@@ -21,7 +21,7 @@
 
 ## Overview
 
-Naftiko capabilities are declared in YAML. Two complementary validation layers ensure your capability documents are correct and follow best practices:
+Ikanos capabilities are declared in YAML. Two complementary validation layers ensure your capability documents are correct and follow best practices:
 
 | Layer | Tool | What it checks |
 |---|---|---|
@@ -33,7 +33,7 @@ Both tools can be run standalone or orchestrated together via [MegaLinter](https
 
 > **JSON Schema** catches "is this valid YAML?", **Spectral** catches "is this *good* YAML?"
 
-For a full reference of all Spectral rules, see the [Ruleset](https://github.com/naftiko/framework/wiki/Specification-%E2%80%90-Rules) page.
+For a full reference of all Spectral rules, see the [Ruleset](https://github.com/naftiko/ikanos/wiki/Specification-%E2%80%90-Rules) page.
 
 ---
 
@@ -45,16 +45,16 @@ If you just want to lint a capability file right now:
 # Install Spectral CLI (one-time)
 npm install -g @stoplight/spectral-cli
 
-# Lint a single file against the Naftiko ruleset
+# Lint a single file against the Ikanos ruleset
 npx @stoplight/spectral-cli lint my-capability.yml \
-  --ruleset https://raw.githubusercontent.com/naftiko/framework/main/src/main/resources/rules/naftiko-rules.yml
+  --ruleset https://raw.githubusercontent.com/Ikanos/ikanos/main/ikanos-spec/src/main/resources/rules/ikanos-rules.yml
 ```
 
-If you have cloned the Naftiko Framework repository locally:
+If you have cloned the Ikanos repository locally:
 
 ```bash
 npx @stoplight/spectral-cli lint my-capability.yml \
-  --ruleset path/to/framework/src/main/resources/rules/naftiko-rules.yml
+  --ruleset path/to/framework/src/main/resources/rules/ikanos-rules.yml
 ```
 
 ---
@@ -74,23 +74,23 @@ Create two files at the root of your project:
 
 #### `.spectral.yaml`
 
-This file tells Spectral where to find the Naftiko ruleset. If the Naftiko Framework repository is a sibling directory or submodule:
+This file tells Spectral where to find the Ikanos ruleset. If the Ikanos repository is a sibling directory or submodule:
 
 ```yaml
 extends:
-  - ./path/to/framework/src/main/resources/rules/naftiko-rules.yml
+  - ./path/to/framework/src/main/resources/rules/ikanos-rules.yml
 ```
 
 Or reference the ruleset directly from GitHub:
 
 ```yaml
 extends:
-  - https://raw.githubusercontent.com/naftiko/framework/main/src/main/resources/rules/naftiko-rules.yml
+  - https://raw.githubusercontent.com/Ikanos/ikanos/main/ikanos-spec/src/main/resources/rules/ikanos-rules.yml
 ```
 
 #### `.mega-linter.yml`
 
-This file configures MegaLinter to only run the two linters relevant to Naftiko capabilities:
+This file configures MegaLinter to only run the two linters relevant to Ikanos capabilities:
 
 ```yaml
 # .mega-linter.yml
@@ -106,7 +106,7 @@ API_SPECTRAL_FILTER_REGEX_INCLUDE: "capabilities/.*\\.(yaml|yml)$"
 
 # ── v8r (JSON Schema validation) ──
 YAML_V8R_FILTER_REGEX_INCLUDE: "capabilities/.*\\.(yaml|yml)$"
-YAML_V8R_ARGUMENTS: "-s path/to/naftiko-schema.json"
+YAML_V8R_ARGUMENTS: "-s path/to/ikanos-schema.json"
 
 # General settings
 APPLY_FIXES: none
@@ -115,7 +115,7 @@ VALIDATE_ALL_CODEBASE: true
 
 > **Adapt the filter regex** to match the directory where you store your capability YAML files. The example above assumes a `capabilities/` directory.
 
-> **v8r requires an explicit schema path** via the `-s` flag. v8r does not auto-detect schemas from `# yaml-language-server: $schema=...` comments. You must point it to a local copy of `naftiko-schema.json` or use a URL.
+> **v8r requires an explicit schema path** via the `-s` flag. v8r does not auto-detect schemas from `# yaml-language-server: $schema=...` comments. You must point it to a local copy of `ikanos-schema.json` or use a URL.
 
 ### Run Locally
 
@@ -141,7 +141,7 @@ docker run --rm -v "$(pwd):/tmp/lint" oxsecurity/megalinter:v9
 npx @stoplight/spectral-cli lint "capabilities/*.yml" --ruleset .spectral.yaml
 
 # v8r only (JSON Schema)
-npx v8r "capabilities/*.yml" -s path/to/naftiko-schema.json
+npx v8r "capabilities/*.yml" -s path/to/ikanos-schema.json
 ```
 
 ### GitHub Actions Workflow
@@ -190,7 +190,7 @@ MegaLinter reads the `.mega-linter.yml` file automatically. No inline `env:` con
 
 Catches structural issues such as:
 
-- Missing required fields (`naftiko`, `info`, `capability`)
+- Missing required fields (`Ikanos`, `info`, `capability`)
 - Invalid types (e.g., `port` must be an integer)
 - Invalid enum values (e.g., `method` must be GET, POST, PUT, PATCH, or DELETE)
 - Invalid patterns (e.g., `namespace` must match `^[a-zA-Z0-9-]+$`)
@@ -206,23 +206,23 @@ Catches semantic and style issues such as:
 | **URL hygiene** | Trailing slashes on `baseUri`, query strings in `path` fields |
 | **Quality** | Missing `description` on consumes entries, REST resources, or operations |
 | **Security** | `<script>` tags or `eval(` in description fields |
-| **Scripting** | Script steps missing `language`/`location` without Control Port defaults (`naftiko-script-defaults-required`) |
+| **Scripting** | Script steps missing `language`/`location` without Control Port defaults (`ikanos-script-defaults-required`) |
 
-For the full list, see the [Specification - Rules](https://github.com/naftiko/framework/wiki/Specification-%E2%80%90-Rules) page.
+For the full list, see the [Specification - Rules](https://github.com/naftiko/ikanos/wiki/Specification-%E2%80%90-Rules) page.
 
 ---
 
-## Extending the Naftiko Ruleset
+## Extending the Ikanos Ruleset
 
-The Naftiko ruleset covers the specification's common pitfalls. You can extend it with your own rules to enforce organization-specific conventions — without forking the original ruleset.
+the Ikanos ruleset covers the specification's common pitfalls. You can extend it with your own rules to enforce organization-specific conventions — without forking the original ruleset.
 
 ### Adding Custom Rules
 
-Create your own `.spectral.yaml` that extends the Naftiko ruleset and adds new rules:
+Create your own `.spectral.yaml` that extends the Ikanos ruleset and adds new rules:
 
 ```yaml
 extends:
-  - https://raw.githubusercontent.com/naftiko/framework/main/src/main/resources/rules/naftiko-rules.yml
+  - https://raw.githubusercontent.com/Ikanos/ikanos/main/ikanos-spec/src/main/resources/rules/ikanos-rules.yml
 
 rules:
   # Enforce that all capabilities have at least two tags
@@ -261,21 +261,21 @@ rules:
 
 ### Overriding Built-in Rules
 
-You can change the severity of any Naftiko rule, or disable it entirely:
+You can change the severity of any Ikanos rule, or disable it entirely:
 
 ```yaml
 extends:
-  - https://raw.githubusercontent.com/naftiko/framework/main/src/main/resources/rules/naftiko-rules.yml
+  - https://raw.githubusercontent.com/Ikanos/ikanos/main/ikanos-spec/src/main/resources/rules/ikanos-rules.yml
 
 rules:
   # Promote trailing slash from warning to error
-  naftiko-consumes-baseuri-no-trailing-slash: error
+  ikanos-consumes-baseuri-no-trailing-slash: error
 
   # Disable the info-tags rule (your org doesn't use tags)
-  naftiko-info-tags: off
+  Ikanos-info-tags: off
 
   # Downgrade missing REST operation description from info to hint
-  naftiko-rest-operation-description: hint
+  Ikanos-rest-operation-description: hint
 ```
 
 ### Adding Custom Functions
@@ -317,7 +317,7 @@ module.exports = function checkBindsLocationScheme(targetVal) {
 
 ```yaml
 extends:
-  - https://raw.githubusercontent.com/naftiko/framework/main/src/main/resources/rules/naftiko-rules.yml
+  - https://raw.githubusercontent.com/Ikanos/ikanos/main/ikanos-spec/src/main/resources/rules/ikanos-rules.yml
 
 functionsDir: ./functions
 
@@ -337,12 +337,12 @@ rules:
 
 ### Full Example
 
-Here is a complete `.spectral.yaml` that extends the Naftiko ruleset with organization-specific rules:
+Here is a complete `.spectral.yaml` that extends the Ikanos ruleset with organization-specific rules:
 
 ```yaml
 # .spectral.yaml — ACME Corp capability linting
 extends:
-  - https://raw.githubusercontent.com/naftiko/framework/main/src/main/resources/rules/naftiko-rules.yml
+  - https://raw.githubusercontent.com/Ikanos/ikanos/main/ikanos-spec/src/main/resources/rules/ikanos-rules.yml
 
 functionsDir: ./functions
 
@@ -351,8 +351,8 @@ functions:
 
 rules:
   # ── Override built-in severities ──
-  naftiko-consumes-baseuri-no-trailing-slash: error
-  naftiko-info-tags: off
+  ikanos-consumes-baseuri-no-trailing-slash: error
+  Ikanos-info-tags: off
 
   # ── Organization rules ──
   acme-min-tags:
@@ -393,18 +393,18 @@ This is a success message — your file has no errors. Warnings and info message
 v8r does not auto-detect schemas from `# yaml-language-server: $schema=...` comments. You must pass the schema explicitly:
 
 ```bash
-npx v8r my-capability.yml -s path/to/naftiko-schema.json
+npx v8r my-capability.yml -s path/to/ikanos-schema.json
 ```
 
 Or in `.mega-linter.yml`:
 
 ```yaml
-YAML_V8R_ARGUMENTS: "-s path/to/naftiko-schema.json"
+YAML_V8R_ARGUMENTS: "-s path/to/ikanos-schema.json"
 ```
 
 ### MegaLinter: Spectral finds no files
 
-MegaLinter's Spectral integration auto-detects files by looking for OpenAPI/AsyncAPI content keywords (`openapi:`, `swagger:`, `asyncapi:`). Naftiko files use `naftiko:` instead, so they are **not auto-detected**.
+MegaLinter's Spectral integration auto-detects files by looking for OpenAPI/AsyncAPI content keywords (`openapi:`, `swagger:`, `asyncapi:`). Ikanos files use `Ikanos:` instead, so they are **not auto-detected**.
 
 Fix: Set `API_SPECTRAL_FILTER_REGEX_INCLUDE` in `.mega-linter.yml` to explicitly target your capability YAML directory.
 
@@ -412,7 +412,7 @@ Fix: Set `API_SPECTRAL_FILTER_REGEX_INCLUDE` in `.mega-linter.yml` to explicitly
 
 Custom functions referenced via `functionsDir` are resolved relative to the ruleset file that declares them.
 
-- If you `extends` the Naftiko ruleset from a URL, Naftiko's built-in custom functions (like `unique-namespaces`) load from the GitHub-hosted `functions/` directory.
+- If you `extends` the Ikanos ruleset from a URL, Ikanos's built-in custom functions (like `unique-namespaces`) load from the GitHub-hosted `functions/` directory.
 - Your own custom functions must be in a `functions/` directory relative to *your* `.spectral.yaml`.
 
 ### MegaLinter: Docker image is too large

--- a/ikanos-docs/wiki/Guide-‐-Use-Cases.md
+++ b/ikanos-docs/wiki/Guide-‐-Use-Cases.md
@@ -1,17 +1,17 @@
 # Guide - Use Cases
 
-Here is an overview of typical use cases where Naftiko Framework can help developers and supporting features available. Additional features are being added as described in the [roadmap](https://github.com/naftiko/framework/wiki/Roadmap).
+Here is an overview of typical use cases where Ikanos can help developers and supporting features available. Additional features are being added as described in the [roadmap](https://github.com/naftiko/ikanos/wiki/Roadmap).
 
 ## 1. AI integration
 
 Connect AI assistants to your systems through capabilities, so they can access trusted business data and actions without custom glue code.
 
-How Naftiko achieves this technically:
+How Ikanos achieves this technically:
 - Declare upstream systems in `capability.consumes` (typically `type: http`) with `namespace`, `baseUri`, authentication, headers, and operation contracts.
 - Expose the same domain as `type: mcp` tools and/or `type: api` resources in `capability.exposes`, so both AI agents and traditional clients use one integration layer.
 - Use `call`, `with`, `steps`, and JSONPath `mapping` in `outputParameters` to return normalized, task-ready payloads instead of raw provider responses.
 
-![Integrate AI](https://naftiko.github.io/docs/images/technology/use_case_AI_integration.png)
+![Integrate AI](https://Ikanos.github.io/docs/images/technology/use_case_AI_integration.png)
 
 #### Key features
 - [x] Declarative HTTP consumption with namespace-scoped adapters
@@ -30,12 +30,12 @@ How Naftiko achieves this technically:
 
 Expose only the context an AI task needs, reducing noise, improving relevance, and keeping prompts efficient.
 
-How Naftiko achieves this technically:
+How Ikanos achieves this technically:
 - Shape response payloads with typed `outputParameters` (string, object, array) and fine-grained JSONPath `mapping` expressions.
 - Keep only relevant fields in exposed tool/resource schemas, while hiding irrelevant upstream fields from the AI surface.
 - Attach meaningful `info.description`, tool descriptions, and tags so discovery is semantic and context quality stays high.
 
-![Rightsize AI context](https://naftiko.github.io/docs/images/technology/use_case_context_engineering_rightsize_ai_context.png)
+![Rightsize AI context](https://Ikanos.github.io/docs/images/technology/use_case_context_engineering_rightsize_ai_context.png)
 
 #### Key features
 - [x] Declarative applied capability exposing MCP
@@ -53,13 +53,13 @@ How Naftiko achieves this technically:
 
 Wrap a current API as a capability to make it easier to discover, reuse, and consume across teams and channels.
 
-How Naftiko achieves this technically:
+How Ikanos achieves this technically:
 - Model the legacy/existing API once in `consumes.resources.operations` with explicit methods, paths, parameters, and body formats.
 - Add a stable capability namespace and expose curated resource paths/tools that are easier to consume than vendor-native endpoints.
 - Reshape not just data but also operation semantics: declare `semantics` (safe, idempotent, cacheable) on aggregate functions so the engine derives correct HTTP methods for REST adapters and `hints` for MCP tools automatically.
 - Enforce schema-based validation (`capability-schema.json`) so the elevated contract remains consistent and machine-checkable.
 
-![Elevate existing APIs](https://naftiko.github.io/docs/images/technology/use_case_api_reusability_elevate_existing_apis.png)
+![Elevate existing APIs](https://Ikanos.github.io/docs/images/technology/use_case_api_reusability_elevate_existing_apis.png)
 
 #### Key features
 - [x] Pass thru source capability
@@ -82,12 +82,12 @@ How Naftiko achieves this technically:
 
 Wrap Google Sheets as a capability so spreadsheet rows become a reusable, domain-specific API for traditional clients and AI agents.
 
-How Naftiko achieves this technically:
+How Ikanos achieves this technically:
 - Consume the Google Sheets values endpoint in `consumes.resources.operations`, with templated `spreadsheet_id` and `range` path parameters plus API key injection through `binds`.
 - Transform raw row arrays from `$.values` into named objects using positional JSONPath mappings such as `$[0]`, `$[1]`, and `$[2]` inside typed `outputParameters`.
 - Expose the normalized result through `type: rest`, `type: mcp`, or both, so one spreadsheet integration serves both application and agent use cases.
 
-![Elevate GSheets API](https://naftiko.github.io/docs/images/technology/use_case_api_reusability_elevate_gsheets_api.png)
+![Elevate GSheets API](https://Ikanos.github.io/docs/images/technology/use_case_api_reusability_elevate_gsheets_api.png)
 
 #### Key features
 - [x] Declarative Google Sheets API consumption
@@ -104,12 +104,12 @@ How Naftiko achieves this technically:
 
 Combine data from multiple APIs into one capability to deliver richer, task-ready context to AI clients.
 
-How Naftiko achieves this technically:
+How Ikanos achieves this technically:
 - Register multiple consumed APIs with unique namespaces, then orchestrate cross-source calls using ordered `steps`.
 - Bridge calls through step `mappings` and per-step input injection, so outputs from one source feed inputs of the next.
 - Return a single composed output model via mapped `outputParameters`, giving AI clients one coherent result.
 
-![Rightsize AI context](https://naftiko.github.io/docs/images/technology/use_case_context_engineering_compose_ai_context.png)
+![Rightsize AI context](https://Ikanos.github.io/docs/images/technology/use_case_context_engineering_compose_ai_context.png)
 
 #### Key features
 - [x] Declarative source HTTP adapter and target MCP adapter
@@ -127,12 +127,12 @@ How Naftiko achieves this technically:
 
 Create a simpler capability layer over many microservices to reduce client complexity and improve consistency.
 
-How Naftiko achieves this technically:
+How Ikanos achieves this technically:
 - Aggregate multiple microservice endpoints under one exposed namespace and a small set of business-oriented resources/tools.
 - Standardize auth/header behavior and parameter handling at capability level instead of duplicating logic in every client.
 - Use orchestration and output shaping to hide service fragmentation and return consistent contracts.
 
-![Rightsize microservices](https://naftiko.github.io/docs/images/technology/use_case_api_reusability_rightsize_microservices.png)
+![Rightsize microservices](https://Ikanos.github.io/docs/images/technology/use_case_api_reusability_rightsize_microservices.png)
 
 #### Key features
 - [x] Declarative source HTTP adapter and target REST adapter
@@ -149,12 +149,12 @@ How Naftiko achieves this technically:
 
 Extract focused capabilities from a broad monolith API so consumers get only what they need for each use case.
 
-How Naftiko achieves this technically:
+How Ikanos achieves this technically:
 - Select only required monolith operations in `consumes` and remap them to narrower exposed resources/tools.
 - Use output filtering/mapping to publish smaller, purpose-built payloads for each consumer scenario.
 - Optionally forward selected routes with `forward.targetNamespace` to keep passthrough paths where full transformation is not needed.
 
-![Rightsize monolith APIs](https://naftiko.github.io/docs/images/technology/use_case_api_reusability_rightsize_monolith_apis.png)
+![Rightsize monolith APIs](https://Ikanos.github.io/docs/images/technology/use_case_api_reusability_rightsize_monolith_apis.png)
 
 #### Key features
 - [x] Selective operation exposure from a broad API
@@ -171,12 +171,12 @@ How Naftiko achieves this technically:
 
 Design capabilities first for MCP clients, then map them to underlying APIs for a clean AI-native integration model.
 
-How Naftiko achieves this technically:
+How Ikanos achieves this technically:
 - Define `type: mcp` exposure with server-level description and tool-level contracts (name, description, input/output parameters).
 - Support MCP transports (`http` or `stdio`) so the same capability can run in remote server mode or local IDE/agent mode.
 - Wire tools to one or many consumed operations via `call` or orchestrated `steps`, without changing upstream APIs.
 
-![Capability-first approach](https://naftiko.github.io/docs/images/technology/use_case_context_engineering_capability_first.png)
+![Capability-first approach](https://Ikanos.github.io/docs/images/technology/use_case_context_engineering_capability_first.png)
 
 #### Key features
 - [x] Declarative MCP server with tools, resources, and prompts
@@ -196,12 +196,12 @@ How Naftiko achieves this technically:
 
 Start from existing APIs and define reusable capabilities on top, so API investments can power new AI and app experiences.
 
-How Naftiko achieves this technically:
+How Ikanos achieves this technically:
 - Begin with consumed API declarations (`baseUri`, auth, resources, operations), then incrementally add exposed REST/MCP adapters.
 - Reuse existing security and configuration using `binds` with file or runtime injection and injected variables (e.g., `{{API_TOKEN}}`).
 - Add format-aware parsing and mapping (JSON, YAML, XML, CSV, TSV, PSV, Avro, Protobuf, HTML, Markdown support in the framework) to normalize diverse backends.
 
-![Capability-first approach](https://naftiko.github.io/docs/images/technology/use_case_api_reusability_capability_first.png)
+![Capability-first approach](https://Ikanos.github.io/docs/images/technology/use_case_api_reusability_capability_first.png)
 
 #### Key features
 - [x] Externalized secrets via `binds`
@@ -218,15 +218,15 @@ How Naftiko achieves this technically:
 
 ## 10. Interoperate with OpenAPI
 
-Bridge existing OpenAPI ecosystems with Naftiko capabilities: import OAS documents to bootstrap consumption adapters, and export REST adapters as standard OpenAPI specifications.
+Bridge existing OpenAPI ecosystems with Ikanos capabilities: import OAS documents to bootstrap consumption adapters, and export REST adapters as standard OpenAPI specifications.
 
-How Naftiko achieves this technically:
-- Import an OpenAPI 3.0 or 3.1 document (or a Swagger 2.0 document, which is auto-converted) with `naftiko import openapi`, generating a ready-to-use `consumes` HTTP adapter with authentication, operations, input parameters, and output parameters pre-filled.
-- Export a REST `exposes` adapter with `naftiko export openapi`, producing a standards-compliant OAS document that can be shared with API gateways, developer portals, and documentation tools.
+How Ikanos achieves this technically:
+- Import an OpenAPI 3.0 or 3.1 document (or a Swagger 2.0 document, which is auto-converted) with `ikanos import openapi`, generating a ready-to-use `consumes` HTTP adapter with authentication, operations, input parameters, and output parameters pre-filled.
+- Export a REST `exposes` adapter with `ikanos export openapi`, producing a standards-compliant OAS document that can be shared with API gateways, developer portals, and documentation tools.
 - Use `--adapter <namespace>` to target a specific REST adapter when the capability exposes more than one.
 
 #### Key features
-- [x] OpenAPI import into Naftiko `consumes` adapter
+- [x] OpenAPI import into Ikanos `consumes` adapter
   - [x] Swagger 2.0 support (auto-converted to OAS 3.0)
   - [x] OAS 3.0 and 3.1 support
   - [x] Authentication mapping (bearer, basic, API key, digest)
@@ -234,7 +234,7 @@ How Naftiko achieves this technically:
   - [x] Operation grouping by tag into separate resources
   - [x] Input parameter conversion (query, header, path, cookie, body)
   - [x] Output parameter conversion (object, array, scalar, allOf, oneOf)
-- [x] OpenAPI export from Naftiko REST `exposes` adapter
+- [x] OpenAPI export from Ikanos REST `exposes` adapter
   - [x] OAS 3.0 and 3.1 output via `--spec-version`
   - [x] YAML and JSON output formats
   - [x] Multi-adapter selection with `--adapter`
@@ -246,7 +246,7 @@ How Naftiko achieves this technically:
 
 Observe capability behavior in real time with built-in metrics, distributed traces, and health checks — configured entirely from the spec.
 
-How Naftiko achieves this technically:
+How Ikanos achieves this technically:
 - Add a `type: control` adapter in `capability.exposes` to expose a management plane with health, metrics, traces, and diagnostic endpoints on a dedicated port.
 - Configure `capability.observability` to enable OpenTelemetry-based distributed tracing and RED metrics (Rate, Errors, Duration) with configurable sampling and OTLP export.
 - Scrape Prometheus-format metrics from the control port's `/metrics` endpoint and inspect recent traces via `/traces` — no additional infrastructure code required.
@@ -272,7 +272,7 @@ How Naftiko achieves this technically:
 
 Reshape, filter, or aggregate data between consumed API calls using inline script steps — without building a separate microservice or writing Java code.
 
-How Naftiko achieves this technically:
+How Ikanos achieves this technically:
 - Add `type: script` steps in orchestrated operations to transform data between `call` steps using JavaScript, Python, or Groovy.
 - Scripts run in sandboxed environments (GraalVM for JS/Python, SecureASTCustomizer for Groovy) with no filesystem or network access.
 - Previous step results are bound as variables; scripts assign to `result` to produce output for subsequent steps or mappings.
@@ -290,6 +290,6 @@ How Naftiko achieves this technically:
   - [x] Configurable statement limits and timeouts
   - [x] Allowed languages restriction
   - [x] Control Port `/scripting` endpoint for runtime management
-  - [x] CLI `naftiko scripting` command for governance
+  - [x] CLI `ikanos scripting` command for governance
 - [x] Linting support
-  - [x] Spectral rule `naftiko-script-defaults-required` validates Control Port defaults
+  - [x] Spectral rule `ikanos-script-defaults-required` validates Control Port defaults

--- a/ikanos-docs/wiki/Home.md
+++ b/ikanos-docs/wiki/Home.md
@@ -1,8 +1,8 @@
-Welcome to Naftiko Framework, the first Open Source project for [Spec-Driven Integration](https://github.com/naftiko/framework/wiki/Spec%E2%80%90Driven-Integration) reinventing API integration for the AI era with governed and versatile capabilities that streamline API sprawl from massive SaaS and microservices growth.
+Welcome to Ikanos, the first Open Source project for [Spec-Driven Integration](https://github.com/naftiko/ikanos/wiki/Spec%E2%80%90Driven-Integration) reinventing API integration for the AI era with governed and versatile capabilities that streamline API sprawl from massive SaaS and microservices growth.
 
-<img src="https://naftiko.github.io/docs/images/technology/architecture_capability.png" width="600">
+<img src="https://Ikanos.github.io/docs/images/technology/architecture_capability.png" width="600">
 
-Each capability is a coarse piece of domain that consumes existing HTTP-based APIs then exposes them in several protocols to enable AI integration and self-integrating agents. Naftiko Framework includes a specification, an engine and a CLI.
+Each capability is a coarse piece of domain that consumes existing HTTP-based APIs then exposes them in several protocols to enable AI integration and self-integrating agents. Ikanos includes a specification, an engine and a CLI.
 
 | Feature | Description |
 |---|---|
@@ -24,22 +24,22 @@ Each capability is a coarse piece of domain that consumes existing HTTP-based AP
 
 Here are additional documents to learn more:
 
-- :compass: [Spec-Driven Integration](https://github.com/naftiko/framework/wiki/Spec%E2%80%90Driven-Integration)
-- :rowboat: [Installation](https://github.com/naftiko/framework/wiki/Installation)
-- :sailboat: [Tutorial - Part 1](https://github.com/naftiko/framework/wiki/Tutorial-%E2%80%90-Part-1)
-- :speedboat: [Tutorial - Part 2](https://github.com/naftiko/framework/wiki/Tutorial-%E2%80%90-Part-2)
-- :ship: [Guide - Use Cases](https://github.com/naftiko/framework/wiki/Guide-%E2%80%90-Use-Cases)
-- :mag: [Guide - Linting](https://github.com/naftiko/framework/wiki/Guide-%E2%80%90-Linting)
-- :anchor: [Specification - Schema](https://github.com/naftiko/framework/wiki/Specification-%E2%80%90-Schema)
-- :triangular_ruler: [Specification - Rules](https://github.com/naftiko/framework/wiki/Specification-%E2%80%90-Rules)
-- :ocean: [FAQ](https://github.com/naftiko/framework/wiki/FAQ)
-- :mega: [Releases](https://github.com/naftiko/framework/wiki/Releases)
-- :telescope: [Roadmap](https://github.com/naftiko/framework/wiki/Roadmap)
-- :nut_and_bolt: [Contribute](https://github.com/naftiko/framework/blob/main/CONTRIBUTING.md)
+- :compass: [Spec-Driven Integration](https://github.com/naftiko/ikanos/wiki/Spec%E2%80%90Driven-Integration)
+- :rowboat: [Installation](https://github.com/naftiko/ikanos/wiki/Installation)
+- :sailboat: [Tutorial - Part 1](https://github.com/naftiko/ikanos/wiki/Tutorial-%E2%80%90-Part-1)
+- :speedboat: [Tutorial - Part 2](https://github.com/naftiko/ikanos/wiki/Tutorial-%E2%80%90-Part-2)
+- :ship: [Guide - Use Cases](https://github.com/naftiko/ikanos/wiki/Guide-%E2%80%90-Use-Cases)
+- :mag: [Guide - Linting](https://github.com/naftiko/ikanos/wiki/Guide-%E2%80%90-Linting)
+- :anchor: [Specification - Schema](https://github.com/naftiko/ikanos/wiki/Specification-%E2%80%90-Schema)
+- :triangular_ruler: [Specification - Rules](https://github.com/naftiko/ikanos/wiki/Specification-%E2%80%90-Rules)
+- :ocean: [FAQ](https://github.com/naftiko/ikanos/wiki/FAQ)
+- :mega: [Releases](https://github.com/naftiko/ikanos/wiki/Releases)
+- :telescope: [Roadmap](https://github.com/naftiko/ikanos/wiki/Roadmap)
+- :nut_and_bolt: [Contribute](https://github.com/naftiko/ikanos/blob/main/CONTRIBUTING.md)
 
 ***
 
-Naftiko Framework is part of [Naftiko Fleet (Community Edition)](https://github.com/naftiko/fleet), which adds free complementary tools:
+Ikanos is part of [Naftiko Fleet (Community Edition)](https://github.com/naftiko/fleet), which adds free complementary tools:
 
 | Tool | What it does |
 |---|---|
@@ -47,6 +47,6 @@ Naftiko Framework is part of [Naftiko Fleet (Community Edition)](https://github.
 | [Naftiko Templates for Backstage](https://github.com/naftiko/fleet/wiki/Naftiko-Templates-for-Backstage) | Scaffold and catalog capabilities from CNCF Backstage |
 | Naftiko Operator for Kubernetes | Deploy and operate capabilities on Kubernetes *(coming soon)* |
 
-Please join the community of users and contributors in [this GitHub Discussion forum!](https://github.com/orgs/naftiko/discussions).
+Please join the community of users and contributors in [this GitHub Discussion forum!](https://github.com/orgs/Ikanos/discussions).
 
-<img src="https://naftiko.github.io/docs/images/navi/navi_hello.svg" width="50">
+<img src="https://Ikanos.github.io/docs/images/navi/navi_hello.svg" width="50">

--- a/ikanos-docs/wiki/Installation.md
+++ b/ikanos-docs/wiki/Installation.md
@@ -13,12 +13,12 @@ To use Ikanos, you need to install and then run the Ikanos Engine, passing a Ika
 * Ikanos provides a docker image hosted in GitHub packages platform. It is public, so you can easily pull it locally.
   ```bash
   # {{RELEASE_TAG}}
-  docker pull ghcr.io/Ikanos/Ikanos-framework:{{RELEASE_TAG}}
+  docker pull ghcr.io/naftiko/ikanos:{{RELEASE_TAG}}
 
   # Or if you prefer to play with the last snapshot
-  docker pull ghcr.io/Ikanos/Ikanos-framework:latest
+  docker pull ghcr.io/naftiko/ikanos:latest
   ```
-  Then, you should see the image 'ghcr.io/Ikanos/Ikanos-framework' in your Docker Desktop.\
+  Then, you should see the image 'ghcr.io/naftiko/ikanos' in your Docker Desktop.\
   <img src="https://Ikanos.github.io/docs/images/technology/framework/docker-install-step-1.png" width="600">
 
   You can also display local images in your terminal with this command:
@@ -50,10 +50,10 @@ You can use more complex capability files from [Tutorial - Part 1](https://githu
 Let's assume you downloaded [step-1-shipyard-first-capability.yml](https://raw.githubusercontent.com/Ikanos/ikanos/refs/tags/v1.0.0-alpha1/src/main/resources/tutorial/step-1-shipyard-first-capability.yml) in your downloads folder. Then you should run:
 ```bash
 # For Linux and Mac
-docker run -p 8081:3001 -v ~/Downloads/step-1-shipyard-first-capability.yml:/app/test.capability.yaml ghcr.io/Ikanos/Ikanos-framework:{{RELEASE_TAG}} /app/test.capability.yaml
+docker run -p 8081:3001 -v ~/Downloads/step-1-shipyard-first-capability.yml:/app/test.capability.yaml ghcr.io/naftiko/ikanos:{{RELEASE_TAG}} /app/test.capability.yaml
 
 # For windows
-docker run -p 8081:3001 -v %USERPROFILE%/Downloads/step-1-shipyard-first-capability.yml:/app/test.capability.yaml ghcr.io/Ikanos/Ikanos-framework:{{RELEASE_TAG}} /app/test.capability.yaml
+docker run -p 8081:3001 -v %USERPROFILE%/Downloads/step-1-shipyard-first-capability.yml:/app/test.capability.yaml ghcr.io/naftiko/ikanos:{{RELEASE_TAG}} /app/test.capability.yaml
 ```
 Then you should be able to request your capability at http://localhost:8081 (the step-1-shipyard-first-capability.yml exposes an MCP tool adapter).
 
@@ -67,7 +67,7 @@ Then you should be able to request your capability at http://localhost:8081 (the
 * Run your capability with Ikanos Engine.\
   Given a capability configuration file 'test.capability.yaml' and an exposition on port 8081, here is the command you have to execute to run the Framework Engine:
   ```bash
-  docker run -p 8081:8081 -v full_path_to_your_capability_folder/test.capability.yaml:/app/test.capability.yaml ghcr.io/Ikanos/framework:latest/app/test.capability.yaml
+  docker run -p 8081:8081 -v full_path_to_your_capability_folder/test.capability.yaml:/app/test.capability.yaml ghcr.io/naftiko/ikanos:latest /app/test.capability.yaml
   ```
 
 ## Ikanos CLI

--- a/ikanos-docs/wiki/Installation.md
+++ b/ikanos-docs/wiki/Installation.md
@@ -1,6 +1,6 @@
-To use Naftiko Framework, you need to install and then run the Naftiko Engine, passing a Naftiko YAML file to it. A command-line interface is also provided.
+To use Ikanos, you need to install and then run the Ikanos Engine, passing a Ikanos YAML file to it. A command-line interface is also provided.
 
-## Naftiko Engine
+## Ikanos Engine
 ### Prerequisites
 * You need Docker or, if you are on macOS or Windows their Docker Desktop version. To do so, follow the official documentation:
   * [For Mac](https://docs.docker.com/desktop/setup/install/mac-install/)
@@ -9,17 +9,17 @@ To use Naftiko Framework, you need to install and then run the Naftiko Engine, p
 
 * Be sure that Docker (or Docker Desktop) is running
 
-### Pull Naftiko's Docker image
-* Naftiko provides a docker image hosted in GitHub packages platform. It is public, so you can easily pull it locally.
+### Pull Ikanos's Docker image
+* Ikanos provides a docker image hosted in GitHub packages platform. It is public, so you can easily pull it locally.
   ```bash
   # {{RELEASE_TAG}}
-  docker pull ghcr.io/naftiko/naftiko-framework:{{RELEASE_TAG}}
+  docker pull ghcr.io/Ikanos/Ikanos-framework:{{RELEASE_TAG}}
 
   # Or if you prefer to play with the last snapshot
-  docker pull ghcr.io/naftiko/naftiko-framework:latest
+  docker pull ghcr.io/Ikanos/Ikanos-framework:latest
   ```
-  Then, you should see the image 'ghcr.io/naftiko/naftiko-framework' in your Docker Desktop.\
-  <img src="https://naftiko.github.io/docs/images/technology/framework/docker-install-step-1.png" width="600">
+  Then, you should see the image 'ghcr.io/Ikanos/Ikanos-framework' in your Docker Desktop.\
+  <img src="https://Ikanos.github.io/docs/images/technology/framework/docker-install-step-1.png" width="600">
 
   You can also display local images in your terminal with this command:
   ```bash
@@ -27,12 +27,12 @@ To use Naftiko Framework, you need to install and then run the Naftiko Engine, p
   ```
 
 ### Configure your own capability
-The Naftiko Engine runs capabilities. For that, it uses a capability configuration file. You first have to create this file locally.\
+The Ikanos Engine runs capabilities. For that, it uses a capability configuration file. You first have to create this file locally.\
   
-* The simpler to start is to download the following capability file example on your local machine: [step-1-shipyard-first-capability.yml](https://raw.githubusercontent.com/naftiko/framework/refs/tags/v1.0.0-alpha1/src/main/resources/tutorial/step-1-shipyard-first-capability.yml).
+* The simpler to start is to download the following capability file example on your local machine: [step-1-shipyard-first-capability.yml](https://raw.githubusercontent.com/Ikanos/ikanos/refs/tags/v1.0.0-alpha1/src/main/resources/tutorial/step-1-shipyard-first-capability.yml).
 
 * Advanced usage\
-You can use more complex capability files from [Tutorial - Part 1](https://github.com/naftiko/framework/wiki/Tutorial-%E2%80%90-Part-1) and [Tutorial - Part 2](https://github.com/naftiko/framework/wiki/Tutorial-%E2%80%90-Part-2), and then move to the comprehensive [Specification - Schema](https://github.com/naftiko/framework/wiki/Specification-%E2%80%90-Schema) and [Specification - Rules](https://github.com/naftiko/framework/wiki/Specification-%E2%80%90-Rules). This file must be a YAML file (yaml and yml extensions are supported).
+You can use more complex capability files from [Tutorial - Part 1](https://github.com/naftiko/ikanos/wiki/Tutorial-%E2%80%90-Part-1) and [Tutorial - Part 2](https://github.com/naftiko/ikanos/wiki/Tutorial-%E2%80%90-Part-2), and then move to the comprehensive [Specification - Schema](https://github.com/naftiko/ikanos/wiki/Specification-%E2%80%90-Schema) and [Specification - Rules](https://github.com/naftiko/ikanos/wiki/Specification-%E2%80%90-Rules). This file must be a YAML file (yaml and yml extensions are supported).
 
   * ⚠️ Localhost references in your capability configuration file.
     * If your capability refers to some local hosts, be careful to not use 'localhost', but 'host.docker.internal' instead. This is because your capability will run into an isolated docker container, so 'localhost' will refer to the container and not your local machine.\
@@ -46,14 +46,14 @@ You can use more complex capability files from [Tutorial - Part 1](https://githu
       address: "0.0.0.0"
       ```
 
-### Run Naftiko Engine as a Docker container
-Let's assume you downloaded [step-1-shipyard-first-capability.yml](https://raw.githubusercontent.com/naftiko/framework/refs/tags/v1.0.0-alpha1/src/main/resources/tutorial/step-1-shipyard-first-capability.yml) in your downloads folder. Then you should run:
+### Run Ikanos Engine as a Docker container
+Let's assume you downloaded [step-1-shipyard-first-capability.yml](https://raw.githubusercontent.com/Ikanos/ikanos/refs/tags/v1.0.0-alpha1/src/main/resources/tutorial/step-1-shipyard-first-capability.yml) in your downloads folder. Then you should run:
 ```bash
 # For Linux and Mac
-docker run -p 8081:3001 -v ~/Downloads/step-1-shipyard-first-capability.yml:/app/test.capability.yaml ghcr.io/naftiko/naftiko-framework:{{RELEASE_TAG}} /app/test.capability.yaml
+docker run -p 8081:3001 -v ~/Downloads/step-1-shipyard-first-capability.yml:/app/test.capability.yaml ghcr.io/Ikanos/Ikanos-framework:{{RELEASE_TAG}} /app/test.capability.yaml
 
 # For windows
-docker run -p 8081:3001 -v %USERPROFILE%/Downloads/step-1-shipyard-first-capability.yml:/app/test.capability.yaml ghcr.io/naftiko/naftiko-framework:{{RELEASE_TAG}} /app/test.capability.yaml
+docker run -p 8081:3001 -v %USERPROFILE%/Downloads/step-1-shipyard-first-capability.yml:/app/test.capability.yaml ghcr.io/Ikanos/Ikanos-framework:{{RELEASE_TAG}} /app/test.capability.yaml
 ```
 Then you should be able to request your capability at http://localhost:8081 (the step-1-shipyard-first-capability.yml exposes an MCP tool adapter).
 
@@ -64,14 +64,14 @@ Then you should be able to request your capability at http://localhost:8081 (the
 * Use of port forwarding.\
   According to your configuration file, your capability will be exposed on a given port (`port` field of the `expose` item). Keep in mind that the framework engine runs in a container context, so this port won't be accessible from your local machine. You must use the port forwarding. This will be done using the '-p' option of the docker run command.
 
-* Run your capability with Naftiko Engine.\
+* Run your capability with Ikanos Engine.\
   Given a capability configuration file 'test.capability.yaml' and an exposition on port 8081, here is the command you have to execute to run the Framework Engine:
   ```bash
-  docker run -p 8081:8081 -v full_path_to_your_capability_folder/test.capability.yaml:/app/test.capability.yaml ghcr.io/naftiko/framework:latest/app/test.capability.yaml
+  docker run -p 8081:8081 -v full_path_to_your_capability_folder/test.capability.yaml:/app/test.capability.yaml ghcr.io/Ikanos/framework:latest/app/test.capability.yaml
   ```
 
-## Naftiko CLI
-The Naftiko Framework also includes a CLI tool.\
+## Ikanos CLI
+The Ikanos also includes a CLI tool.\
 The goal of this CLI is to simplify configuration and validation. While everything can be done manually, the CLI provides helper commands.
 
 ## Installation
@@ -80,27 +80,27 @@ For the moment, CLI is only provided for Apple Silicon (with M chip).
 **Apple Silicon (M1/M2/M3/M4):**
 ```bash
 # Download the binary
-curl -L https://github.com/naftiko/framework/releases/download/{{RELEASE_TAG}}/naftiko-cli-macos-arm64 -o naftiko
+curl -L https://github.com/naftiko/ikanos/releases/download/{{RELEASE_TAG}}/ikanos-cli-macos-arm64 -o Ikanos
 
 # Set binary as executable
-chmod +x naftiko
+chmod +x Ikanos
 
 # Delete the macOS quarantine (temporary step, because the binary is not signed yet)
-xattr -d com.apple.quarantine naftiko
+xattr -d com.apple.quarantine Ikanos
 
 # Install
-sudo mv naftiko /usr/local/bin/
+sudo mv Ikanos /usr/local/bin/
 ```
 ### Linux
 ```bash
 # Download the binary
-curl -L https://github.com/naftiko/framework/releases/download/{{RELEASE_TAG}}/naftiko-cli-linux-amd64 -o naftiko
+curl -L https://github.com/naftiko/ikanos/releases/download/{{RELEASE_TAG}}/ikanos-cli-linux-amd64 -o Ikanos
 
 # Set binary as executable
-chmod +x naftiko
+chmod +x Ikanos
 
 # Install
-sudo mv naftiko /usr/local/bin/
+sudo mv Ikanos /usr/local/bin/
 ```
 ### Windows
 PowerShell installation is recommended.
@@ -108,21 +108,21 @@ PowerShell installation is recommended.
 **Open PowerShell as admin and execute:**
 ```powershell
 # Create installation folder
-New-Item -ItemType Directory -Force -Path "C:\Program Files\Naftiko"
+New-Item -ItemType Directory -Force -Path "C:\Program Files\Ikanos"
 
 # Download the binary
-Invoke-WebRequest -Uri "https://github.com/naftiko/framework/releases/download/{{RELEASE_TAG}}/naftiko-cli-windows-amd64.exe" -OutFile "C:\Program Files\Naftiko\naftiko.exe"
+Invoke-WebRequest -Uri "https://github.com/naftiko/ikanos/releases/download/{{RELEASE_TAG}}/ikanos-cli-windows-amd64.exe" -OutFile "C:\Program Files\Ikanos\Ikanos.exe"
 
 # Add to the system PATH
 $oldPath = [Environment]::GetEnvironmentVariable('Path', 'Machine')
-$newPath = $oldPath + ';C:\Program Files\Naftiko'
+$newPath = $oldPath + ';C:\Program Files\Ikanos'
 [Environment]::SetEnvironmentVariable('Path', $newPath, 'Machine')
 ```
 
 ## Test
 After installation, you may have to restart your terminal. Then run this command to check the CLI is well installed:
 ```bash
-naftiko --help
+ikanos --help
 ```
 You should see the help of the command.
 
@@ -130,65 +130,65 @@ You should see the help of the command.
 There are two available features for the moment: the creation of a "minimum" valid capability configuration file, and the validation of a capability file.
 ### Create a capability configuration file
 ```bash
-naftiko create capability
+ikanos create capability
 # You can also use aliases like:
-naftiko cr cap
-naftiko c cap
+Ikanos cr cap
+Ikanos c cap
 ```
 The terminal will then ask you several questions. Finally, the file will be generated in your current directory.
 ### Validate a capability configuration file
 The capabilities configuration file generated by the previous command should be valid. However, you can then complete it or even create it from scratch.\
 The validation command allows you to check your file.
 ```bash
-naftiko validate path_to_your_capability_file
+ikanos validate path_to_your_capability_file
 # You can also use aliases like:
-naftiko val path_to_your_capability_file
-naftiko v path_to_your_capability_file
+Ikanos val path_to_your_capability_file
+ikanos v path_to_your_capability_file
 ```
 By default, validation is performed on the latest schema version. If you want to test validation on a previous schema version, you can specify it as the second argument.
 ```bash
 # Validate the capability configuration file with the schema v0.5
-naftiko validate path_to_your_capability_file 0.5
+ikanos validate path_to_your_capability_file 0.5
 ```
 The result will tell you if the file is valid or if there are any errors.
 
 > **💡 Tip:** For inline validation as you type, install the free [Naftiko Extension for VS Code](https://github.com/naftiko/fleet/wiki/Naftiko-Extension-for-VS-Code). It validates both JSON Schema structure and Spectral rules directly in your editor.
 
 ### Import an OpenAPI specification
-Bootstrap a Naftiko `consumes` adapter from an existing OpenAPI 3.0 or 3.1 document:
+Bootstrap a Ikanos `consumes` adapter from an existing OpenAPI 3.0 or 3.1 document:
 ```bash
-naftiko import openapi path_to_openapi_file
+ikanos import openapi path_to_openapi_file
 # You can also use aliases like:
-naftiko im oas path_to_openapi_file
-naftiko i oas path_to_openapi_file
+Ikanos im oas path_to_openapi_file
+Ikanos i oas path_to_openapi_file
 ```
 By default, the generated capability is written to `./<namespace>-consumes.yml`. Use `-o` to choose a different output path:
 ```bash
 # Import with custom output path
-naftiko import openapi petstore.yaml -o my-petstore-capability.yaml
+ikanos import openapi petstore.yaml -o my-petstore-capability.yaml
 ```
-The importer maps OAS authentication schemes (bearer, basic, API key, digest) to Naftiko `authentication` blocks, derives a namespace from the API title, and converts operations into `consumes` resources.
+The importer maps OAS authentication schemes (bearer, basic, API key, digest) to Ikanos `authentication` blocks, derives a namespace from the API title, and converts operations into `consumes` resources.
 
 ### Export a REST adapter as an OpenAPI specification
-Generate an OpenAPI document from an existing Naftiko capability's REST adapter:
+Generate an OpenAPI document from an existing Ikanos capability's REST adapter:
 ```bash
-naftiko export openapi path_to_capability_file
+ikanos export openapi path_to_capability_file
 # You can also use aliases like:
-naftiko ex oas path_to_capability_file
-naftiko e oas path_to_capability_file
+Ikanos ex oas path_to_capability_file
+Ikanos e oas path_to_capability_file
 ```
 By default, the OpenAPI document is written to `./openapi.yaml` in OAS 3.0 format. Use `--spec-version` to produce OAS 3.1, `-o` for a custom output path, and `-f` for JSON output:
 ```bash
 # Export as OAS 3.1 YAML
-naftiko export openapi capability.yaml --spec-version 3.1
+ikanos export openapi capability.yaml --spec-version 3.1
 
 # Export as OAS 3.0 JSON
-naftiko export openapi capability.yaml -f json -o api-spec.json
+ikanos export openapi capability.yaml -f json -o api-spec.json
 ```
 If the capability has multiple REST adapters, use `--adapter` (or `-a`) to select a specific namespace:
 ```bash
 # Export only the "public-api" REST adapter
-naftiko export openapi capability.yaml -a public-api
+ikanos export openapi capability.yaml -a public-api
 ```
 When `--adapter` is omitted, the first REST adapter found is exported.
 
@@ -196,16 +196,16 @@ When `--adapter` is omitted, the first REST adapter found is exported.
 Query and update the scripting governance configuration on a running capability's Control Port:
 ```bash
 # Display current scripting config and execution stats
-naftiko scripting
+ikanos scripting
 
 # Update a scripting setting at runtime
-naftiko scripting --set timeout=60000
+ikanos scripting --set timeout=60000
 
 # Disable scripting
-naftiko scripting --set enabled=false
+ikanos scripting --set enabled=false
 
 # Restrict allowed languages
-naftiko scripting --set allowedLanguages=javascript,python
+ikanos scripting --set allowedLanguages=javascript,python
 ```
 
 > **Note:** Requires a running Control Port with `management.scripting` configured in the capability. The CLI connects to the control port address and port defined in the capability.

--- a/ikanos-docs/wiki/Releases.md
+++ b/ikanos-docs/wiki/Releases.md
@@ -1,9 +1,9 @@
 | Version & Notes | Release | EOL | Requirements | Java EOL | Maven Group ID | Maven Repo | Docker Repo | 
 | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
-| [0.4](https://github.com/naftiko/framework/releases/tag/v0.4)  | 2026-03-03  | 2026-03-17 | Java 21 LTS | Sept. 2028 | io.naftiko | GitHub Packages | GitHub Packages |
-| [0.5](https://github.com/naftiko/framework/releases/tag/v0.5) | 2026-03-17 | 2026-03-30 * | Java 21 LTS | Sept. 2028 | io.naftiko | GitHub Packages | GitHub Packages |
-| [1.0 Alpha 1](https://github.com/naftiko/framework/releases/tag/v1.0.0-alpha1) | 2026-04-02 | 2026-04-30 | Java 21 LTS | Sept. 2028 | io.naftiko | GitHub Packages | GitHub Packages |
-| [1.0 Alpha 2](https://github.com/naftiko/framework/releases/tag/v1.0.0-alpha2) | 2026-04-30 | 2026-05-22 | Java 21 LTS | Sept. 2028 | io.naftiko | Maven Central | Docker Hub |
-| 1.0 Alpha 3 * | 2026-05-22 | 2026-06-19 | Java 21 LTS | Sept. 2028 | io.naftiko | Maven Central | Docker Hub |
+| [0.4](https://github.com/naftiko/ikanos/releases/tag/v0.4)  | 2026-03-03  | 2026-03-17 | Java 21 LTS | Sept. 2028 | io.naftiko | GitHub Packages | GitHub Packages |
+| [0.5](https://github.com/naftiko/ikanos/releases/tag/v0.5) | 2026-03-17 | 2026-03-30 * | Java 21 LTS | Sept. 2028 | io.naftiko | GitHub Packages | GitHub Packages |
+| [1.0 Alpha 1](https://github.com/naftiko/ikanos/releases/tag/v1.0.0-alpha1) | 2026-04-02 | 2026-04-30 | Java 21 LTS | Sept. 2028 | io.naftiko | GitHub Packages | GitHub Packages |
+| [1.0 Alpha 2](https://github.com/naftiko/ikanos/releases/tag/v1.0.0-alpha2) | 2026-04-30 | 2026-05-22 | Java 21 LTS | Sept. 2028 | io.naftiko | Maven Central | Docker Hub |
+| 1.0 Alpha 3 * | 2026-05-22 | 2026-06-19 | Java 21 LTS | Sept. 2028 | io.ikanos | Maven Central | Docker Hub |
 
 \* Future release

--- a/ikanos-docs/wiki/Roadmap.md
+++ b/ikanos-docs/wiki/Roadmap.md
@@ -18,25 +18,25 @@
 - [ ] Deterministic orchestration
   - [ ] Add conditional steps, for-each steps, parallel-join
 - [ ] Agentic with A2A server adapter with tool discovery and execution
-  - [ ] Native integration with [Langchain4j](https://docs.langchain4j.dev/), see [issue #293](https://github.com/naftiko/framework/issues/293)
+  - [ ] Native integration with [Langchain4j](https://docs.langchain4j.dev/), see [issue #293](https://github.com/naftiko/ikanos/issues/293)
 
 ### Core developer experience
-- [ ] Run capabilities simply from Naftiko's CLI (aka Docker-less mode)
+- [ ] Run capabilities simply from Ikanos's CLI (aka Docker-less mode)
 - [ ] Use named objects for input and output parameters, like for properties, matching the JSON Structure syntax
 - [ ] Externalize individual "exposes" objects into separate files, similar to "consumes" objects
-- [ ] Expand support for "tags" and "labels" in Naftiko Spec
+- [ ] Expand support for "tags" and "labels" in Ikanos Spec
 - [ ] Allow reuse of "binds" blocks across capabilities
 - [ ] Complete test coverage and overall quality
 - [ ] Complete the Javadoc descriptions, at package level in particular
 
 ### Packaging
-- [ ] Publish Naftiko JSON Structure
-- [ ] Publish Naftiko Skill based on Naftiko CLI
-- [ ] Publish Naftiko Ruleset based on Spectral
+- [ ] Publish Ikanos JSON Structure
+- [ ] Publish Ikanos Skill based on Ikanos CLI
+- [ ] Publish Ikanos ruleset based on Spectral
 
 ## Version 1.0 - First Beta - End of June :blossom:
 
-The goal of this version is to deliver a stable MVP, including a stable Naftiko Specification.
+The goal of this version is to deliver a stable MVP, including a stable Ikanos Specification.
 
 ### Rightsize AI context
 - [ ] Enable interactive [MCP Apps](https://apps.extensions.modelcontextprotocol.io/)
@@ -46,7 +46,7 @@ The goal of this version is to deliver a stable MVP, including a stable Naftiko 
 
 ### Enable API reusability
 - [ ] Increase HTTP client resiliency (circuit breaker, rate limiter, bulkhead, cache, fallback)
-- [ ] Add client SDKs generation to Naftiko CLI for top languages (TypeScript, Python, Java, Go)
+- [ ] Add client SDKs generation to Ikanos CLI for top languages (TypeScript, Python, Java, Go)
   - [ ] Ensure it is extensible to bring your own client SDK generator (Apimatic, Fern, Stainless, Speakeasy, etc.)
 
 ### Core developer experience

--- a/ikanos-docs/wiki/Specification-‐-Rules.md
+++ b/ikanos-docs/wiki/Specification-‐-Rules.md
@@ -1,4 +1,4 @@
-# Naftiko Specification - Rules
+# Ikanos Specification - Rules
 
 Version: {{RELEASE_TAG}}
 Category: Tooling  
@@ -24,17 +24,17 @@ Last updated: {{CURRENT_DATE}}
 
 ## Overview
 
-The Naftiko rules (`naftiko-rules.yml`) is a Spectral ruleset used to lint Naftiko YAML documents.
+The Ikanos rules (`ikanos-rules.yml`) is a Spectral ruleset used to lint Ikanos YAML documents.
 
 It is intentionally **complementary** to the JSON Schema, not a duplicate of it:
 
 - JSON Schema enforces structural validity and required fields.
 - Spectral enforces cross-object consistency, style hygiene, and security hygiene.
 
-The current ruleset supports both document shapes allowed by Naftiko {{RELEASE_TAG}}:
+The current ruleset supports both document shapes allowed by Ikanos {{RELEASE_TAG}}:
 
-1. Full capability documents (`naftiko` + `capability`, optionally root `consumes`)
-2. Shared consumes documents (`naftiko` + root `consumes`, without `capability`)
+1. Full capability documents (`Ikanos` + `capability`, optionally root `consumes`)
+2. Shared consumes documents (`Ikanos` + root `consumes`, without `capability`)
 
 ---
 
@@ -42,7 +42,7 @@ The current ruleset supports both document shapes allowed by Naftiko {{RELEASE_T
 
 The ruleset follows these principles:
 
-1. Avoid duplicating schema constraints already enforced by `naftiko-schema.json`
+1. Avoid duplicating schema constraints already enforced by `ikanos-schema.json`
 2. Keep value-added lint only (consistency, discoverability, security)
 3. Support root-level `consumes` and capability-local `consumes`
 4. Keep severities pragmatic (`error` for safety/consistency breakage, `warn`/`info` for quality)
@@ -76,13 +76,13 @@ npm install -g @stoplight/spectral-cli
 Lint a file:
 
 ```bash
-npx @stoplight/spectral-cli lint my-capability.yml --ruleset src/main/resources/rules/naftiko-rules.yml
+npx @stoplight/spectral-cli lint my-capability.yml --ruleset src/main/resources/rules/ikanos-rules.yml
 ```
 
 Lint all YAML files:
 
 ```bash
-npx @stoplight/spectral-cli lint "**/*.yml" --ruleset src/main/resources/rules/naftiko-rules.yml
+npx @stoplight/spectral-cli lint "**/*.yml" --ruleset src/main/resources/rules/ikanos-rules.yml
 ```
 
 ---
@@ -103,7 +103,7 @@ npx @stoplight/spectral-cli lint "**/*.yml" --ruleset src/main/resources/rules/n
 
 These rules validate cross-object consistency and URL/path hygiene not fully covered by schema-only validation.
 
-#### `naftiko-namespaces-unique`
+#### `ikanos-namespaces-unique`
 
 - Severity: `error`
 - Scope: root `consumes`, `capability.consumes`, `capability.exposes`, root `binds`, and `capability.binds`
@@ -111,13 +111,13 @@ These rules validate cross-object consistency and URL/path hygiene not fully cov
 
 Example: using `sales` in both a consumed adapter and an exposed adapter — or in both an adapter and a bind — is invalid.
 
-#### `naftiko-consumes-baseuri-no-trailing-slash`
+#### `ikanos-consumes-baseuri-no-trailing-slash`
 
 - Severity: `warn`
 - Scope: root `consumes` and `capability.consumes`
 - Purpose: avoid `//` path joins during URI composition.
 
-#### `naftiko-consumed-resource-no-query-in-path`
+#### `ikanos-consumed-resource-no-query-in-path`
 
 - Severity: `warn`
 - Scope: root `consumes` and `capability.consumes`
@@ -125,19 +125,19 @@ Example: using `sales` in both a consumed adapter and an exposed adapter — or 
 
 Note: this check is applied to HTTP consumes entries.
 
-#### `naftiko-rest-resource-path-no-trailing-slash`
+#### `ikanos-rest-resource-path-no-trailing-slash`
 
 - Severity: `warn`
 - Scope: exposed REST resources
 - Purpose: avoid path style ambiguity and accidental double-slash URLs.
 
-#### `naftiko-rest-resource-path-no-query`
+#### `Ikanos-rest-resource-path-no-query`
 
 - Severity: `warn`
 - Scope: exposed REST resources
 - Purpose: enforce separation of path vs query parameters.
 
-#### `naftiko-address-not-example`
+#### `Ikanos-address-not-example`
 
 - Severity: `warn`
 - Scope: exposed adapter addresses
@@ -149,28 +149,28 @@ Note: this check is applied to HTTP consumes entries.
 
 These rules improve agent and human discoverability.
 
-#### `naftiko-info-tags`
+#### `Ikanos-info-tags`
 
 - Severity: `info`
 - Purpose: encourage capability categorization for discovery/filtering.
 
-#### `naftiko-consumes-description`
+#### `ikanos-consumes-description`
 
 - Severity: `warn`
 - Scope: root `consumes` and `capability.consumes`
 - Purpose: improve clarity about external dependencies.
 
-#### `naftiko-rest-resource-description`
+#### `Ikanos-rest-resource-description`
 
 - Severity: `warn`
 - Purpose: improve semantic discoverability of REST resources.
 
-#### `naftiko-rest-operation-description`
+#### `Ikanos-rest-operation-description`
 
 - Severity: `info`
 - Purpose: improve operation-level intent clarity.
 
-#### `naftiko-steps-name-pattern`
+#### `Ikanos-steps-name-pattern`
 
 - Severity: `warn`
 - Purpose: encourage stable step naming for template references.
@@ -181,19 +181,19 @@ These rules improve agent and human discoverability.
 
 These rules reduce injection risk in rendered documentation/UIs.
 
-#### `naftiko-no-script-tags-in-markdown`
+#### `ikanos-no-script-tags-in-markdown`
 
 - Severity: `error`
 - Scope: description-like text fields
 - Purpose: block `<script>` injection patterns.
 
-#### `naftiko-no-eval-in-markdown`
+#### `Ikanos-no-eval-in-markdown`
 
 - Severity: `error`
 - Scope: description-like text fields
 - Purpose: block `eval(` JavaScript injection patterns.
 
-#### `naftiko-baseuri-not-example`
+#### `ikanos-baseuri-not-example`
 
 - Severity: `warn`
 - Scope: root `consumes` and `capability.consumes`
@@ -205,13 +205,13 @@ These rules reduce injection risk in rendered documentation/UIs.
 
 These rules validate the control adapter configuration for safety and consistency.
 
-#### `naftiko-control-port-singleton-and-unique`
+#### `ikanos-control-port-singleton-and-unique`
 
 - Severity: `error`
 - Scope: `capability.exposes`
 - Purpose: at most one `type: control` adapter is allowed per capability, and its port MUST NOT collide with any business adapter port (`rest`, `mcp`, `skill`).
 
-#### `naftiko-control-address-localhost-warning`
+#### `ikanos-control-address-localhost-warning`
 
 - Severity: `warn`
 - Scope: `capability.exposes[?(@.type == 'control')].address`
@@ -223,7 +223,7 @@ These rules validate the control adapter configuration for safety and consistenc
 
 These rules validate inline script step configuration for completeness.
 
-#### `naftiko-script-defaults-required`
+#### `ikanos-script-defaults-required`
 
 - Severity: `error`
 - Scope: `capability.exposes` (cross-object: script steps + control adapter)
@@ -233,29 +233,29 @@ These rules validate inline script step configuration for completeness.
 
 ## Rule Lineage Table
 
-| Naftiko Rule | Severity | Inspired By |
+| Ikanos rule | Severity | Inspired By |
 |---|---|---|
-| `naftiko-namespaces-unique` | error | `arazzo-workflowId-unique`, `operation-operationId-unique` |
-| `naftiko-consumes-baseuri-no-trailing-slash` | warn | `oas2-host-trailing-slash`, `oas3-server-trailing-slash` |
-| `naftiko-consumed-resource-no-query-in-path` | warn | `path-not-include-query` |
-| `naftiko-rest-resource-path-no-trailing-slash` | warn | `path-keys-no-trailing-slash` |
-| `naftiko-rest-resource-path-no-query` | warn | `path-not-include-query` |
-| `naftiko-address-not-example` | warn | `oas3-server-not-example.com` |
-| `naftiko-info-tags` | info | `openapi-tags` |
-| `naftiko-consumes-description` | warn | `info-description` |
-| `naftiko-rest-resource-description` | warn | `tag-description` |
-| `naftiko-rest-operation-description` | info | `operation-description` |
-| `naftiko-steps-name-pattern` | warn | `arazzo-step-stepId` |
-| `naftiko-no-script-tags-in-markdown` | error | `no-script-tags-in-markdown`, `arazzo-no-script-tags-in-markdown` |
-| `naftiko-no-eval-in-markdown` | error | `no-eval-in-markdown` |
-| `naftiko-baseuri-not-example` | warn | `oas2-host-not-example`, `oas3-server-not-example.com` |
-| `naftiko-control-port-singleton-and-unique` | error | — (Naftiko-specific) |
-| `naftiko-control-address-localhost-warning` | warn | — (Naftiko-specific) |
-| `naftiko-script-defaults-required` | error | — (Naftiko-specific) |
+| `ikanos-namespaces-unique` | error | `arazzo-workflowId-unique`, `operation-operationId-unique` |
+| `ikanos-consumes-baseuri-no-trailing-slash` | warn | `oas2-host-trailing-slash`, `oas3-server-trailing-slash` |
+| `ikanos-consumed-resource-no-query-in-path` | warn | `path-not-include-query` |
+| `ikanos-rest-resource-path-no-trailing-slash` | warn | `path-keys-no-trailing-slash` |
+| `Ikanos-rest-resource-path-no-query` | warn | `path-not-include-query` |
+| `Ikanos-address-not-example` | warn | `oas3-server-not-example.com` |
+| `Ikanos-info-tags` | info | `openapi-tags` |
+| `ikanos-consumes-description` | warn | `info-description` |
+| `Ikanos-rest-resource-description` | warn | `tag-description` |
+| `Ikanos-rest-operation-description` | info | `operation-description` |
+| `Ikanos-steps-name-pattern` | warn | `arazzo-step-stepId` |
+| `ikanos-no-script-tags-in-markdown` | error | `no-script-tags-in-markdown`, `arazzo-no-script-tags-in-markdown` |
+| `Ikanos-no-eval-in-markdown` | error | `no-eval-in-markdown` |
+| `ikanos-baseuri-not-example` | warn | `oas2-host-not-example`, `oas3-server-not-example.com` |
+| `ikanos-control-port-singleton-and-unique` | error | — (Ikanos-specific) |
+| `ikanos-control-address-localhost-warning` | warn | — (Ikanos-specific) |
+| `ikanos-script-defaults-required` | error | — (Ikanos-specific) |
 
 ---
 
 ## Notes
 
 - This page documents the current lean ruleset and intentionally does not list schema-duplicated checks.
-- For mandatory structure/required fields, rely on `src/main/resources/schemas/naftiko-schema.json`.
+- For mandatory structure/required fields, rely on `ikanos-spec/src/main/resources/schemas/ikanos-schema.json`.

--- a/ikanos-docs/wiki/Specification-‐-Schema.md
+++ b/ikanos-docs/wiki/Specification-‐-Schema.md
@@ -1,4 +1,4 @@
-# Naftiko Specification - Schema
+# Ikanos Specification - Schema
 
 **Version:** {{RELEASE_TAG}}
 
@@ -6,9 +6,9 @@
 
 ## 1. Introduction
 
-The Naftiko Specification defines a standard, language-agnostic interface for describing modular, composable capabilities. In short, a **capability** is a functional unit that consumes external APIs (sources) and exposes adapters that allow other systems to interact with it.
+The Ikanos Specification defines a standard, language-agnostic interface for describing modular, composable capabilities. In short, a **capability** is a functional unit that consumes external APIs (sources) and exposes adapters that allow other systems to interact with it.
 
-A Naftiko capability focuses on declaring the **integration intent** — what a system needs to consume and what it exposes — rather than implementation details. This higher-level abstraction makes capabilities naturally suitable for AI-driven discovery, orchestration and integration use cases, and beyond. When properly defined, a capability can be discovered, orchestrated, validated and executed with minimal implementation logic. The specification enables description of:
+A Ikanos capability focuses on declaring the **integration intent** — what a system needs to consume and what it exposes — rather than implementation details. This higher-level abstraction makes capabilities naturally suitable for AI-driven discovery, orchestration and integration use cases, and beyond. When properly defined, a capability can be discovered, orchestrated, validated and executed with minimal implementation logic. The specification enables description of:
 
 - **Consumed sources**: External APIs or services that the capability uses
 - **Exposed adapters**: Server interfaces that the capability provides (HTTP, REST, etc.)
@@ -17,10 +17,10 @@ A Naftiko capability focuses on declaring the **integration intent** — what a 
 
 ### 1.1 Schema Access
 
-The JSON Schema for the Naftiko Specification is available in two forms:
+The JSON Schema for the Ikanos Specification is available in two forms:
 
-- **Raw file** — The schema source file is hosted on GitHub: [naftiko-schema.json](https://github.com/naftiko/framework/blob/main/src/main/resources/schemas/naftiko-schema.json)
-- **Interactive viewer** — A human-friendly viewer is available at: [Schema Viewer](https://naftiko.github.io/schema-viewer/)
+- **Raw file** — The schema source file is hosted on GitHub: [ikanos-schema.json](https://github.com/naftiko/ikanos/blob/main/ikanos-spec/src/main/resources/schemas/ikanos-schema.json)
+- **Interactive viewer** — A human-friendly viewer is available at: [Schema Viewer](https://Ikanos.github.io/schema-viewer/)
 
 ### 1.2 Core Objects
 
@@ -51,13 +51,13 @@ The JSON Schema for the Naftiko Specification is available in two forms:
 <aside>
 💡
 
-**Acknowledgments** — The Naftiko Specification is inspired by and builds upon foundational work from [OpenAPI](https://www.openapis.org/), [Arazzo](https://spec.openapis.org/arazzo/latest.html), and [OpenCollections](https://opencollections.io/). We gratefully credit these initiatives and their communities for the patterns and conventions that informed this specification.
+**Acknowledgments** — The Ikanos Specification is inspired by and builds upon foundational work from [OpenAPI](https://www.openapis.org/), [Arazzo](https://spec.openapis.org/arazzo/latest.html), and [OpenCollections](https://opencollections.io/). We gratefully credit these initiatives and their communities for the patterns and conventions that informed this specification.
 
 </aside>
 
 Three specifications that work better together.
 
-|  | **OpenAPI** | **Arazzo** | **OpenCollections** | **Naftiko** |
+|  | **OpenAPI** | **Arazzo** | **OpenCollections** | **Ikanos** |
 | --- | --- | --- | --- | --- |
 | **Focus** | Defines *what* your API is — the contract, the schema, the structure. | Defines *how* API calls are sequenced — the workflows between endpoints. | Defines *how* to use your API — the scenarios, the runnable collections. | Defines *what* a capability consumes and exposes — the integration intent. |
 | **Scope** | Single API surface | Workflows across one or more APIs | Runnable collections of API calls | Modular capability spanning multiple APIs |
@@ -65,17 +65,17 @@ Three specifications that work better together.
 | **Analogy** | The *parts list* and dimensions | The *assembly sequence* between parts | The *step-by-step assembly guide* you can run | The *product blueprint* — what goes in, what comes out |
 | **Best used when you need to…** | Define & document an API contract, generate SDKs, validate payloads | Describe multi-step API workflows with dependencies | Share runnable API examples, test workflows, onboard developers | Declare a composable capability that consumes sources and exposes unified interfaces |
 
-**OpenAPI** tells you the shape of the door. **Arazzo** describes the sequence of doors to walk through. **OpenCollections** lets you actually walk through them. **Naftiko** combines the features of those 3 specs into a single, coherent spec, reducing complexity and offering consistent tooling out of the box
+**OpenAPI** tells you the shape of the door. **Arazzo** describes the sequence of doors to walk through. **OpenCollections** lets you actually walk through them. **Ikanos** combines the features of those 3 specs into a single, coherent spec, reducing complexity and offering consistent tooling out of the box
 
 ---
 
 ## 2. Format
 
-Naftiko specifications can be represented in YAML format, complying with the provided Naftiko schema which is made available in both JSON Schema and [JSON Structure](https://json-structure.org/) formats.
+Ikanos Specifications can be represented in YAML format, complying with the provided Ikanos schema which is made available in both JSON Schema and [JSON Structure](https://json-structure.org/) formats.
 
 All field names in the specification are **case-sensitive**.
 
-Naftiko Objects expose two types of fields:
+Ikanos Objects expose two types of fields:
 
 - **Fixed fields**: which have a declared name
 - **Patterned fields**: which have a declared pattern for the field name
@@ -84,22 +84,22 @@ Naftiko Objects expose two types of fields:
 
 ## 3. Objects and Fields
 
-### 3.1 Naftiko Object
+### 3.1 Ikanos Object
 
-This is the root object of the Naftiko document.
+This is the root object of the Ikanos document.
 
 #### 3.1.1 Fixed Fields
 
 | Field Name | Type | Description |
 | --- | --- | --- |
-| **naftiko** | `string` | **REQUIRED**. Version of the Naftiko schema. MUST be `"0.5"` for this version. |
+| **Ikanos** | `string` | **REQUIRED**. Version of the Ikanos schema. MUST be `"0.5"` for this version. |
 | **info** | `Info` | *Recommended*. Metadata about the capability. |
 | **capability** | `Capability` | **REQUIRED**. Technical configuration of the capability including sources and adapters. |
 | **binds** | `Bind[]` | List of external bindings for variable injection. Each entry declares injected variables via a `keys` map. |
 
 #### 3.1.2 Rules
 
-- The `naftiko` field MUST be present and MUST have the value `"0.5"` for documents conforming to this version of the specification.
+- The `Ikanos` field MUST be present and MUST have the value `"0.5"` for documents conforming to this version of the specification.
 - The `capability` object MUST be present. The `info` object is recommended.
 - The `binds` field is OPTIONAL. When present, it MUST contain at least one entry.
 - No additional properties are allowed at the root level.
@@ -489,7 +489,7 @@ MCP Server exposition configuration. Exposes capability operations as MCP tools,
 
 **MCP Initialize Capabilities:**
 
-During the MCP `initialize` handshake, the Naftiko runtime advertises the server's supported capability groups to the connecting client. The advertised capabilities are derived directly from the MCP Expose configuration:
+During the MCP `initialize` handshake, the Ikanos runtime advertises the server's supported capability groups to the connecting client. The advertised capabilities are derived directly from the MCP Expose configuration:
 
 - **`tools`** — advertised when the `tools` array is present and contains at least one entry.
 - **`resources`** — advertised when the `resources` array is present and contains at least one entry.
@@ -706,7 +706,7 @@ resources:
     uri: docs://api/reference
     description: "API reference documentation served from local markdown files"
     mimeType: text/markdown
-    location: file:///etc/naftiko/resources/api-docs
+    location: file:///etc/Ikanos/resources/api-docs
 ```
 
 ---
@@ -1875,7 +1875,7 @@ Executes a sandboxed script file to transform, filter, or aggregate data between
 - `type`, `name`, and `file` are mandatory.
 - `language` is optional only when `management.scripting.defaultLanguage` is configured on the Control Port; otherwise it is effectively required at runtime.
 - `location` is optional only when `management.scripting.defaultLocation` is configured on the Control Port; otherwise it is effectively required at runtime.
-- The Spectral rule `naftiko-script-defaults-required` validates that omitted `language`/`location` fields have corresponding Control Port defaults.
+- The Spectral rule `ikanos-script-defaults-required` validates that omitted `language`/`location` fields have corresponding Control Port defaults.
 - Previous step results are bound as variables using the step name (camelCased).
 - The script MUST assign to the `result` variable to produce output.
 - No additional properties are allowed.
@@ -2263,7 +2263,7 @@ with:
 > **Updated**: The former `ExternalRef` discriminated union (file-resolved / runtime-resolved) has been replaced by a single **`Bind`** object. The `name` field is now `namespace`, `type` and `resolution` have been removed, and `uri` has been replaced by the optional `location` field. Variable names (keys in the `keys` map) now follow `SCREAMING_SNAKE_CASE` convention.
 > 
 
-Declares an external binding that provides variables to the capability. Bindings are declared at the root level of the Naftiko document via the `binds` array.
+Declares an external binding that provides variables to the capability. Bindings are declared at the root level of the Ikanos document via the `binds` array.
 
 #### 3.19.1 Fixed Fields
 
@@ -2425,7 +2425,7 @@ The simplest capability: forward incoming requests to a consumed API without any
 
 ```yaml
 ---
-naftiko: "0.5"
+ikanos: "0.5"
 info:
   label: "Notion Proxy"
   description: "Pass-through proxy to the Notion API for development and debugging"
@@ -2468,7 +2468,7 @@ A single exposed operation that directly calls a consumed operation, maps parame
 
 ```yaml
 ---
-naftiko: "0.5"
+ikanos: "0.5"
 binds:
   - namespace: "env"
     keys:
@@ -2547,7 +2547,7 @@ An exposed operation that chains two consumed operations using named steps and `
 
 ```yaml
 ---
-naftiko: "0.5"
+ikanos: "0.5"
 binds:
   - namespace: "env"
     keys:
@@ -2656,7 +2656,7 @@ Demonstrates a `lookup` step that cross-references the output of a previous call
 
 ```yaml
 ---
-naftiko: "0.5"
+ikanos: "0.5"
 binds:
   - namespace: "env"
     keys:
@@ -2755,7 +2755,7 @@ Combines forward proxy, simple-mode operations, orchestrated multi-step with loo
 
 ```yaml
 ---
-naftiko: "0.5"
+ikanos: "0.5"
 binds:
   - namespace: "env"
     keys:
@@ -2843,7 +2843,7 @@ capability:
                   name: "list-github-users"
                   call: "github.list-org-members"
                   with:
-                    org: "naftiko"
+                    org: "Ikanos"
                 - type: "lookup"
                   name: "match-contributors"
                   index: "list-github-users"
@@ -2960,7 +2960,7 @@ Exposes a single MCP tool over Streamable HTTP that calls a consumed operation, 
 
 ```yaml
 ---
-naftiko: "0.5"
+ikanos: "0.5"
 binds:
   - namespace: "env"
     keys:
@@ -3020,9 +3020,9 @@ capability:
 
 ## 5. Versioning
 
-The Naftiko Specification uses semantic versioning. The `naftiko` field in the Naftiko Object specifies the exact version of the specification (e.g., `"0.5"`). 
+The Ikanos Specification uses semantic versioning. The `Ikanos` field in the Ikanos Object specifies the exact version of the specification (e.g., `"0.5"`). 
 
-Tools processing Naftiko documents MUST validate this field to ensure compatibility with the specification version they support.
+Tools processing Ikanos documents MUST validate this field to ensure compatibility with the specification version they support.
 
 ---
 

--- a/ikanos-docs/wiki/Tutorial-‐-Part-1.md
+++ b/ikanos-docs/wiki/Tutorial-‐-Part-1.md
@@ -6,7 +6,7 @@ Good news: you don't have to. This tutorial opens with a **mock**. One YAML file
 
 No code. Just a spec. Contract-first.
 
-> ⚓ **Prerequisites.** A running Naftiko Engine (see the [installation instructions](https://github.com/naftiko/framework/wiki/Installation)). All capability files for this tutorial live in `src/main/resources/tutorial/`.
+> ⚓ **Prerequisites.** A running Ikanos Engine (see the [installation instructions](https://github.com/naftiko/ikanos/wiki/Installation)). All capability files for this tutorial live in `ikanos-docs/tutorial/`.
 >
 > **Editor support.** For inline validation and autocompletion while writing capability files, install the free [Naftiko Extension for VS Code](https://github.com/naftiko/fleet/wiki/Naftiko-Extension-for-VS-Code). Name your files `*.naftiko.yaml` / `*.naftiko.yml` to activate it.
 
@@ -14,14 +14,14 @@ No code. Just a spec. Contract-first.
 
 ## Step 1 — Mock First
 
-**File:** `step-1-shipyard-mock.yml` — [download](https://raw.githubusercontent.com/naftiko/framework/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/step-1-shipyard-mock.yml)
+**File:** `step-1-shipyard-mock.yml` — [download](https://raw.githubusercontent.com/Ikanos/ikanos/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/step-1-shipyard-mock.yml)
 
 You don't have a backend. You *will*, eventually — but operations hasn't finished migrating ship data, and the registry API is still in review. Meanwhile, the agent needs to demo next week.
 
 Contract-first says: define what the agent sees *first*, fill it with mock data, worry about the wire later. One expose block, one tool, no `consumes`, no `call`. Just `value`:
 
 ~~~yaml
-naftiko: "1.0.0-alpha2"
+ikanos: "1.0.0-alpha2"
 
 capability:
   exposes:
@@ -69,7 +69,7 @@ The agent works. The contract is locked. Step 2 will swap every `value` for a `m
 
 ## Step 2 — Wiring to a real API
 
-**File:** `step-2-shipyard-wiring.yml` — [download](https://raw.githubusercontent.com/naftiko/framework/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/step-2-shipyard-wiring.yml)
+**File:** `step-2-shipyard-wiring.yml` — [download](https://raw.githubusercontent.com/Ikanos/ikanos/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/step-2-shipyard-wiring.yml)
 
 The Maritime Registry is live. `GET /ships/{imo_number}` returns real data. Time to honor the contract you defined in Step 1 — same tool signature, same output shape, real data behind it.
 
@@ -155,7 +155,7 @@ The mock is gone. The contract survived.
 
 ## Step 3 — Auth & Binds — both doors
 
-**File:** `step-3-shipyard-auth.yml` — [download](https://raw.githubusercontent.com/naftiko/framework/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/step-3-shipyard-auth.yml)
+**File:** `step-3-shipyard-auth.yml` — [download](https://raw.githubusercontent.com/Ikanos/ikanos/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/step-3-shipyard-auth.yml)
 
 The registry's public tier returns 5 fields per ship. Nice for a demo, useless for operations. Specs, dimensions, certifications, crew assignments — all of that sits behind a bearer token. And while we're handling tokens, there's a second door to lock: the MCP server itself. Right now *anyone* on the network can call `get-ship`. Not acceptable.
 
@@ -212,7 +212,7 @@ mcp-server-token: "sk-mcp-YYYYYYYYYYYY"
 
 ## Step 4 — Shaping the ship card
 
-**File:** `step-4-shipyard-output-shaping.yml` — [download](https://raw.githubusercontent.com/naftiko/framework/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/step-4-shipyard-output-shaping.yml)
+**File:** `step-4-shipyard-output-shaping.yml` — [download](https://raw.githubusercontent.com/Ikanos/ikanos/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/step-4-shipyard-output-shaping.yml)
 
 Auth unlocked the firehose. 30+ fields on every `get-ship` call: year built, gross tonnage, length overall, beam, draft, classification society, certifications, crew assignments, port of registry… An agent asked *"tell me about Northern Star"* doesn't need all of that. It needs a **ship card**.
 
@@ -262,9 +262,9 @@ Four steps in. Contract-first → wire → auth → shape. A clean progression.
 
 **Files:** `step-5-shipyard-multi-source.yml`, `shared/step5-registry-consumes.yaml`, `shared/legacy-consumes.yaml`
 
-- [step-5-shipyard-multi-source.yml](https://raw.githubusercontent.com/naftiko/framework/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/step-5-shipyard-multi-source.yml)
-- [step5-registry-consumes.yaml](https://raw.githubusercontent.com/naftiko/framework/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/shared/step5-registry-consumes.yaml)
-- [legacy-consumes.yaml](https://raw.githubusercontent.com/naftiko/framework/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/shared/legacy-consumes.yaml)
+- [step-5-shipyard-multi-source.yml](https://raw.githubusercontent.com/Ikanos/ikanos/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/step-5-shipyard-multi-source.yml)
+- [step5-registry-consumes.yaml](https://raw.githubusercontent.com/Ikanos/ikanos/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/shared/step5-registry-consumes.yaml)
+- [legacy-consumes.yaml](https://raw.githubusercontent.com/Ikanos/ikanos/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/shared/legacy-consumes.yaml)
 
 Data rarely sits in one place. The modern registry is clean, but older vessels still live in the **legacy Dockyard** — a system that predates JSON, speaks **XML**, and authenticates with an API key instead of a bearer token.
 
@@ -329,9 +329,9 @@ Two tools now, one per source: `list-ships` (registry) and `list-legacy-vessels`
 
 **Files:** `step-6-shipyard-write-operations.yml`, `shared/step6-registry-consumes.yaml`, `shared/legacy-consumes.yaml`
 
-- [step-6-shipyard-write-operations.yml](https://raw.githubusercontent.com/naftiko/framework/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/step-6-shipyard-write-operations.yml)
-- [step6-registry-consumes.yaml](https://raw.githubusercontent.com/naftiko/framework/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/shared/step6-registry-consumes.yaml)
-- [legacy-consumes.yaml](https://raw.githubusercontent.com/naftiko/framework/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/shared/legacy-consumes.yaml)
+- [step-6-shipyard-write-operations.yml](https://raw.githubusercontent.com/Ikanos/ikanos/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/step-6-shipyard-write-operations.yml)
+- [step6-registry-consumes.yaml](https://raw.githubusercontent.com/Ikanos/ikanos/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/shared/step6-registry-consumes.yaml)
+- [legacy-consumes.yaml](https://raw.githubusercontent.com/Ikanos/ikanos/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/shared/legacy-consumes.yaml)
 
 Captain Erik Lindström walks into the office. He wants to take the *Northern Star* from Oslo to Singapore. He's got his crew lined up, his cargo booked, the dates locked. Can the agent plan the voyage? Right now: no. Every tool so far is read-only — the agent can *observe* the shipyard, never *act* on it.
 
@@ -384,9 +384,9 @@ Captain Erik has his voyage. The agent went from observer to operator.
 
 **Files:** `step-7-shipyard-orchestrated-lookup.yml`, `shared/step7-registry-consumes.yaml`, `shared/legacy-consumes.yaml`
 
-- [step-7-shipyard-orchestrated-lookup.yml](https://raw.githubusercontent.com/naftiko/framework/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/step-7-shipyard-orchestrated-lookup.yml)
-- [step7-registry-consumes.yaml](https://raw.githubusercontent.com/naftiko/framework/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/shared/step7-registry-consumes.yaml)
-- [legacy-consumes.yaml](https://raw.githubusercontent.com/naftiko/framework/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/shared/legacy-consumes.yaml)
+- [step-7-shipyard-orchestrated-lookup.yml](https://raw.githubusercontent.com/Ikanos/ikanos/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/step-7-shipyard-orchestrated-lookup.yml)
+- [step7-registry-consumes.yaml](https://raw.githubusercontent.com/Ikanos/ikanos/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/shared/step7-registry-consumes.yaml)
+- [legacy-consumes.yaml](https://raw.githubusercontent.com/Ikanos/ikanos/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/shared/legacy-consumes.yaml)
 
 Back to the captain. He insists on his cook: *"No Aiko, no departure."* The agent calls `get-ship` for the Northern Star and gets back `assignedCrew: ["CREW-001", "CREW-003"]`. Raw IDs. Useless. Who is CREW-003? Is that Aiko?
 
@@ -466,4 +466,4 @@ No code. Welcome to Spec-Driven Integration.
 
 Ready to expose your tools as **Agent Skills**, factor logic into reusable **aggregates**, add a **REST front door**, and assemble a full **Fleet Manifest** capstone?
 
-Continue with [Tutorial — Part 2](https://github.com/naftiko/framework/wiki/Tutorial-%E2%80%90-Part-2).
+Continue with [Tutorial — Part 2](https://github.com/naftiko/ikanos/wiki/Tutorial-%E2%80%90-Part-2).

--- a/ikanos-docs/wiki/Tutorial-‐-Part-2.md
+++ b/ikanos-docs/wiki/Tutorial-‐-Part-2.md
@@ -6,17 +6,17 @@ Part 2 adds four layers on top of Part 1's foundation without touching the core 
 
 Same YAML. Still no code.
 
-> ⚓ **Before you start.** You should have completed [Part 1](https://github.com/naftiko/framework/wiki/Tutorial-%E2%80%90-Part-1) (Steps 1–7). All files for this part live alongside the earlier ones in `src/main/resources/tutorial/`.
+> ⚓ **Before you start.** You should have completed [Part 1](https://github.com/naftiko/ikanos/wiki/Tutorial-%E2%80%90-Part-1) (Steps 1–7). All files for this part live alongside the earlier ones in `ikanos-docs/tutorial/`.
 
 ---
 
 ## Step 8 — Skill Groups
 
-**File:** `step-8-shipyard-skill-groups.yml` — [download](https://raw.githubusercontent.com/naftiko/framework/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/step-8-shipyard-skill-groups.yml)
+**File:** `step-8-shipyard-skill-groups.yml` — [download](https://raw.githubusercontent.com/Ikanos/ikanos/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/step-8-shipyard-skill-groups.yml)
 
 Five tools today. Twenty tomorrow. Fifty next quarter. An agent landing on your MCP endpoint sees a flat list and has to figure out on its own which tools matter for *planning a voyage* versus *auditing the fleet*. That's noise, and noise burns context.
 
-**Agent Skills** are the table of contents for your toolbox. They group related tools under a business-facing label (`fleet-ops`, `voyage-ops`) with a description the agent reads *before* deciding what to do. The [Agent Skills website](https://agentskills.io/) documents the broader model; Naftiko exposes it as a third expose type alongside MCP and REST.
+**Agent Skills** are the table of contents for your toolbox. They group related tools under a business-facing label (`fleet-ops`, `voyage-ops`) with a description the agent reads *before* deciding what to do. The [Agent Skills website](https://agentskills.io/) documents the broader model; Ikanos exposes it as a third expose type alongside MCP and REST.
 
 ~~~yaml
 - type: skill
@@ -64,7 +64,7 @@ Typical workflow: **discover** with `GET /skills`, **inspect** with `GET /skills
 
 ## Step 9 — Aggregates & Ref
 
-**File:** `step-9-shipyard-aggregates.yml` — [download](https://raw.githubusercontent.com/naftiko/framework/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/step-9-shipyard-aggregates.yml)
+**File:** `step-9-shipyard-aggregates.yml` — [download](https://raw.githubusercontent.com/Ikanos/ikanos/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/step-9-shipyard-aggregates.yml)
 
 Something's starting to smell. Step 7 defined a three-step chain inside `get-ship-with-crew` — fetch ship, fetch crew, lookup. Step 11 will chain seven steps for the Fleet Manifest. And the REST adapter in Step 10 wants to expose `get-ship-with-crew` too. That's the *same* logic needed in three places. Copy-paste is where capabilities go to die.
 
@@ -129,7 +129,7 @@ The tool output is byte-for-byte identical to Step 7. The *spec* got dramaticall
 
 ## Step 10 — REST adapter
 
-**File:** `step-10-shipyard-rest-adapter.yml` — [download](https://raw.githubusercontent.com/naftiko/framework/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/step-10-shipyard-rest-adapter.yml)
+**File:** `step-10-shipyard-rest-adapter.yml` — [download](https://raw.githubusercontent.com/Ikanos/ikanos/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/step-10-shipyard-rest-adapter.yml)
 
 Not every consumer is an AI agent. The operations dashboard is a plain React app. The partner logistics company speaks OpenAPI. The mobile team doesn't care what MCP is — they want `GET /ships/{imo}` and they want it *now*.
 
@@ -186,9 +186,9 @@ Two things to notice. First, REST operations declare HTTP-level parameter placem
 
 **Files:** `step-11-shipyard-fleet-manifest.yml`, `shared/step11-registry-consumes.yml`, `shared/legacy-consumes.yaml`
 
-- [step-11-shipyard-fleet-manifest.yml](https://raw.githubusercontent.com/naftiko/framework/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/step-11-shipyard-fleet-manifest.yml)
-- [step11-registry-consumes.yml](https://raw.githubusercontent.com/naftiko/framework/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/shared/step11-registry-consumes.yml)
-- [legacy-consumes.yaml](https://raw.githubusercontent.com/naftiko/framework/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/shared/legacy-consumes.yaml)
+- [step-11-shipyard-fleet-manifest.yml](https://raw.githubusercontent.com/Ikanos/ikanos/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/step-11-shipyard-fleet-manifest.yml)
+- [step11-registry-consumes.yml](https://raw.githubusercontent.com/Ikanos/ikanos/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/shared/step11-registry-consumes.yml)
+- [legacy-consumes.yaml](https://raw.githubusercontent.com/Ikanos/ikanos/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/shared/legacy-consumes.yaml)
 
 The voyage is planned. The crew is confirmed. Oslo to Singapore, Northern Star, Captain Erik, Aiko in the galley. And now operations walks in with the final ask: *"I need one document. Voyage, ship, crew, cargo — all of it, resolved, in one payload. Before the ship leaves."*
 
@@ -294,7 +294,7 @@ Three front doors (MCP, Skills, REST) share one engine, one set of consumes, one
 
 That's the Shipyard.
 
-**File:** `step-9-shipyard-rest-adapter.yml` — [download](https://raw.githubusercontent.com/naftiko/framework/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/step-9-shipyard-rest-adapter.yml)
+**File:** `step-9-shipyard-rest-adapter.yml` — [download](https://raw.githubusercontent.com/Ikanos/ikanos/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/step-9-shipyard-rest-adapter.yml)
 
 Not every consumer is an AI agent. The operations dashboard is a plain React app. The partner logistics company speaks OpenAPI. The mobile app team doesn't even know what MCP is — they want `GET /ships/{imo}` and they want it *now*.
 
@@ -341,7 +341,7 @@ Exactly the same `call` + `with` wiring you learned in Part 1 — just a differe
 
 **Files:** `step-10-shipyard-fleet-manifest.yml`, `shared/step10-registry-consumes.yml`, `shared/legacy-consumes.yaml`
 
-- [step-10-shipyard-fleet-manifest.yml](https://raw.githubusercontent.com/naftiko/framework/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/step-10-shipyard-fleet-manifest.yml)
+- [step-10-shipyard-fleet-manifest.yml](https://raw.githubusercontent.com/Ikanos/ikanos/refs/tags/v1.0.0-alpha2/src/main/resources/tutorial/step-10-shipyard-fleet-manifest.yml)
 
 The voyage is planned. The crew is confirmed. Oslo to Singapore, Northern Star, Captain Erik, Aiko in the galley. Now operations walks in and says: *"I need one document. Ship, crew, cargo — all of it, resolved, in one payload. Before the ship leaves."*
 

--- a/scripts/builder.sh
+++ b/scripts/builder.sh
@@ -1,5 +1,5 @@
 #!/bin/sh 
-cd "$(dirname "$0")/../../../.." || exit 1
+cd "$(dirname "$0")/.." || exit 1
 
 # FUNCTIONS
 print(){ printf "%s" "$*"; }

--- a/scripts/ikanos_version.py
+++ b/scripts/ikanos_version.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Shared utilities for Naftiko version synchronization.
+Shared utilities for Ikanos version synchronization.
 """
 
 import re
@@ -42,7 +42,7 @@ def update_yaml_version(file_path, new_version):
         with open(file_path, 'r', encoding='utf-8') as f:
             content = f.read()
 
-        pattern = r'(naftiko:\s*")[^"]*(")'
+        pattern = r'(ikanos:\s*")[^"]*(")'
         replacement = rf'\g<1>{new_version}\g<2>'
 
         updated_content = re.sub(pattern, replacement, content)

--- a/scripts/pr-check-mac-linux.sh
+++ b/scripts/pr-check-mac-linux.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # ============================================================
 # pr-check.sh — Run all checks before opening a PR
-# usage : from root run 'bash ./src/main/resources/scripts/pr-check-mac-linux.sh'
+# usage : from root run 'bash ./scripts/pr-check-mac-linux.sh'
 # Compatible: Mac, Linux (apt/yum/dnf/brew)
 # ============================================================
 

--- a/scripts/pr-check-wind.ps1
+++ b/scripts/pr-check-wind.ps1
@@ -1,6 +1,6 @@
 # ============================================================
 # pr-check.ps1 — Run all checks before opening a PR (Windows)
-# Usage: from root run: '.\src\main\resources\scripts\pr-check-wind.ps1'
+# Usage: from root run: '.\scripts\pr-check-wind.ps1'
 # Requirements: maven, trivy, gitleaks (winget or choco)
 # ============================================================
 

--- a/scripts/sync-ikanos-version-to-backstage.py
+++ b/scripts/sync-ikanos-version-to-backstage.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Script to synchronize the Naftiko version from pom.xml into Backstage skeleton templates.
+Script to synchronize the Ikanos version from pom.xml into Backstage skeleton templates.
 """
 
 import argparse
@@ -8,12 +8,12 @@ from pathlib import Path
 import sys
 
 sys.path.insert(0, str(Path(__file__).parent))
-from naftiko_version import extract_version_from_pom, update_yaml_version
+from ikanos_version import extract_version_from_pom, update_yaml_version
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Sync Naftiko version to Backstage skeletons")
-    parser.add_argument("--pom", required=True, help="Path to framework pom.xml")
+    parser = argparse.ArgumentParser(description="Sync Ikanos version to Backstage skeletons")
+    parser.add_argument("--pom", required=True, help="Path to ikanos pom.xml")
     parser.add_argument("--target", required=True, help="Path to skeleton capabilities directory")
     args = parser.parse_args()
 

--- a/scripts/sync-ikanos-version-to-vscode.py
+++ b/scripts/sync-ikanos-version-to-vscode.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Script to synchronize the Naftiko version from pom.xml into the VS Code extension package.json.
+Script to synchronize the Ikanos version from pom.xml into the VS Code extension package.json.
 """
 
 import argparse
@@ -9,7 +9,7 @@ from pathlib import Path
 import sys
 
 sys.path.insert(0, str(Path(__file__).parent))
-from naftiko_version import extract_version_from_pom
+from ikanos_version import extract_version_from_pom
 
 
 def update_package_json_version(file_path, new_version):
@@ -35,8 +35,8 @@ def update_package_json_version(file_path, new_version):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Sync Naftiko version to VS Code extension package.json")
-    parser.add_argument("--pom", required=True, help="Path to framework pom.xml")
+    parser = argparse.ArgumentParser(description="Sync Ikanos version to VS Code extension package.json")
+    parser.add_argument("--pom", required=True, help="Path to ikanos pom.xml")
     parser.add_argument("--target", required=True, help="Path to extensions/naftiko-vscode/package.json")
     args = parser.parse_args()
 

--- a/scripts/sync-ikanos-version.py
+++ b/scripts/sync-ikanos-version.py
@@ -9,11 +9,11 @@ from pathlib import Path
 import sys
 
 sys.path.insert(0, str(Path(__file__).parent))
-from naftiko_version import extract_version_from_pom, update_yaml_version
+from ikanos_version import extract_version_from_pom, update_yaml_version
 
 
 def update_json_version(file_path, new_version):
-    """Updates version in JSON (naftiko.const + $id URL)."""
+    """Updates version in JSON (ikanos.const + $id URL)."""
     try:
         with open(file_path, 'r', encoding='utf-8') as f:
             data = json.load(f)
@@ -22,11 +22,11 @@ def update_json_version(file_path, new_version):
 
         if (
             "properties" in data and
-            "naftiko" in data["properties"] and
-            "const" in data["properties"]["naftiko"]
+            "ikanos" in data["properties"] and
+            "const" in data["properties"]["ikanos"]
         ):
-            if data["properties"]["naftiko"]["const"] != new_version:
-                data["properties"]["naftiko"]["const"] = new_version
+            if data["properties"]["ikanos"]["const"] != new_version:
+                data["properties"]["ikanos"]["const"] = new_version
                 updated = True
 
         if "$id" in data and isinstance(data["$id"], str):
@@ -77,15 +77,16 @@ def find_files(base_paths):
 def main():
     """Main function."""
     print("=" * 60)
-    print("Naftiko version synchronization")
+    print("Ikanos version synchronization")
     print("=" * 60)
 
     version = extract_version_from_pom()
 
     search_paths = [
-        "src/main/resources/schemas/naftiko-schema.json",
-        "src/main/resources/tutorial",
-        "src/test/resources",
+        "ikanos-spec/src/main/resources/schemas/ikanos-schema.json",
+        "ikanos-docs/tutorial",
+        "ikanos-engine/src/test/resources",
+        "ikanos-cli/src/test/resources",
     ]
 
     print(" Searching for YAML/JSON files in:")


### PR DESCRIPTION
## Related Issue

Closes #443
Refs #408 (umbrella initiative)

> ⚠️ **Stacked PR.** Base branch is `feat/ikanos-modularize` (Phase 3, #442), which is itself stacked on `feat/ikanos-rename` (Phase 2, #440). I will retarget this PR to `main` once Phases 2 and 3 merge.

---

## What does this PR do?

Phase 4 of the [Ikanos Rename & Modularization](https://github.com/naftiko/blueprints/blob/main/ikanos-rename-modularization.md) initiative — **Documentation & Agent Instructions**. Documentation-only changes, no production code touched.

### Top-level docs

- `AGENTS.md`, `CONTRIBUTING.md`, `README.md` rewritten to reflect the Ikanos identity and the modular Maven layout (`ikanos-spec`, `ikanos-engine`, `ikanos-cli`, `ikanos-docs`, repo-root `scripts/` and `deployment/`).
- All `github.com/naftiko/framework` URLs → `github.com/naftiko/ikanos`.
- All schema/rules paths now point at the modular locations (`ikanos-spec/src/main/resources/schemas/ikanos-schema.json`, `ikanos-spec/src/main/resources/rules/ikanos-rules.yml`).

### Agent skills

- Renamed `.agents/skills/naftiko-capability/` → `.agents/skills/ikanos-capability/` (`git mv` + content updates).
- Updated `SKILL.md` frontmatter (`name: ikanos-capability`), all references, lint script, and example asset.
- Replaced `naftiko-*` rule names → `ikanos-*` and `naftiko.*` OTel metric names → `ikanos.*` (matches `EngineMetrics.java`).
- Updated `.agents/skills/pr-review/` example paths to the new module layout.

### CI / repo metadata

- Issue templates (`bug_report.yml`, `feature_request.yml`, `config.yml`) updated with Ikanos identity and `ikanos --version` placeholder.
- `mega-linter-validate.yml` workflow display name → "Lint Ikanos Capabilities".
- Renamed and updated the version-sync workflows: `synchronize-naftiko-version-in-{framework,other-repos}.yml` → `synchronize-ikanos-version-in-*.yml`. Updated PR titles, branch names, commit messages, and prose. Sister-repo paths (`naftiko/backstage`, `naftiko/vscode`, `naftiko-vscode/package.json`, `*.naftiko.yml`) preserved — those are external contracts.

### Scripts

- `naftiko_version.py` → `ikanos_version.py` (docstring + YAML regex `naftiko:` → `ikanos:`).
- `sync-naftiko-version*.py` → `sync-ikanos-version*.py` (imports, JSON property, search paths).
- `pr-check-{wind.ps1,mac-linux.sh}` and `builder.sh` updated to use `scripts/` at repo root (was `src/main/resources/scripts/`).

### Wiki

- 12 pages under `ikanos-docs/wiki/` bulk-updated:
  - `naftiko-cli-<os>` binary names → `ikanos-cli-<os>`.
  - Top-level YAML key `naftiko:` → `ikanos:`.
  - CLI commands `naftiko <verb>` → `ikanos <verb>`.
  - Polychro rule names `naftiko-*` → `ikanos-*`.
  - `IKANOS_SCRIPTING` env var, `ikanos-schema.json`, `ikanos-rules.yml`.
- **Preserved (external sister projects, file extensions, mock identifiers):** `Naftiko Fleet`, `Naftiko Extension for VS Code`, `Naftiko Templates for Backstage`, `Naftiko Operator for Kubernetes`, `.naftiko.yaml`, `mocks.naftiko.net`, `naftiko-shipyard-*` mock service names. Verified mock names match engine fixtures.

### Out of scope (Phase 5)

- Workflows that publish artifacts (`publish-cli-bin.yml`, `publish-engine-image.yml`, `quality-gate.yml`) and the `mega-linter-validate.yml` path triggers.
- The blueprints repo cross-repo update will follow as a separate PR in `naftiko/blueprints`.

---

## Tests

`mvn test` from repo root: **683 tests, 0 failures, 37 errors** — exactly the same 37 pre-existing baseline errors documented in Phase 3 (missing `shared/step*.yaml` import fixtures for Step 5–8 Shipyard MCP tests). No regressions from Phase 4. Phase 4 only touches `*.md`, `*.yml` workflows, agent skills, scripts, and templates — no Java code.

---

## Checklist

- [x] CI is green (will be confirmed once GitHub Actions run on this PR)
- [x] Rebased on latest `feat/ikanos-modularize` (the stacked base)
- [x] Small and focused — one concern per PR (docs + agent + scripts + workflow renames)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context

```yaml
agent_name: GitHub Copilot Chat
llm: Claude Opus 4.7
tool: VS Code Copilot Chat
confidence: high
source_event: user request — "Start phase 4, basing the work on the phase 3 Git branch"
discovery_method: planned_work
review_focus: |
  - AGENTS.md, CONTRIBUTING.md, README.md (full re-read recommended)
  - .agents/skills/ikanos-capability/SKILL.md
  - scripts/sync-ikanos-version*.py (imports + search paths)
  - .github/workflows/synchronize-ikanos-version-in-*.yml
  - ikanos-docs/wiki/*.md — verify preserve-list (Naftiko Fleet/Extension/Templates/Operator, .naftiko.yaml, naftiko-shipyard-*)
```
