### PR TITLE
chore: rename backstage to warden

### DIFF
--- a/.github/workflows/synchronize-ikanos-version-in-other-repos.yml
+++ b/.github/workflows/synchronize-ikanos-version-in-other-repos.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   # This job is only executed when triggered (automatically or manually) from the 'main' branch.
-  sync-backstage-version:
+  sync-warden-version:
     runs-on: ubuntu-latest
     if: github.ref_name == 'main'
 
@@ -25,24 +25,24 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Checkout backstage
+      - name: Checkout warden
         uses: actions/checkout@v4
         with:
-          repository: naftiko/backstage
-          token: ${{ secrets.BACKSTAGE_CONTENTS_WRITE_PR_WRITE }}
-          path: backstage
+          repository: naftiko/warden
+          token: ${{ secrets.WARDEN_CONTENTS_WRITE_PR_WRITE }}
+          path: warden
 
-      - name: Sync Ikanos version to backstage
+      - name: Sync Ikanos version to warden
         id: sync
         run: |
-          VERSION=$(python3 ikanos/scripts/sync-ikanos-version-to-backstage.py \
+          VERSION=$(python3 ikanos/scripts/sync-ikanos-version-to-warden.py \
             --pom ikanos/pom.xml \
-            --target backstage/templates/skeletons/capabilities)
+            --target warden/templates/skeletons/capabilities)
           echo "value=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Check for changes
         id: git-check
-        working-directory: backstage
+        working-directory: warden
         run: |
           if git diff --quiet; then
             echo "changes=false" >> $GITHUB_OUTPUT
@@ -54,8 +54,8 @@ jobs:
         if: steps.git-check.outputs.changes == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.BACKSTAGE_CONTENTS_WRITE_PR_WRITE }}
-          path: backstage
+          token: ${{ secrets.WARDEN_CONTENTS_WRITE_PR_WRITE }}
+          path: warden
           base: main
           branch: "chore/sync-ikanos-version"
           commit-message: "chore: sync Ikanos version to ${{ steps.sync.outputs.value }} [skip ci]"
@@ -64,14 +64,14 @@ jobs:
             Automated sync from [ikanos@${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}).
 
             Updated files:
-            - `templates/skeletons/capabilities/*.naftiko.yml`
+            - `templates/skeletons/capabilities/*.ikanos.yml`
           delete-branch: true
 
   # This job is only executed when triggered (automatically or manually) from the 'main' branch.
   sync-vscode-version:
     runs-on: ubuntu-latest
     if: github.ref_name == 'main'
-    needs: sync-backstage-version
+    needs: sync-warden-version
 
     steps:
       - name: Checkout ikanos

--- a/scripts/sync-ikanos-version-to-warden.py
+++ b/scripts/sync-ikanos-version-to-warden.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Script to synchronize the Ikanos version from pom.xml into Backstage skeleton templates.
+Script to synchronize the Ikanos version from pom.xml into Warden backstage skeleton templates.
 """
 
 import argparse
@@ -12,7 +12,7 @@ from ikanos_version import extract_version_from_pom, update_yaml_version
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Sync Ikanos version to Backstage skeletons")
+    parser = argparse.ArgumentParser(description="Sync Ikanos version to Warden backstage skeletons")
     parser.add_argument("--pom", required=True, help="Path to ikanos pom.xml")
     parser.add_argument("--target", required=True, help="Path to skeleton capabilities directory")
     args = parser.parse_args()
@@ -20,10 +20,10 @@ def main():
     version = extract_version_from_pom(args.pom)
 
     target = Path(args.target)
-    files = list(target.glob("*.naftiko.yml"))
+    files = list(target.glob("*.ikanos.yml"))
 
     if not files:
-        print(f"⚠ No .naftiko.yml files found in {target}", file=sys.stderr)
+        print(f"⚠ No .ikanos.yml files found in {target}", file=sys.stderr)
     else:
         for file in files:
             if update_yaml_version(file, version):


### PR DESCRIPTION
## Related Issue

Part of #warden14 (needs warden + fleet PRs in addition)

---

## What does this PR do?

replace backstage repo by warden repo

---

## Tests

I manually tested the synchronize-ikanos-version-in-other-repos github action

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main`
- [ ] Small and focused — one concern per PR
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

<!-- If this PR was created or assisted by an AI agent, provide metadata below (YAML) -->

```yaml
# agent_name:
# llm:
# tool:
# confidence:          # low | medium | high
# source_event:
# discovery_method:    # runtime_observation | code_review | test_failure | user_report
# review_focus:        # e.g. ClassName.java:line-range
```
