### PR TITLE
feat: require issue proposal before agent work; fix pr-review skill finding numbering

### DIFF
--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-review
-version: "1.3.0"
+version: "1.3.1"
 description: >
   On-demand skill for reviewing GitHub Pull Requests and posting inline
   comments via the GitHub API. Activate when the user asks to: review a PR,
@@ -128,13 +128,20 @@ reject the comment silently.
 
 ## Step 5 — Present findings, then branch on user response
 
-Present all findings to the user in a table:
+Present all findings to the user in a **working table** (conversation only — do not paste this table into GitHub):
 
-| # | File | Line | Severity | Comment (raw) |
+| N | File | Line | Severity | Comment (raw) |
 |---|------|------|----------|---------------|
 | 1 | `path/to/File.java` | L42 | 🔴 HIGH | Comment text ready to paste |
 
 Severity scale: 🔴 HIGH (blocking) · 🟡 MEDIUM · 🔵 LOW (nit).
+
+> **Numbering rules for GitHub-bound text**
+> - When the user selects a subset of findings to post, **renumber them sequentially
+>   from 1** in the review `body` and inline comments — never carry over the
+>   working-list numbers, which would create confusing gaps (e.g. "findings 2 and 5").
+> - Plain integers (1, 2, 3 …) are fine in GitHub text to cross-reference findings.
+> - **Never use `#N`** — GitHub renders `#N` as a hyperlink to issue or PR number N.
 
 **All comments must be written in English**, regardless of the language used in the conversation with the user — see AGENTS.md.
 
@@ -156,7 +163,7 @@ user confirmation — this is an irreversible action on a shared system.
 # 1. Write the review payload to a temp file (edit paths, lines, and bodies as needed)
 $review = @{
     event    = "REQUEST_CHANGES"   # or COMMENT, APPROVE
-    body     = "Overall summary — see inline comments."
+    body     = "Overall summary — see inline comments. (1) blocking issue must be fixed before merge."
     comments = @(
         @{ path = "ikanos-engine/src/main/java/io/ikanos/Foo.java"; line = 42;   body = "Comment text." }
         @{ path = "src/.../Bar.java";                  line = 17;   body = "Another comment." }
@@ -175,7 +182,7 @@ Set-Content -Path "$env:TEMP\review-<number>.json" -Encoding utf8 -Value $review
 cat > /tmp/review-<number>.json <<'EOF'
 {
   "event": "REQUEST_CHANGES",
-  "body": "Overall summary — see inline comments.",
+  "body": "Overall summary — see inline comments. (1) blocking issue must be fixed before merge.",
   "comments": [
     { "path": "ikanos-engine/src/main/java/io/ikanos/Foo.java", "line": 42, "body": "Comment text." },
     { "path": "src/.../Bar.java", "line": 17, "body": "Another comment." }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,7 @@ When designing or modifying a Capability:
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow. Key rules:
 
-- Open an Issue before starting work
+- **Open an Issue before starting work** — this applies to every change (feat, fix, chore, skill update, doc edit). Before writing any code or modifying any file, propose opening a GitHub issue and wait for the user's confirmation. The user may explicitly waive the issue step; only then proceed without one.
 - **All GitHub interactions must be in English** — issues, PR titles/bodies, inline review comments, and commit messages. The codebase and its community are English-first.
 - Branch from `main`: `feat/`, `fix/`, or `chore/` prefix
 - Use [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `chore:` — no scopes for now


### PR DESCRIPTION
## Related Issue

None — improvement identified during a live review session (waived by user).

---

## What does this PR do?

Two related improvements to the agent workflow:

**1. `pr-review` skill v1.3.0 → v1.3.1** (`.agents/skills/pr-review/SKILL.md`)

- The working findings table is now explicitly scoped to the conversation with the user ("conversation only — do not paste this table into GitHub").
- Added numbering rules for GitHub-bound text: when posting a subset of findings, renumber them sequentially from 1; never carry over working-list numbers (which would create confusing gaps); never use `#N` notation (GitHub renders it as a hyperlink to issue/PR N).
- Updated the review body examples in both PowerShell and bash snippets to use `(1)` instead of `#1`.

**2. `AGENTS.md` — Contribution Workflow**

- Expanded the "Open an Issue before starting work" bullet to require the agent to **propose** opening an issue and **wait for user confirmation** before writing any code or modifying any file. The user may explicitly waive the issue step. This closes the gap where the agent would start work (branch, edits, commit) before the issue step, as observed during this session.

---

## Tests

No code change — documentation and agent instructions only.

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Naftiko - Claude Sonnet 4.6
tool: VS Code
confidence: high
source_event: runtime_observation
discovery_method: runtime_observation
review_focus: .agents/skills/pr-review/SKILL.md, AGENTS.md
```
