### PR TITLE
fix: defer ScriptStepExecutor instantiation to avoid eager GraalVM class loading

### DIFF
--- a/.github/workflows/validate-tuto-examples.yml
+++ b/.github/workflows/validate-tuto-examples.yml
@@ -3,7 +3,13 @@ name: Validate Shipyard tutorial examples
 on:
   push:
     paths:
-      - 'src/main/**'
+      - 'ikanos-*/src/main/**'
+      - 'ikanos-*/pom.xml'
+      - 'pom.xml'
+  pull_request:
+    paths:
+      - 'ikanos-*/src/main/**'
+      - 'ikanos-*/pom.xml'
       - 'pom.xml'
   workflow_dispatch:
 

--- a/ikanos-engine/src/main/java/io/ikanos/engine/util/OperationStepExecutor.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/util/OperationStepExecutor.java
@@ -69,7 +69,7 @@ public class OperationStepExecutor {
 
     private final Capability capability;
     private final ObjectMapper mapper;
-    private final ScriptStepExecutor scriptExecutor;
+    private ScriptStepExecutor scriptExecutor;
     private volatile String exposeNamespace;
 
     public OperationStepExecutor(Capability capability) {
@@ -79,9 +79,9 @@ public class OperationStepExecutor {
     public OperationStepExecutor(Capability capability, String exposeNamespace) {
         this.capability = capability;
         this.mapper = new ObjectMapper();
-        this.scriptExecutor = new ScriptStepExecutor();
         this.exposeNamespace = exposeNamespace;
         if (capability != null && capability.getScriptingSpec() != null) {
+            this.scriptExecutor = new ScriptStepExecutor();
             this.scriptExecutor.setScriptingSpec(capability.getScriptingSpec());
         }
     }
@@ -343,11 +343,13 @@ public class OperationStepExecutor {
                 }
                 case OperationStepScriptSpec scriptStep -> {
                     ScriptStepExecutor.requireScriptingPermitted(
-                            scriptStep.getName(), scriptExecutor.getScriptingSpec());
+                            scriptStep.getName(),
+                            scriptExecutor != null ? scriptExecutor.getScriptingSpec() : null);
                     TelemetryBootstrap scriptTelemetry = TelemetryBootstrap.get();
                     String effectiveScriptLanguage = scriptStep.getLanguage();
                     if ((effectiveScriptLanguage == null
                             || effectiveScriptLanguage.isBlank())
+                            && scriptExecutor != null
                             && scriptExecutor.getScriptingSpec() != null) {
                         effectiveScriptLanguage =
                                 scriptExecutor.getScriptingSpec().getDefaultLanguage();


### PR DESCRIPTION
## Related Issue

Closes #490
Closes #492

---

## What does this PR do?

**Fix 1 — `NoClassDefFoundError` at startup (#490)**

`ScriptStepExecutor` has a top-level import of `org.graalvm.polyglot.PolyglotException`, causing the JVM to load GraalVM classes when `OperationStepExecutor` is constructed — even for capabilities that use no scripting.

`ikanos.jar` intentionally excludes GraalVM from the shaded artifact (for native binary compatibility). Since the `validate-tuto-examples` CI workflow was updated to run `ikanos.jar serve` instead of the engine JAR, every `serve` invocation crashed immediately with `NoClassDefFoundError: org/graalvm/polyglot/PolyglotException`.

`ScriptStepExecutor` is now only instantiated when the capability declares a `scriptingSpec`. For capabilities without scripting (the common case), GraalVM classes are never loaded. If a script step is encountered without a configured executor, `requireScriptingPermitted()` already raises a clear `IllegalStateException`.

**Fix 2 — `validate-tuto-examples` never triggered on PRs (#492)**

The `paths` filter still used the pre-modularization path `src/main/**`. After the codebase was split into `ikanos-spec/`, `ikanos-engine/`, `ikanos-cli/`, no source file lives under `src/main/**` anymore — so the workflow never fired on any PR or feature branch push. Updated to `ikanos-*/src/main/**` and added a `pull_request` trigger.

---

## Tests

- Existing `OperationStepExecutorBranchTest` and `OperationStepExecutorIntegrationTest` cover the scripting path end-to-end.
- Full suite: `684 tests, 0 failures, 0 errors`.

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Naftiko - Claude Sonnet 4.6
tool: VS Code
confidence: high
source_event: validate-tuto-examples CI failure on all branches
discovery_method: code_review
review_focus: ikanos-engine/src/main/java/io/ikanos/engine/util/OperationStepExecutor.java:82
```
