### PR TITLE
feat: reload active skill after context compaction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow. Key rules:
   - PRs: `.github/PULL_REQUEST_TEMPLATE.md` — follow the structure exactly, do not improvise
 - When creating issues or PRs with multiline bodies via `gh`, **never construct the body as a string in the terminal** — PowerShell here-strings and multiline variable assignments hang or corrupt content. Always write the body to a temp `.md` file using the file creation tool (outside the terminal), then pass it via `--body-file "/path/to/file.md"`
 - When asked to review a PR, load and follow the `pr-review` skill in `.agents/skills/pr-review/` before doing anything else
+- When resuming after a context compaction (conversation summary), always re-read any active skill's `SKILL.md` before continuing — compaction erases step formalism, workflow constraints, and all details defined in the skill
 - When editing documentation, skill, or instruction files (`.md`, `SKILL.md`, `AGENTS.md`), re-read the **entire file** after applying edits and before committing — to catch terminology drift, broken cross-references, and inconsistencies between sections that targeted edits cannot detect
 - Do **not** use `git push --force` — use `--force-with-lease`
 - When the user corrects a mistake, note it immediately so the insight is not lost — see [Self-Improvement](#self-improvement)


### PR DESCRIPTION
## Related Issue

Closes #480

---

## What does this PR do?

Adds an explicit rule to the Contribution Workflow section of `AGENTS.md`:

> When resuming after a context compaction (conversation summary), always re-read any active skill's `SKILL.md` before continuing — compaction erases step formalism, workflow constraints, and all details defined in the skill.

This addresses a gap observed in practice: when a conversation is compacted, the agent silently loses the detailed workflow steps defined in active skill files and resumes work without reloading them, drifting from the defined process.

The rule is placed alongside the existing skill-load instruction (load skill before starting a PR review), making the full lifecycle explicit: load before starting, reload after compaction.

---

## Tests

Documentation-only change — no code modified, no tests required.

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Claude Sonnet 4.6
tool: VS Code Copilot Chat
confidence: high
source_event: pr_review_session
discovery_method: runtime_observation
review_focus: AGENTS.md:Contribution Workflow
```
