### PR TITLE
chore: add pre-submission guard to pr-review skill (v1.3.1)

### DIFF
--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-review
-version: "1.3.0"
+version: "1.3.1"
 description: >
   On-demand skill for reviewing GitHub Pull Requests and posting inline
   comments via the GitHub API. Activate when the user asks to: review a PR,
@@ -146,6 +146,16 @@ Answer questions and refine findings. Do **not** post anything yet.
 Return to this step when the user is ready.
 
 ### Branch B — User confirms: post the review
+
+> **Pre-submission guard — always run this first, even on a retry**
+> Before writing or posting any payload, check whether a review from you already exists:
+> ```powershell
+> gh api repos/{owner}/{repo}/pulls/<number>/reviews --jq '[.[] | {id, state, submitted_at, body: .body[:80]}]'
+> ```
+> - If a review with `state = CHANGES_REQUESTED` or `COMMENT` from `eskenazit` already exists → **do not post a new review**. Instead, inspect its inline comments with `gh api repos/{owner}/{repo}/pulls/<number>/comments` and report the current state to the user. Any missing inline comment can only be added as a follow-up `COMMENT`-event review, not as a duplicate `REQUEST_CHANGES`.
+> - If no review exists (empty array or only PENDING) → proceed with submission below.
+>
+> This guard prevents irrecoverable duplicates when a previous submission appeared to fail (silent exit, timeout, ^C) but actually succeeded.
 
 Submit all inline comments in a **single** API call. Do not post without explicit
 user confirmation — this is an irreversible action on a shared system.


### PR DESCRIPTION
## Related Issue

No related issue

---

## What does this PR do?

Adds a **pre-submission guard** to the `pr-review` skill (Branch B) to prevent duplicate reviews when a previous submission appeared to fail (silent exit, timeout, `^C`) but had actually succeeded.

Before writing or posting any payload, the agent must now check whether a review already exists on the PR:
- If a `CHANGES_REQUESTED` or `COMMENT` review already exists → **do not post a new review**, report the current state to the user instead
- If no review exists → proceed with submission normally

Identified during the #440–#444 review cycle: a `^C`-interrupted `gh api` call had silently succeeded, causing a duplicate `CHANGES_REQUESTED` review on PR #442.

---

## Tests

No additional tests required. Skill-only change (no Java code modified).

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Claude Sonnet 4.6
tool: VS Code Copilot Chat
confidence: high
source_event: duplicate review posted on PR #442
discovery_method: runtime_observation
review_focus: .agents/skills/pr-review/SKILL.md Branch B section
```
