### PR TITLE
fix: reset TelemetryBootstrap singleton in CapabilityRuntimeIntegrationTest teardown

### DIFF
--- a/ikanos-engine/src/test/java/io/ikanos/bootstrap/CapabilityRuntimeIntegrationTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/bootstrap/CapabilityRuntimeIntegrationTest.java
@@ -29,8 +29,10 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import io.ikanos.engine.observability.TelemetryBootstrap;
 
 public class CapabilityRuntimeIntegrationTest {
 
@@ -127,5 +129,10 @@ public class CapabilityRuntimeIntegrationTest {
         try (java.net.ServerSocket socket = new java.net.ServerSocket(0)) {
             return socket.getLocalPort();
         }
+    }
+
+    @AfterEach
+    void tearDown() {
+        TelemetryBootstrap.reset();
     }
 }


### PR DESCRIPTION
## Related Issue

Closes #476

---

## What does this PR do?

`CapabilityRuntimeIntegrationTest` starts a full `CapabilityRuntime` internally (which calls `TelemetryBootstrap.init(...)`), but had no `@AfterEach` to call `TelemetryBootstrap.reset()`. When Surefire runs tests sequentially in the same JVM, the singleton stayed set for subsequent test classes, causing `MetricsResourceTest.getMetricsShouldReturn503WhenOTelIsNoop` to receive `text/plain` instead of `application/json`.

This PR adds an `@AfterEach void tearDown()` that calls `TelemetryBootstrap.reset()`, matching the pattern already used by `MetricsResourceTest` and all other observability test classes.

---

## Tests

- The pre-existing non-regression test `MetricsResourceTest.getMetricsShouldReturn503WhenOTelIsNoop` was confirmed to fail on `main` before this fix and pass after.
- Full suite: `684 tests, 0 failures, 0 errors`.

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Naftiko - Claude Sonnet 4.6
tool: VS Code
confidence: high
source_event: full suite test failure during PR #471 rebase
discovery_method: test_failure
review_focus: ikanos-engine/src/test/java/io/ikanos/bootstrap/CapabilityRuntimeIntegrationTest.java
```
