### PR TITLE
chore: sync Ikanos version

### DIFF
--- a/ikanos-docs/tutorial/shared/legacy-consumes.yaml
+++ b/ikanos-docs/tutorial/shared/legacy-consumes.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 consumes:
   - namespace: legacy
     type: http

--- a/ikanos-docs/tutorial/shared/registry-consumes.yaml
+++ b/ikanos-docs/tutorial/shared/registry-consumes.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 consumes:
   - namespace: registry
     type: http

--- a/ikanos-docs/tutorial/shared/step11-registry-consumes.yml
+++ b/ikanos-docs/tutorial/shared/step11-registry-consumes.yml
@@ -1,5 +1,5 @@
 # shared/registry-consumes.yaml (final — added get-voyage + cargo resource)
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 consumes:
   - namespace: registry
     type: http

--- a/ikanos-docs/tutorial/shared/step5-registry-consumes.yaml
+++ b/ikanos-docs/tutorial/shared/step5-registry-consumes.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 consumes:
   - namespace: registry
     type: http

--- a/ikanos-docs/tutorial/shared/step6-registry-consumes.yaml
+++ b/ikanos-docs/tutorial/shared/step6-registry-consumes.yaml
@@ -1,5 +1,5 @@
 # shared/registry-consumes.yaml (updated — added voyages resource)
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 consumes:
   - namespace: registry
     type: http

--- a/ikanos-docs/tutorial/shared/step7-registry-consumes.yml
+++ b/ikanos-docs/tutorial/shared/step7-registry-consumes.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 consumes:
   - namespace: registry
     type: http

--- a/ikanos-docs/tutorial/step-1-shipyard-mock.yml
+++ b/ikanos-docs/tutorial/step-1-shipyard-mock.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 
 capability:
   exposes:

--- a/ikanos-docs/tutorial/step-10-shipyard-rest-adapter.yml
+++ b/ikanos-docs/tutorial/step-10-shipyard-rest-adapter.yml
@@ -1,5 +1,5 @@
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 
 binds:
   - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-11-shipyard-fleet-manifest.yml
+++ b/ikanos-docs/tutorial/step-11-shipyard-fleet-manifest.yml
@@ -1,5 +1,5 @@
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 
 info:
   label: "Shipyard Fleet Management"

--- a/ikanos-docs/tutorial/step-2-shipyard-wiring.yml
+++ b/ikanos-docs/tutorial/step-2-shipyard-wiring.yml
@@ -1,5 +1,5 @@
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 
 capability:
   consumes:

--- a/ikanos-docs/tutorial/step-3-shipyard-auth.yml
+++ b/ikanos-docs/tutorial/step-3-shipyard-auth.yml
@@ -1,5 +1,5 @@
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 
 binds:
   - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-4-shipyard-output-shaping.yml
+++ b/ikanos-docs/tutorial/step-4-shipyard-output-shaping.yml
@@ -1,5 +1,5 @@
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 
 binds:
   - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-5-shipyard-multi-source.yml
+++ b/ikanos-docs/tutorial/step-5-shipyard-multi-source.yml
@@ -1,5 +1,5 @@
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 
 binds:
   - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-6-shipyard-write-operations.yml
+++ b/ikanos-docs/tutorial/step-6-shipyard-write-operations.yml
@@ -1,5 +1,5 @@
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 
 binds:
   - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-7-shipyard-orchestrated-lookup.yml
+++ b/ikanos-docs/tutorial/step-7-shipyard-orchestrated-lookup.yml
@@ -1,5 +1,5 @@
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 
 binds:
   - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-8-shipyard-skill-groups.yml
+++ b/ikanos-docs/tutorial/step-8-shipyard-skill-groups.yml
@@ -1,5 +1,5 @@
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 
 binds:
   - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-9-shipyard-aggregates.yml
