### PR TITLE
feat: enforce JaCoCo coverage gate at current baseline

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -105,7 +105,7 @@ jobs:
         run: ln -s ikanos-engine/src/test/resources/tutorial/shared shared
 
       - name: Run tests + JaCoCo coverage
-        run: mvn clean test --no-transfer-progress
+        run: mvn clean verify --no-transfer-progress
 
       - name: Publish test failures summary
         if: always()

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
           in Phase C. Do not lower these values.
 
           Current per-module baseline (mvn verify, tutorial integration tests
-          excluded — they require Microcks):
+          excluded - they require Microcks):
             ikanos-spec    line 0.68  branch 0.62
             ikanos-engine  line 0.77  branch 0.67
             ikanos-cli     line 0.76  branch 0.66

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,24 @@
         <opentelemetry.version>1.48.0</opentelemetry.version>
         <graalvm.polyglot.version>24.1.1</graalvm.polyglot.version>
         <groovy.version>4.0.24</groovy.version>
+
+        <!--
+          JaCoCo coverage gate (Phase A of the 100 % coverage plan, epic #445).
+          Each module's BUNDLE LINE / BRANCH coverage must stay >= these floors.
+          Floors are set to the lowest current per-module coverage so the gate
+          is enforceable but non-blocking on day one. Ratchet upward as test
+          coverage is added cluster by cluster (B1..B4), ending at 1.00 / 1.00
+          in Phase C. Do not lower these values.
+
+          Current per-module baseline (mvn verify, tutorial integration tests
+          excluded — they require Microcks):
+            ikanos-spec    line 0.68  branch 0.62
+            ikanos-engine  line 0.77  branch 0.67
+            ikanos-cli     line 0.76  branch 0.66
+        -->
+        <jacoco.halt>true</jacoco.halt>
+        <jacoco.line.min>0.68</jacoco.line.min>
+        <jacoco.branch.min>0.62</jacoco.branch.min>
     </properties>
 
     <distributionManagement>
@@ -357,6 +375,40 @@
                             <goals>
                                 <goal>report</goal>
                             </goals>
+                        </execution>
+                        <execution>
+                            <!--
+                                Coverage gate (Phase A of epic #445). Fails the
+                                build when a module's BUNDLE line or branch
+                                coverage drops below the floors defined by
+                                jacoco.line.min / jacoco.branch.min in the root
+                                pom. Ratchet those properties upward only.
+                            -->
+                            <id>check</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                            <configuration>
+                                <haltOnFailure>${jacoco.halt}</haltOnFailure>
+                                <rules>
+                                    <rule>
+                                        <element>BUNDLE</element>
+                                        <limits>
+                                            <limit>
+                                                <counter>LINE</counter>
+                                                <value>COVEREDRATIO</value>
+                                                <minimum>${jacoco.line.min}</minimum>
+                                            </limit>
+                                            <limit>
+                                                <counter>BRANCH</counter>
+                                                <value>COVEREDRATIO</value>
+                                                <minimum>${jacoco.branch.min}</minimum>
+                                            </limit>
+                                        </limits>
+                                    </rule>
+                                </rules>
+                            </configuration>
                         </execution>
                     </executions>
                 </plugin>


### PR DESCRIPTION
## Related Issue

Closes #446

Part of epic #445 — Reach 100 % JaCoCo coverage on the QA gate.

---

## What does this PR do?

Wires an enforceable JaCoCo coverage gate so the QA workflow fails any build that drops a module's BUNDLE line or branch coverage below the configured floor. Today the workflow only **observes** coverage in the GitHub step summary; nothing prevents a regression.

This is **Phase A** of the plan in `blueprints/ikanos-100-percent-coverage.md`: tiny, mechanical, no test changes, no production code changes.

### Changes

- **Root `pom.xml`** — three new properties drive the gate so thresholds can be ratcheted upward without touching any module pom:

  | Property            | Initial value | Source                   |
  |---------------------|---------------|--------------------------|
  | `jacoco.halt`       | `true`        | hard gate from day one   |
  | `jacoco.line.min`   | `0.68`        | floor: `ikanos-spec`     |
  | `jacoco.branch.min` | `0.62`        | floor: `ikanos-spec`     |

  The starting floors are the **lowest current per-module coverage** measured by a fresh `mvn verify` (tutorial integration tests excluded — they require Microcks). This makes the gate enforceable on day one without blocking the existing baseline.

- **Root `pom.xml`** — adds a `check` execution to the existing `jacoco-maven-plugin` block in `<pluginManagement>`. BUNDLE-level rule on `LINE` + `BRANCH` `COVEREDRATIO`, `haltOnFailure=${jacoco.halt}`. All three Java modules (`ikanos-spec`, `ikanos-engine`, `ikanos-cli`) inherit it; `ikanos-docs` is `<packaging>pom</packaging>` and is not affected.

- **`.github/workflows/quality-gate.yml`** — switches `mvn clean test` to `mvn clean verify` so the `check` goal runs.

### Per-module baseline (unchanged by this PR)

| Module          | Line cov | Branch cov |
|-----------------|----------|------------|
| `ikanos-spec`   | 0.68     | 0.62       |
| `ikanos-engine` | 0.77     | 0.67       |
| `ikanos-cli`    | 0.76     | 0.66       |

From this point, every test PR (clusters B1..B4) ratchets the floors upward, ending at `1.00` / `1.00` in Phase C.

---

## Tests

No test code is added or modified.

Local validation:

- ✅ `mvn -pl ikanos-spec clean verify` → **BUILD SUCCESS** at the configured thresholds.
- ✅ `mvn -pl ikanos-spec '-Djacoco.line.min=0.99' clean verify` → **BUILD FAILURE** with `Rule violated for bundle ikanos-spec: lines covered ratio is 0.68, but expected minimum is 0.99` — confirms the gate enforces the threshold.

Full `mvn clean verify` was run; tutorial integration tests fail locally because Microcks is not running, which is the existing behavior and is unaffected by this PR (CI runs Microcks).

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main` <!-- branched from feat/ikanos-docs-update (PR #444); will rebase on main after #444 merges -->
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

> **Note on base branch:** This PR is branched off `feat/ikanos-docs-update` (PR #444) per the user's request to use the #444 branch as baseline. It will be rebased onto `main` once #444 merges.

---

## Agent Context (optional)

```yaml
agent_name: github-copilot
llm: claude-opus-4.7 (Naftiko)
tool: vscode
confidence: high
source_event: user_request
discovery_method: code_review
review_focus: pom.xml:84-86, pom.xml:367-403, .github/workflows/quality-gate.yml:108
```