+++ b/ikanos-docs/tutorial/step-9-shipyard-aggregates.yml
@@ -1,5 +1,5 @@
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 
 binds:
   - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-basic.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-basic.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 info:
   label: "Aggregate Basic Test"
   description: "Test capability for aggregate function ref resolution"

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-hints-override.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-hints-override.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 info:
   label: "Aggregate Hints Override Test"
   description: "Test capability for semantics-to-hints derivation with override"

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-invalid-ref.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-invalid-ref.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 info:
   label: "Aggregate Invalid Ref Test"
   description: "Test capability with an unknown aggregate ref"

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-shared-mock.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-shared-mock.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 info:
   label: "Aggregate Shared Mock Test"
   description: "Shared aggregate mock function consumed by MCP and REST refs"

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-step-with-namespace.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-step-with-namespace.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=../../../main/resources/schemas/ikanos-schema.json
 # Fixture for issue #290: namespace-qualified references in aggregate function steps
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 info:
   label: "Aggregate Step Namespace Test"
   description: "Test capability for namespace-qualified references in aggregate function steps"

--- a/ikanos-engine/src/test/resources/baseuri-trailing-slash-capability.yaml
+++ b/ikanos-engine/src/test/resources/baseuri-trailing-slash-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 info:
   label: "BaseUri Trailing Slash Regression Test"
   description: "Capability intentionally using a trailing-slash baseUri to test strict validation"

--- a/ikanos-engine/src/test/resources/control/control-capability.yaml
+++ b/ikanos-engine/src/test/resources/control/control-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 info:
   label: "Control Port Test Capability"
   description: "Test capability for Control Server Adapter deserialization and wiring"

--- a/ikanos-engine/src/test/resources/control/control-observability-disabled.yaml
+++ b/ikanos-engine/src/test/resources/control/control-observability-disabled.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 info:
   label: "Control Port — Observability Disabled"
   description: "Test fixture: observability.enabled=false should suppress /metrics and /traces"

--- a/ikanos-engine/src/test/resources/control/control-scripting-capability.yaml
+++ b/ikanos-engine/src/test/resources/control/control-scripting-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 info:
   label: "Control Port Scripting Test"
   description: "Test capability for scripting governance on the Control Port"

--- a/ikanos-engine/src/test/resources/embedding/embedding-capability.yaml
+++ b/ikanos-engine/src/test/resources/embedding/embedding-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 info:
   label: "Embedding Test"
   description: "Test capability for step handler registry integration"

--- a/ikanos-engine/src/test/resources/formats/avro-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/avro-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 info:
   label: "Avro Test Capability"
   description: "Test capability for Avro message decoding from API responses"

--- a/ikanos-engine/src/test/resources/formats/csv-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/csv-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 info:
   label: "CSV Test Capability"
   description: "Test capability for CSV parsing from API responses"

--- a/ikanos-engine/src/test/resources/formats/html-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/html-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 info:
   label: "HTML Test Capability"
   description: "Test capability for HTML table parsing"

--- a/ikanos-engine/src/test/resources/formats/markdown-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/markdown-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 info:
   label: "Markdown Test Capability"
   description: "Test capability for Markdown parsing"

--- a/ikanos-engine/src/test/resources/formats/proto-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/proto-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 info:
   label: "Protobuf Test Capability"
   description: "Test capability for Protobuf message decoding from API responses"

--- a/ikanos-engine/src/test/resources/formats/xml-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/xml-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 info:
   label: "XML Test Capability"
   description: "Test capability for XML parsing from API responses"

--- a/ikanos-engine/src/test/resources/formats/yaml-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/yaml-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 info:
   label: "YAML Test Capability"
   description: "Test capability for YAML parsing from API responses"

--- a/ikanos-engine/src/test/resources/http/http-body-capability.yaml
+++ b/ikanos-engine/src/test/resources/http/http-body-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 capability:
   exposes:
     - type: "rest"

--- a/ikanos-engine/src/test/resources/http/http-forward-value-capability.yaml
+++ b/ikanos-engine/src/test/resources/http/http-forward-value-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 info:
   label: "HTTP Forward with Value Field Test"
   description: "Test capability for forward spec with value field supporting Mustache templates"

--- a/ikanos-engine/src/test/resources/http/http-header-query-capability.yaml
+++ b/ikanos-engine/src/test/resources/http/http-header-query-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 capability:
   exposes:
     - type: "rest"

--- a/ikanos-engine/src/test/resources/mcp/mcp-capability.yaml
+++ b/ikanos-engine/src/test/resources/mcp/mcp-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 info:
   label: "MCP Test Capability"
   description: "Test capability for MCP Server Adapter deserialization and wiring"

--- a/ikanos-engine/src/test/resources/mcp/mcp-hints-capability.yaml
+++ b/ikanos-engine/src/test/resources/mcp/mcp-hints-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 info:
   label: "MCP Hints Test Capability"
   description: "Test capability for MCP tool hints (ToolAnnotations) support"

--- a/ikanos-engine/src/test/resources/mcp/mcp-resources-prompts-capability.yaml
+++ b/ikanos-engine/src/test/resources/mcp/mcp-resources-prompts-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 info:
   label: "MCP Resources & Prompts Test Capability"
   description: "Test capability for MCP Server Adapter resources and prompts support"

--- a/ikanos-engine/src/test/resources/mcp/mcp-stdio-capability.yaml
+++ b/ikanos-engine/src/test/resources/mcp/mcp-stdio-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 info:
   label: "MCP Stdio Test Capability"
   description: "Test capability for MCP Server Adapter with stdio transport"

--- a/ikanos-engine/src/test/resources/mcp/mcp-step-with-namespace-capability.yaml
+++ b/ikanos-engine/src/test/resources/mcp/mcp-step-with-namespace-capability.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=../../../main/resources/schemas/ikanos-schema.json
 # Fixture for issue #290: namespace-qualified references in step-level WithInjector
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 
 capability:
   consumes:

--- a/ikanos-engine/src/test/resources/mcp/mcp-tool-handler-with-mustache-capability.yaml
+++ b/ikanos-engine/src/test/resources/mcp/mcp-tool-handler-with-mustache-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 
 capability:
   consumes:

--- a/ikanos-engine/src/test/resources/nested-object-output-capability.yaml
+++ b/ikanos-engine/src/test/resources/nested-object-output-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 info:
   label: "Nested Object Output Capability"
   description: "Test fixture for verifying that output mappings correctly resolve nested object

--- a/ikanos-engine/src/test/resources/observability/observability-capability.yaml
+++ b/ikanos-engine/src/test/resources/observability/observability-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 info:
   label: "Observability Test Capability"
   description: "Test capability for observability spec deserialization"

--- a/ikanos-engine/src/test/resources/observability/observability-disabled.yaml
+++ b/ikanos-engine/src/test/resources/observability/observability-disabled.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 info:
   label: "Observability Disabled Capability"
   description: "Test capability with observability disabled"

--- a/ikanos-engine/src/test/resources/register.capability.yml
+++ b/ikanos-engine/src/test/resources/register.capability.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 info:
   label: "register"
   description: "Business description of your capability"

--- a/ikanos-engine/src/test/resources/skill-capability.yaml
+++ b/ikanos-engine/src/test/resources/skill-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 info:
   label: "Skill Test Capability"
   description: "Test capability for Skill Server Adapter deserialization and wiring"

--- a/ikanos-engine/src/test/resources/tutorial/shared/legacy-consumes.yaml
+++ b/ikanos-engine/src/test/resources/tutorial/shared/legacy-consumes.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 consumes:
   - namespace: legacy
     type: http

--- a/ikanos-engine/src/test/resources/tutorial/shared/registry-consumes.yaml
+++ b/ikanos-engine/src/test/resources/tutorial/shared/registry-consumes.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 consumes:
   - namespace: registry
     type: http

--- a/ikanos-engine/src/test/resources/tutorial/shared/step11-registry-consumes.yml
+++ b/ikanos-engine/src/test/resources/tutorial/shared/step11-registry-consumes.yml
@@ -1,5 +1,5 @@
 # shared/registry-consumes.yaml (final — added get-voyage + cargo resource)
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 consumes:
   - namespace: registry
     type: http

--- a/ikanos-engine/src/test/resources/tutorial/shared/step5-registry-consumes.yaml
+++ b/ikanos-engine/src/test/resources/tutorial/shared/step5-registry-consumes.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 consumes:
   - namespace: registry
     type: http

--- a/ikanos-engine/src/test/resources/tutorial/shared/step6-registry-consumes.yaml
+++ b/ikanos-engine/src/test/resources/tutorial/shared/step6-registry-consumes.yaml
@@ -1,5 +1,5 @@
 # shared/registry-consumes.yaml (updated — added voyages resource)
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 consumes:
   - namespace: registry
     type: http

--- a/ikanos-engine/src/test/resources/tutorial/shared/step7-registry-consumes.yml
+++ b/ikanos-engine/src/test/resources/tutorial/shared/step7-registry-consumes.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 consumes:
   - namespace: registry
     type: http

--- a/ikanos-engine/src/test/resources/tutorial/step-1-shipyard-mock.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-1-shipyard-mock.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 
 capability:
   exposes:

--- a/ikanos-engine/src/test/resources/tutorial/step-10-shipyard-rest-adapter.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-10-shipyard-rest-adapter.yml
@@ -1,5 +1,5 @@
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 
 binds:
   - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-11-shipyard-fleet-manifest.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-11-shipyard-fleet-manifest.yml
@@ -1,5 +1,5 @@
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 
 info:
   label: "Shipyard Fleet Management"

--- a/ikanos-engine/src/test/resources/tutorial/step-2-shipyard-wiring.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-2-shipyard-wiring.yml
@@ -1,5 +1,5 @@
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 
 capability:
   consumes:

--- a/ikanos-engine/src/test/resources/tutorial/step-3-shipyard-auth.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-3-shipyard-auth.yml
@@ -1,5 +1,5 @@
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 
 binds:
   - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-4-shipyard-output-shaping.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-4-shipyard-output-shaping.yml
@@ -1,5 +1,5 @@
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 
 binds:
   - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-5-shipyard-multi-source.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-5-shipyard-multi-source.yml
@@ -1,5 +1,5 @@
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 
 binds:
   - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-6-shipyard-write-operations.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-6-shipyard-write-operations.yml
@@ -1,5 +1,5 @@
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 
 binds:
   - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-7-shipyard-orchestrated-lookup.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-7-shipyard-orchestrated-lookup.yml
@@ -1,5 +1,5 @@
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 
 binds:
   - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-8-shipyard-skill-groups.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-8-shipyard-skill-groups.yml
@@ -1,5 +1,5 @@
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 
 binds:
   - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-9-shipyard-aggregates.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-9-shipyard-aggregates.yml
@@ -1,5 +1,5 @@
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha6"
 
 binds:
   - namespace: "registry-env"

--- a/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
+++ b/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ikanos.io/schemas/v1.0.0-alpha3/ikanos.json",
+  "$id": "https://ikanos.io/schemas/v1.0.0-alpha6/ikanos.json",
   "name": "Ikanos Specification",
   "description": "Ikanos Capability Specification \u2014 describes a capability document (adapter + metadata). A valid document must declare `ikanos` + either `capability` (adapter document) or `consumes` (shared consumer file). All adapter logic lives under `capability`; shared consumer definitions live at root `consumes`.",
   "type": "object",
@@ -8,7 +8,7 @@
     "ikanos": {
       "type": "string",
       "description": "Ikanos specification version. Must be `1.0.0-alpha2`. Signals schema compatibility \u2014 always the first key in a capability file.",
-      "const": "1.0.0-alpha3"
+      "const": "1.0.0-alpha6"
     },
     "info": {
       "$ref": "#/$defs/Info",


### PR DESCRIPTION
## No related issue

---

## What does this PR do?

Automatically synchronizes the Ikanos version across the repository:
- Updates `ikanos` version in YAML files
- Updates `const` in JSON schema
- Updates `$id` schema URL

Source of truth: `pom.xml`

---

## Tests

No additional tests required.
This change is limited to version synchronization and does not impact runtime behavior.

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main`
- [ ] Small and focused — one concern per PR
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)