### PR TITLE
feat: rename label to display and add tags to sub-entities

### DIFF
--- a/.agents/skills/ikanos-capability/SKILL.md
+++ b/.agents/skills/ikanos-capability/SKILL.md
@@ -29,7 +29,7 @@ Key spec objects you will work with:
 - **Capability** — root technical config; contains `exposes`, `consumes`, and `aggregates`
 - **Consumes** — HTTP client adapter: baseUri, namespace, resources, operations
 - **Exposes** — server adapter: REST (`type: rest`), MCP (`type: mcp`), Skill (`type: skill`), or Control (`type: control`)
-- **Aggregates** — DDD-inspired domain building blocks; each aggregate groups reusable functions under a namespace. Tools and operations reference functions via `ref`
+- **Aggregates** — DDD-inspired domain building blocks; each aggregate groups reusable flows under a namespace. Tools and operations reference flows via `ref`
 - **Observability** — optional OTel configuration on the control adapter: trace sampling, propagation format, OTLP exporter endpoint
 - **Script Steps** — embed JavaScript, Python, or Groovy transformations between API calls using sandboxed GraalVM engines. Scripts read step results via bound variables and produce output through a `result` variable
 - **Binds** — variable injection from file (dev) or runtime (prod)
@@ -49,7 +49,7 @@ removed from the object body.
 
 **Keyed maps** (key = name, no `name` property inside):
 `tools`, `resources`, `operations`, `inputParameters` (all contexts),
-`steps`, `functions`, `aggregates`, `skills`, `prompts`
+`steps`, `flows`, `aggregates`, `skills`, `prompts`
 
 **Arrays** (keep `- item` syntax):
 `outputParameters`, `binds`, `exposes`, `consumes`, `stakeholders`, `mappings`
@@ -88,14 +88,14 @@ resources:
             mapping: "$."
 ```
 
-Example — aggregates + functions (keyed maps):
+Example — aggregates + flows (keyed maps):
 
 ```yaml
 aggregates:
   forecast:                            # ← key IS the aggregate namespace
     description: "Weather forecast domain"
-    functions:
-      get-forecast:                    # ← key IS the function name
+    flows:
+      get-forecast:                    # ← key IS the flow name
         description: "Retrieve forecast for a location"
         inputParameters:
           location:                    # ← key IS the name
@@ -117,7 +117,7 @@ for *how*.
 | "I want to proxy an API today and encapsulate it incrementally" | Read `references/proxy-then-customize.md` |
 | "I want to chain multiple HTTP calls to consumed APIs and expose the result into a single REST operation" | Read `references/chain-api-calls.md` |
 | "I need to go from local test credentials to production secrets" | Read `references/dev-to-production.md` |
-| "I want to define a domain function once and expose it via both REST and MCP" | Use `aggregates` with `ref` — read `references/design-guidelines.md` (Aggregate Design Guidelines) |
+| "I want to define a domain flow once and expose it via both REST and MCP" | Use `aggregates` with `ref` — read `references/design-guidelines.md` (Aggregate Design Guidelines) |
 | "I want to add health checks, Prometheus metrics, or trace inspection" | Read `references/control-port-observability.md` |
 | "I want to enable OpenTelemetry distributed tracing and RED metrics" | Read `references/control-port-observability.md` |
 | "I want to transform data between API calls using JavaScript, Python, or Groovy" | Read `references/inline-script-step.md` |
@@ -195,13 +195,13 @@ before writing any mock output parameters.
    exposed contract does not change.
    and `trustedHeaders` (at least one entry).
 10. MCP tools must have `name` and `description` (unless using `ref`, in which
-    case they are inherited from the referenced aggregate function). MCP tool input
+    case they are inherited from the referenced aggregate flow). MCP tool input
     parameters must have `name`, `type`, and `description`. Tools may declare optional
     `hints` (readOnly, destructive, idempotent, openWorld) — these map to
     MCP `ToolAnnotations` on the wire.
 11. ExposedOperation supports three modes (oneOf): simple (`call` +
     optional `with`), orchestrated (`steps` + optional `mappings`), or
-    ref (`ref` to an aggregate function). Never mix fields from
+    ref (`ref` to an aggregate flow). Never mix fields from
     incompatible modes.
 12. Do not modify `scripts/lint-capability.sh` unless explicitly asked —
     it wraps Spectral with the correct ruleset and flags.
@@ -217,14 +217,14 @@ before writing any mock output parameters.
     resource name — variables are already scoped to their context.
     Redundant prefixes reduce readability without adding disambiguation.
 17. When using `ref` on MCP tools or REST operations, the `ref` value must
-    follow the format `{aggregate-namespace}.{function-name}` and resolve
-    to an existing function in the capability's `aggregates` array.
+    follow the format `{aggregate-namespace}.{flow-name}` and resolve
+    to an existing flow in the capability's `aggregates` section.
 18. Do not chain `ref` through multiple levels of aggregates — `ref`
-    resolves to a function in a single aggregate, not transitively.
-19. Aggregate functions can declare `semantics` (safe, idempotent, cacheable).
+    resolves to a flow in a single aggregate, not transitively.
+19. Aggregate flows can declare `semantics` (safe, idempotent, cacheable).
     When exposed via MCP, the engine auto-derives `hints` from semantics.
     Explicit `hints` on the MCP tool override derived values.
-20. Do not duplicate a full function definition inline on both MCP tools
+20. Do not duplicate a full flow definition inline on both MCP tools
     and REST operations — use `aggregates` + `ref` instead.
 21. In mock mode, use `value` on output parameters — never `const`.
     `const` is a JSON Schema keyword retained for validation and linting

--- a/.agents/skills/ikanos-capability/SKILL.md
+++ b/.agents/skills/ikanos-capability/SKILL.md
@@ -25,7 +25,7 @@ is a single YAML file validated against the Ikanos JSON Schema (v1.0.0-alpha3).
 
 Key spec objects you will work with:
 
-- **Info** — metadata: label, description, tags, stakeholders
+- **Info** — metadata: display, description, tags, stakeholders
 - **Capability** — root technical config; contains `exposes`, `consumes`, and `aggregates`
 - **Consumes** — HTTP client adapter: baseUri, namespace, resources, operations
 - **Exposes** — server adapter: REST (`type: rest`), MCP (`type: mcp`), Skill (`type: skill`), or Control (`type: control`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,9 +145,9 @@ When designing or modifying a Capability:
 - Keep the [Ikanos Specification](ikanos-spec/src/main/resources/schemas/ikanos-schema.json) and the [Ikanos Rules](ikanos-spec/src/main/resources/rules/ikanos-rules.yml) as first-class citizens — the schema enforces structure, the rules enforce cross-object consistency, quality, and security
 - Look at `ikanos-spec/src/main/resources/schemas/examples/` for patterns before writing new capabilities
 - When renaming a consumed field for a lookup `match`, also add a `ConsumedOutputParameter` on the consumed operation to map the raw field name to a kebab-case name — otherwise the lookup has nothing to match against
-- Use `aggregates` to define reusable domain functions when the same operation is exposed through multiple adapters (REST and MCP) — this follows the DDD Aggregate pattern: one definition, multiple projections
-- Declare `semantics` (safe, idempotent, cacheable) on aggregate functions to describe domain behavior — the engine derives MCP `hints` automatically
-- Override only adapter-specific fields when using `ref` (e.g., `method` for REST, `hints` for MCP) — let the rest be inherited from the function
+- Use `aggregates` to define reusable domain flows when the same operation is exposed through multiple adapters (REST and MCP) — this follows the DDD Aggregate pattern: one definition, multiple projections
+- Declare `semantics` (safe, idempotent, cacheable) on aggregate flows to describe domain behavior — the engine derives MCP `hints` automatically
+- Override only adapter-specific fields when using `ref` (e.g., `method` for REST, `hints` for MCP) — let the rest be inherited from the flow
 
 **Don't:**
 - Expose an `inputParameter` that is not used in any step
@@ -163,8 +163,8 @@ When designing or modifying a Capability:
 - Use `MappedOutputParameter` (with `mapping`, no `name`) when the tool/operation uses `steps` — use `OrchestratedOutputParameter` (with `name`, no `mapping`) instead
 - Use typed objects for lookup step `outputParameters` — they are plain string arrays of field names to extract (e.g. `- "fullName"`)
 - Put a `path` property on an `ExposedOperation` — extract multi-step operations with a different path into their own `ExposedResource`
-- Duplicate a full function definition inline on both MCP tools and REST operations — use `aggregates` + `ref` instead
-- Chain `ref` through multiple levels of aggregates — `ref` resolves to a function in a single aggregate, not transitively
+- Duplicate a full flow definition inline on both MCP tools and REST operations — use `aggregates` + `ref` instead
+- Chain `ref` through multiple levels of aggregates — `ref` resolves to a flow in a single aggregate, not transitively
 
 ## Contribution Workflow
 

--- a/ikanos-cli/src/main/java/io/ikanos/cli/FileFormat.java
+++ b/ikanos-cli/src/main/java/io/ikanos/cli/FileFormat.java
@@ -25,7 +25,7 @@ public enum FileFormat {
         this.pathName = pathName;
     }
 
-    public static FileFormat valueOfLabel(String display) {
+    public static FileFormat valueOfDisplay(String display) {
         for (FileFormat fileFormat : values()) {
             if (java.util.Objects.equals(fileFormat.display, display)) {
                 return fileFormat;

--- a/ikanos-cli/src/main/java/io/ikanos/cli/FileFormat.java
+++ b/ikanos-cli/src/main/java/io/ikanos/cli/FileFormat.java
@@ -17,17 +17,17 @@ public enum FileFormat {
     YAML("Yaml","yaml"),
     UNKNOWN("Unknown","unknown");
 
-    public final String label;
+    public final String display;
     public final String pathName;
 
-    private FileFormat(String label, String pathName) {
-        this.label = label;
+    private FileFormat(String display, String pathName) {
+        this.display = display;
         this.pathName = pathName;
     }
 
-    public static FileFormat valueOfLabel(String label) {
+    public static FileFormat valueOfLabel(String display) {
         for (FileFormat fileFormat : values()) {
-            if (java.util.Objects.equals(fileFormat.label, label)) {
+            if (java.util.Objects.equals(fileFormat.display, display)) {
                 return fileFormat;
             }
         }

--- a/ikanos-cli/src/main/java/io/ikanos/cli/StatusCommand.java
+++ b/ikanos-cli/src/main/java/io/ikanos/cli/StatusCommand.java
@@ -64,8 +64,8 @@ public class StatusCommand implements Callable<Integer> {
                 }
             }
 
-            String label = root.path("capability").path("label").asText("unknown");
-            System.out.println(label + ": " + (allStarted ? "UP" : "DEGRADED"));
+            String display = root.path("capability").path("display").asText("unknown");
+            System.out.println(display + ": " + (allStarted ? "UP" : "DEGRADED"));
 
             // Engine
             JsonNode engine = root.path("engine");

--- a/ikanos-cli/src/test/java/io/ikanos/cli/ControlPortMixinTest.java
+++ b/ikanos-cli/src/test/java/io/ikanos/cli/ControlPortMixinTest.java
@@ -86,7 +86,7 @@ public class ControlPortMixinTest {
         Files.writeString(yaml, """
                 ikanos: "1.0.0-alpha2"
                 info:
-                  label: Test
+                  display: Test
                 capability:
                   exposes:
                     - type: control
@@ -138,7 +138,7 @@ public class ControlPortMixinTest {
         Files.writeString(yaml, """
                 ikanos: "1.0.0-alpha2"
                 info:
-                  label: Test
+                  display: Test
                 capability:
                   exposes:
                     - type: control
@@ -170,7 +170,7 @@ public class ControlPortMixinTest {
         Files.writeString(yaml, """
                 ikanos: "1.0.0-alpha2"
                 info:
-                  label: Test
+                  display: Test
                 capability:
                   exposes:
                     - type: rest
@@ -194,7 +194,7 @@ public class ControlPortMixinTest {
         Files.writeString(yaml1, """
                 ikanos: "1.0.0-alpha2"
                 info:
-                  label: Test A
+                  display: Test A
                 capability:
                   exposes:
                     - type: rest
@@ -205,7 +205,7 @@ public class ControlPortMixinTest {
         Files.writeString(yaml2, """
                 ikanos: "1.0.0-alpha2"
                 info:
-                  label: Test B
+                  display: Test B
                 capability:
                   exposes:
                     - type: control
@@ -230,7 +230,7 @@ public class ControlPortMixinTest {
         Files.writeString(yaml, """
                 ikanos: "1.0.0-alpha2"
                 info:
-                  label: Test
+                  display: Test
                 capability: {}
                 """);
 

--- a/ikanos-cli/src/test/java/io/ikanos/cli/ExportOpenApiCommandTest.java
+++ b/ikanos-cli/src/test/java/io/ikanos/cli/ExportOpenApiCommandTest.java
@@ -35,7 +35,7 @@ public class ExportOpenApiCommandTest {
         Files.writeString(capFile, """
                 ikanos: "1.0.0-alpha1"
                 info:
-                  label: "Test API"
+                  display: "Test API"
                   description: "A test capability"
                 capability:
                   exposes:
@@ -73,7 +73,7 @@ public class ExportOpenApiCommandTest {
         Files.writeString(capFile, """
                 ikanos: "1.0.0-alpha1"
                 info:
-                  label: "JSON Test"
+                  display: "JSON Test"
                 capability:
                   exposes:
                     - type: rest
@@ -114,7 +114,7 @@ public class ExportOpenApiCommandTest {
         Files.writeString(capFile, """
                 ikanos: "1.0.0-alpha1"
                 info:
-                  label: "Spec Version Test"
+                  display: "Spec Version Test"
                 capability:
                   exposes:
                     - type: rest
@@ -141,7 +141,7 @@ public class ExportOpenApiCommandTest {
         Files.writeString(capFile, """
                 ikanos: "1.0.0-alpha1"
                 info:
-                  label: "OpenAPI 3.1 Test"
+                  display: "OpenAPI 3.1 Test"
                 capability:
                   exposes:
                     - type: rest
@@ -171,7 +171,7 @@ public class ExportOpenApiCommandTest {
         Files.writeString(capFile, """
                 ikanos: "1.0.0-alpha1"
                 info:
-                  label: "Default Output Test"
+                  display: "Default Output Test"
                 capability:
                   exposes:
                     - type: rest
@@ -203,7 +203,7 @@ public class ExportOpenApiCommandTest {
         Files.writeString(capFile, """
                 ikanos: "1.0.0-alpha1"
                 info:
-                  label: "JSON Default Output Test"
+                  display: "JSON Default Output Test"
                 capability:
                   exposes:
                     - type: rest

--- a/ikanos-cli/src/test/java/io/ikanos/cli/FileFormatEnumTest.java
+++ b/ikanos-cli/src/test/java/io/ikanos/cli/FileFormatEnumTest.java
@@ -42,8 +42,8 @@ public class FileFormatEnumTest {
 
     @Test
     public void enumValuesShouldHaveCorrectLabels() {
-        assertEquals("Yaml", FileFormat.YAML.label);
-        assertEquals("Unknown", FileFormat.UNKNOWN.label);
+        assertEquals("Yaml", FileFormat.YAML.display);
+        assertEquals("Unknown", FileFormat.UNKNOWN.display);
     }
 
     @Test

--- a/ikanos-cli/src/test/java/io/ikanos/cli/FileFormatEnumTest.java
+++ b/ikanos-cli/src/test/java/io/ikanos/cli/FileFormatEnumTest.java
@@ -19,23 +19,23 @@ import org.junit.jupiter.api.Test;
 public class FileFormatEnumTest {
 
     @Test
-    public void valueOfLabelShouldReturnYamlForYamlLabel() {
-        FileFormat result = FileFormat.valueOfLabel("Yaml");
+    public void valueOfDisplayShouldReturnYamlForYamlLabel() {
+        FileFormat result = FileFormat.valueOfDisplay("Yaml");
 
         assertEquals(FileFormat.YAML, result);
         assertEquals("yaml", result.pathName);
     }
 
     @Test
-    public void valueOfLabelShouldReturnUnknownForUnrecognizedLabel() {
-        FileFormat result = FileFormat.valueOfLabel("Unknown");
+    public void valueOfDisplayShouldReturnUnknownForUnrecognizedLabel() {
+        FileFormat result = FileFormat.valueOfDisplay("Unknown");
 
         assertEquals(FileFormat.UNKNOWN, result);
     }
 
     @Test
-    public void valueOfLabelShouldReturnUnknownForNull() {
-        FileFormat result = FileFormat.valueOfLabel(null);
+    public void valueOfDisplayShouldReturnUnknownForNull() {
+        FileFormat result = FileFormat.valueOfDisplay(null);
 
         assertEquals(FileFormat.UNKNOWN, result);
     }

--- a/ikanos-cli/src/test/java/io/ikanos/cli/StatusCommandTest.java
+++ b/ikanos-cli/src/test/java/io/ikanos/cli/StatusCommandTest.java
@@ -54,7 +54,7 @@ public class StatusCommandTest {
     @Test
     void statusShouldDisplayCapabilityInfo() {
         String json = """
-                {"capability":{"label":"Weather Service","specVersion":"1.0.0-alpha2"},
+                {"capability":{"display":"Weather Service","specVersion":"1.0.0-alpha2"},
                  "engine":{"version":"1.0.0-alpha2","java":"21.0.3","native":false},
                  "uptime":"PT2H34M12S",
                  "otel":{"status":"inactive"},
@@ -88,7 +88,7 @@ public class StatusCommandTest {
     @Test
     void statusShouldShowDegradedWhenAdapterStopped() {
         String json = """
-                {"capability":{"label":"Test"},
+                {"capability":{"display":"Test"},
                  "engine":{"version":"1.0.0","java":"21","native":false},
                  "uptime":"PT5S",
                  "otel":{"status":"inactive"},
@@ -143,7 +143,7 @@ public class StatusCommandTest {
     @Test
     void statusShouldDisplayActiveOtelExporterWhenPresent() {
         String json = """
-                {"capability":{"label":"Weather Service"},
+                {"capability":{"display":"Weather Service"},
                  "engine":{"version":"1.0.0","java":"21","native":false},
                  "uptime":"PT15S",
                  "otel":{"status":"active","exporter":"otlp","endpoint":"http://otel:4317"},
@@ -187,7 +187,7 @@ public class StatusCommandTest {
     @Test
     void statusShouldDisplayNativeEngineIndicator() {
         String json = """
-                {"capability":{"label":"Native App"},
+                {"capability":{"display":"Native App"},
                  "engine":{"version":"1.0.0","java":"21","native":true},
                  "uptime":"PT1S",
                  "otel":{"status":"inactive"},
@@ -211,7 +211,7 @@ public class StatusCommandTest {
     @Test
     void statusShouldHandleOtelInactiveWithoutExporter() {
         String json = """
-                {"capability":{"label":"Test"},
+                {"capability":{"display":"Test"},
                  "engine":{"version":"1.0.0","java":"21","native":false},
                  "uptime":"PT10S",
                  "otel":{"status":"inactive"},
@@ -235,7 +235,7 @@ public class StatusCommandTest {
     @Test
     void statusShouldDisplayMultipleAdapters() {
         String json = """
-                {"capability":{"label":"Multi-adapter"},
+                {"capability":{"display":"Multi-adapter"},
                  "engine":{"version":"1.0.0","java":"21","native":false},
                  "uptime":"PT20S",
                  "otel":{"status":"inactive"},

--- a/ikanos-cli/src/test/resources/control/control-capability.yaml
+++ b/ikanos-cli/src/test/resources/control/control-capability.yaml
@@ -2,7 +2,7 @@
 ---
 ikanos: "1.0.0-alpha3"
 info:
-  label: "CLI Control Port Test Capability"
+  display: "CLI Control Port Test Capability"
   description: "Test capability for CLI runtime startup"
   tags:
     - Test

--- a/ikanos-docs/tutorial/step-10-shipyard-rest-adapter.yml
+++ b/ikanos-docs/tutorial/step-10-shipyard-rest-adapter.yml
@@ -1,4 +1,4 @@
-﻿ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha3"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-10-shipyard-rest-adapter.yml
+++ b/ikanos-docs/tutorial/step-10-shipyard-rest-adapter.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+﻿ikanos: "1.0.0-alpha3"
 
 binds:
 - namespace: "registry-env"
@@ -25,7 +25,7 @@ capability:
     crew-resolver:
       display: "Crew Resolver"
       namespace: crew-resolver
-      functions:
+      flows:
         resolve-crew-for-ship:
           description: "Resolve crew member names and roles for a given ship"
           semantics:

--- a/ikanos-docs/tutorial/step-10-shipyard-rest-adapter.yml
+++ b/ikanos-docs/tutorial/step-10-shipyard-rest-adapter.yml
@@ -23,7 +23,7 @@ capability:
 
   aggregates:
     crew-resolver:
-      label: "Crew Resolver"
+      display: "Crew Resolver"
       namespace: crew-resolver
       functions:
         resolve-crew-for-ship:

--- a/ikanos-docs/tutorial/step-11-shipyard-fleet-manifest.yml
+++ b/ikanos-docs/tutorial/step-11-shipyard-fleet-manifest.yml
@@ -1,7 +1,7 @@
 ikanos: "1.0.0-alpha3"
 
 info:
-  label: "Shipyard Fleet Management"
+  display: "Shipyard Fleet Management"
   description: "Maritime fleet management capability — exposes MCP tools, skills, and REST APIs for ship registry, legacy dockyard, and voyage planning."
   tags:
   - Maritime

--- a/ikanos-docs/tutorial/step-9-shipyard-aggregates.yml
+++ b/ikanos-docs/tutorial/step-9-shipyard-aggregates.yml
@@ -1,4 +1,4 @@
-﻿ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha3"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-9-shipyard-aggregates.yml
+++ b/ikanos-docs/tutorial/step-9-shipyard-aggregates.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+﻿ikanos: "1.0.0-alpha3"
 
 binds:
 - namespace: "registry-env"
@@ -25,7 +25,7 @@ capability:
     crew-resolver:
       display: "Crew Resolver"
       namespace: crew-resolver
-      functions:
+      flows:
         resolve-crew-for-ship:
           description: "Resolve crew member names and roles for a given ship"
           semantics:

--- a/ikanos-docs/tutorial/step-9-shipyard-aggregates.yml
+++ b/ikanos-docs/tutorial/step-9-shipyard-aggregates.yml
@@ -23,7 +23,7 @@ capability:
 
   aggregates:
     crew-resolver:
-      label: "Crew Resolver"
+      display: "Crew Resolver"
       namespace: crew-resolver
       functions:
         resolve-crew-for-ship:

--- a/ikanos-docs/wiki/FAQ.md
+++ b/ikanos-docs/wiki/FAQ.md
@@ -227,7 +227,7 @@ exposes:
 - `name` and `description` are optional when using `ref` — they default to the function's values.
 
 ### Q: How do semantics map to MCP tool hints?
-**A:** aggregate flows can declare transport-neutral **semantics** (`safe`, `idempotent`, `cacheable`). When exposed as MCP tools, the engine automatically derives [MCP tool hints](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#tool-annotations):
+**A:** Aggregate flows can declare transport-neutral **semantics** (`safe`, `idempotent`, `cacheable`). When exposed as MCP tools, the engine automatically derives [MCP tool hints](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#tool-annotations):
 
 | Semantics | MCP Hint | Rule |
 |-----------|----------|------|

--- a/ikanos-docs/wiki/FAQ.md
+++ b/ikanos-docs/wiki/FAQ.md
@@ -203,7 +203,7 @@ capability:
 ```
 
 ### Q: How does `ref` work to reference an aggregate flow?
-**A:** MCP tools and REST operations can reference an aggregate flow using `ref: {namespace}.{function-name}`. The engine merges inherited fields from the function — you only specify what's different at the adapter level.
+**A:** MCP tools and REST operations can reference an aggregate flow using `ref: {namespace}.{flow-name}`. The engine merges inherited fields from the flow — you only specify what's different at the adapter level.
 
 ```yaml
 exposes:
@@ -218,13 +218,13 @@ exposes:
       - path: /forecast
         operations:
           - method: GET
-            ref: forecast.get-forecast   # Same function, REST adapter
+            ref: forecast.get-forecast   # Same flow, REST adapter
 ```
 
 **Merge rules:**
-- Explicit fields on the tool/operation **override** inherited fields from the function.
-- Fields not set on the tool/operation are **inherited** from the function.
-- `name` and `description` are optional when using `ref` — they default to the function's values.
+- Explicit fields on the tool/operation **override** inherited fields from the flow.
+- Fields not set on the tool/operation are **inherited** from the flow.
+- `name` and `description` are optional when using `ref` — they default to the flow's values.
 
 ### Q: How do semantics map to MCP tool hints?
 **A:** Aggregate flows can declare transport-neutral **semantics** (`safe`, `idempotent`, `cacheable`). When exposed as MCP tools, the engine automatically derives [MCP tool hints](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#tool-annotations):

--- a/ikanos-docs/wiki/FAQ.md
+++ b/ikanos-docs/wiki/FAQ.md
@@ -1,4 +1,4 @@
-﻿Welcome to the Ikanos FAQ! This guide answers common questions from developers who are learning, using, and contributing to Ikanos. For comprehensive technical details, see the [Specification - Schema](https://github.com/naftiko/ikanos/wiki/Specification-Schema) and [Specification - Rules](https://github.com/naftiko/ikanos/wiki/Specification-Rules).
+Welcome to the Ikanos FAQ! This guide answers common questions from developers who are learning, using, and contributing to Ikanos. For comprehensive technical details, see the [Specification - Schema](https://github.com/naftiko/ikanos/wiki/Specification-Schema) and [Specification - Rules](https://github.com/naftiko/ikanos/wiki/Specification-Rules).
 
 ---
 

--- a/ikanos-docs/wiki/FAQ.md
+++ b/ikanos-docs/wiki/FAQ.md
@@ -1,4 +1,4 @@
-Welcome to the Ikanos FAQ! This guide answers common questions from developers who are learning, using, and contributing to Ikanos. For comprehensive technical details, see the [Specification - Schema](https://github.com/naftiko/ikanos/wiki/Specification-Schema) and [Specification - Rules](https://github.com/naftiko/ikanos/wiki/Specification-Rules).
+﻿Welcome to the Ikanos FAQ! This guide answers common questions from developers who are learning, using, and contributing to Ikanos. For comprehensive technical details, see the [Specification - Schema](https://github.com/naftiko/ikanos/wiki/Specification-Schema) and [Specification - Rules](https://github.com/naftiko/ikanos/wiki/Specification-Rules).
 
 ---
 
@@ -186,7 +186,7 @@ capability:
   aggregates:
     - label: Weather Forecast
       namespace: forecast
-      functions:
+      flows:
         - name: get-forecast
           description: Retrieve weather forecast for a city
           semantics:
@@ -202,8 +202,8 @@ capability:
               mapping: $.forecast
 ```
 
-### Q: How does `ref` work to reference an aggregate function?
-**A:** MCP tools and REST operations can reference an aggregate function using `ref: {namespace}.{function-name}`. The engine merges inherited fields from the function — you only specify what's different at the adapter level.
+### Q: How does `ref` work to reference an aggregate flow?
+**A:** MCP tools and REST operations can reference an aggregate flow using `ref: {namespace}.{function-name}`. The engine merges inherited fields from the function — you only specify what's different at the adapter level.
 
 ```yaml
 exposes:
@@ -227,7 +227,7 @@ exposes:
 - `name` and `description` are optional when using `ref` — they default to the function's values.
 
 ### Q: How do semantics map to MCP tool hints?
-**A:** Aggregate functions can declare transport-neutral **semantics** (`safe`, `idempotent`, `cacheable`). When exposed as MCP tools, the engine automatically derives [MCP tool hints](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#tool-annotations):
+**A:** aggregate flows can declare transport-neutral **semantics** (`safe`, `idempotent`, `cacheable`). When exposed as MCP tools, the engine automatically derives [MCP tool hints](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#tool-annotations):
 
 | Semantics | MCP Hint | Rule |
 |-----------|----------|------|

--- a/ikanos-docs/wiki/Guide-‐-Linting.md
+++ b/ikanos-docs/wiki/Guide-‐-Linting.md
@@ -1,4 +1,4 @@
-# Guide - Linting
+﻿# Guide - Linting
 
 ## Table of Contents
 
@@ -280,7 +280,7 @@ rules:
 
 ### Adding Custom Functions
 
-For advanced validation logic (like the built-in `unique-namespaces` function), you can write custom JavaScript functions:
+For advanced validation logic (like the built-in `unique-namespaces` function), you can write custom JavaScript flows:
 
 1. Create a `functions/` directory next to your `.spectral.yaml`:
 
@@ -321,7 +321,7 @@ extends:
 
 functionsDir: ./functions
 
-functions:
+flows:
   - check-binds-location-scheme
 
 rules:
@@ -346,7 +346,7 @@ extends:
 
 functionsDir: ./functions
 
-functions:
+flows:
   - check-binds-location-scheme
 
 rules:

--- a/ikanos-docs/wiki/Guide-‐-Linting.md
+++ b/ikanos-docs/wiki/Guide-‐-Linting.md
@@ -323,6 +323,16 @@ functionsDir: ./functions
 
 functions:
   - check-binds-location-scheme
+
+rules:
+  my-org-binds-location-scheme:
+    message: "Bind locations must use an approved URI scheme."
+    severity: error
+    given:
+      - "$.binds[*].location"
+      - "$.capability.binds[*].location"
+    then:
+      function: check-binds-location-scheme
 ```
 
 ### Full Example

--- a/ikanos-docs/wiki/Guide-‐-Linting.md
+++ b/ikanos-docs/wiki/Guide-‐-Linting.md
@@ -1,4 +1,4 @@
-﻿# Guide - Linting
+# Guide - Linting
 
 ## Table of Contents
 

--- a/ikanos-docs/wiki/Guide-‐-Linting.md
+++ b/ikanos-docs/wiki/Guide-‐-Linting.md
@@ -280,7 +280,7 @@ rules:
 
 ### Adding Custom Functions
 
-For advanced validation logic (like the built-in `unique-namespaces` function), you can write custom JavaScript flows:
+For advanced validation logic (like the built-in `unique-namespaces` function), you can write custom JavaScript functions:
 
 1. Create a `functions/` directory next to your `.spectral.yaml`:
 
@@ -321,18 +321,8 @@ extends:
 
 functionsDir: ./functions
 
-flows:
+functions:
   - check-binds-location-scheme
-
-rules:
-  my-org-binds-location-scheme:
-    message: "Bind locations must use an approved URI scheme."
-    severity: error
-    given:
-      - "$.binds[*].location"
-      - "$.capability.binds[*].location"
-    then:
-      function: check-binds-location-scheme
 ```
 
 ### Full Example
@@ -346,7 +336,7 @@ extends:
 
 functionsDir: ./functions
 
-flows:
+functions:
   - check-binds-location-scheme
 
 rules:

--- a/ikanos-docs/wiki/Guide-‐-Use-Cases.md
+++ b/ikanos-docs/wiki/Guide-‐-Use-Cases.md
@@ -1,4 +1,4 @@
-﻿# Guide - Use Cases
+# Guide - Use Cases
 
 Here is an overview of typical use cases where Ikanos can help developers and supporting features available. Additional features are being added as described in the [roadmap](https://github.com/naftiko/ikanos/wiki/Roadmap).
 

--- a/ikanos-docs/wiki/Guide-‐-Use-Cases.md
+++ b/ikanos-docs/wiki/Guide-‐-Use-Cases.md
@@ -1,4 +1,4 @@
-# Guide - Use Cases
+﻿# Guide - Use Cases
 
 Here is an overview of typical use cases where Ikanos can help developers and supporting features available. Additional features are being added as described in the [roadmap](https://github.com/naftiko/ikanos/wiki/Roadmap).
 
@@ -56,7 +56,7 @@ Wrap a current API as a capability to make it easier to discover, reuse, and con
 How Ikanos achieves this technically:
 - Model the legacy/existing API once in `consumes.resources.operations` with explicit methods, paths, parameters, and body formats.
 - Add a stable capability namespace and expose curated resource paths/tools that are easier to consume than vendor-native endpoints.
-- Reshape not just data but also operation semantics: declare `semantics` (safe, idempotent, cacheable) on aggregate functions so the engine derives correct HTTP methods for REST adapters and `hints` for MCP tools automatically.
+- Reshape not just data but also operation semantics: declare `semantics` (safe, idempotent, cacheable) on aggregate flows so the engine derives correct HTTP methods for REST adapters and `hints` for MCP tools automatically.
 - Enforce schema-based validation (`capability-schema.json`) so the elevated contract remains consistent and machine-checkable.
 
 ![Elevate existing APIs](https://Ikanos.github.io/docs/images/technology/use_case_api_reusability_elevate_existing_apis.png)

--- a/ikanos-docs/wiki/Specification-‐-Schema.md
+++ b/ikanos-docs/wiki/Specification-‐-Schema.md
@@ -1,4 +1,4 @@
-# Ikanos Specification - Schema
+﻿# Ikanos Specification - Schema
 
 **Version:** {{RELEASE_TAG}}
 
@@ -320,7 +320,7 @@ Transport-neutral behavioral metadata for an invocable unit. These properties de
 
 #### 3.4.5.3 Semantics-to-Hints Derivation
 
-When an MCP tool references an aggregate function via `ref`, the function's `semantics` are automatically derived into MCP `hints` (`McpToolHints`). Explicit `hints` on the MCP tool override derived values field by field.
+When an MCP tool references an aggregate flow via `ref`, the function's `semantics` are automatically derived into MCP `hints` (`McpToolHints`). Explicit `hints` on the MCP tool override derived values field by field.
 
 **Mapping table:**
 
@@ -341,7 +341,7 @@ capability:
   aggregates:
     - display: "Forecast"
       namespace: "forecast"
-      functions:
+      flows:
         - name: "get-forecast"
           description: "Fetch current weather forecast for a location."
           semantics:
@@ -503,7 +503,7 @@ Capability groups not declared in the configuration are omitted from the `initia
 
 An MCP tool definition. Each tool maps to one or more consumed HTTP operations, similar to ExposedOperation but adapted for the MCP protocol (no HTTP method, tool-oriented input schema).
 
-> The McpTool supports the same two modes as ExposedOperation: **simple** (direct `call` + `with`) and **orchestrated** (multi-step with `steps` + `mappings`). Additionally, a tool can use **`ref`** to reference an aggregate function, inheriting its fields.
+> The McpTool supports the same two modes as ExposedOperation: **simple** (direct `call` + `with`) and **orchestrated** (multi-step with `steps` + `mappings`). Additionally, a tool can use **`ref`** to reference an aggregate flow, inheriting its fields.
 > 
 
 **Fixed Fields:**
@@ -514,7 +514,7 @@ An MCP tool definition. Each tool maps to one or more consumed HTTP operations, 
 | **display** | `string` | Human-readable display name for the tool. Mapped to MCP `title` in protocol responses. |
 | **tags** | `string[]` | Arbitrary string tags for filtering and discovery. |
 | **description** | `string` | A meaningful description of the tool. Essential for agent discovery. **REQUIRED** unless `ref` is used (inherited from function). |
-| **ref** | `string` | Reference to an aggregate function. Format: `{aggregate-namespace}.{function-name}`. Inherited fields are merged; explicit fields override. See [3.4.5 Aggregate Object](#345-aggregate-object). |
+| **ref** | `string` | Reference to an aggregate flow. Format: `{aggregate-namespace}.{function-name}`. Inherited fields are merged; explicit fields override. See [3.4.5 Aggregate Object](#345-aggregate-object). |
 | **hints** | `McpToolHints` | Optional behavioral hints for MCP clients. Mapped to `ToolAnnotations` in the MCP protocol. When `ref` is used, hints are automatically derived from the function's `semantics`; explicit values override derived ones. See [3.5.5.1 McpToolHints Object](#3551-mctoolhints-object). |
 | **inputParameters** | `McpToolInputParameter[]` | Tool input parameters. These become the MCP tool's input schema (JSON Schema). |
 | **call** | `string` | **Simple mode only**. Reference to a consumed operation. Format: `{namespace}.{operationId}`. MUST match pattern `^[a-zA-Z0-9-]+\.[a-zA-Z0-9-]+$`. |
@@ -540,7 +540,7 @@ An MCP tool definition. Each tool maps to one or more consumed HTTP operations, 
 - `outputParameters` are `OrchestratedOutputParameter[]`
 - `call` and `with` MUST NOT be present
 
-**Ref mode** — reference to an aggregate function:
+**Ref mode** — reference to an aggregate flow:
 
 - `ref` is **REQUIRED**
 - All other fields are optional — inherited from the referenced function
@@ -1334,7 +1334,7 @@ Describes an operation exposed on an exposed resource.
 
 > Update (schema v0.5): ExposesObject now supports two modes via `oneOf` — **simple** (direct call with mapped output) and **orchestrated** (multi-step with named operation). The `call` and `with` fields are new. The `name` and `steps` fields are only required in orchestrated mode.
 >
-> Update (schema v1.0.0-alpha1): A third **ref mode** allows referencing an aggregate function, inheriting its fields. See [3.4.5 Aggregate Object](#345-aggregate-object).
+> Update (schema v1.0.0-alpha1): A third **ref mode** allows referencing an aggregate flow, inheriting its fields. See [3.4.5 Aggregate Object](#345-aggregate-object).
 > 
 
 #### 3.9.1 Fixed Fields
@@ -1347,7 +1347,7 @@ All fields available on ExposesObject:
 | **name** | `string` | Technical name for the operation (pattern `^[a-zA-Z0-9-]+$`). **REQUIRED in orchestrated mode.** Optional when `ref` is used (inherited from function). |
 | **display** | `string` | Display name for the operation (likely used in UIs). |
 | **description** | `string` | A longer description of the operation. Useful for agent discovery and documentation. Optional when `ref` is used (inherited from function). |
-| **ref** | `string` | Reference to an aggregate function. Format: `{aggregate-namespace}.{function-name}`. Inherited fields are merged; explicit fields override. See [3.4.5 Aggregate Object](#345-aggregate-object). |
+| **ref** | `string` | Reference to an aggregate flow. Format: `{aggregate-namespace}.{function-name}`. Inherited fields are merged; explicit fields override. See [3.4.5 Aggregate Object](#345-aggregate-object). |
 | **inputParameters** | `ExposedInputParameter[]` | Input parameters attached to the operation. |
 | **call** | `string` | **Simple mode only**. Direct reference to a consumed operation. Format: `{namespace}.{operationId}`. MUST match pattern `^[a-zA-Z0-9-]+\.[a-zA-Z0-9-]+$`. |
 | **with** | `WithInjector` | **Simple mode only**. Parameter injection for the called operation. |
@@ -1374,7 +1374,7 @@ All fields available on ExposesObject:
 - `outputParameters` are `OrchestratedOutputParameter[]` (name + type)
 - `call` and `with` MUST NOT be present
 
-**Ref mode** — reference to an aggregate function:
+**Ref mode** — reference to an aggregate flow:
 
 - `ref` is **REQUIRED**
 - `method` is still **REQUIRED** (transport-specific)
@@ -1387,7 +1387,7 @@ All fields available on ExposesObject:
 - Exactly one of the three modes MUST be used (simple, orchestrated, or ref).
 - In simple mode, `call` MUST follow the format `{namespace}.{operationId}` and reference a valid consumed operation.
 - In orchestrated mode, the `steps` array MUST contain at least one entry. Each step references a consumed operation using `{namespace}.{operationName}`.
-- In ref mode, `ref` MUST resolve to an existing aggregate function at capability load time.
+- In ref mode, `ref` MUST resolve to an existing aggregate flow at capability load time.
 - The `method` field is always required regardless of mode.
 
 #### 3.9.4 ExposesObject Examples

--- a/ikanos-docs/wiki/Specification-‐-Schema.md
+++ b/ikanos-docs/wiki/Specification-‐-Schema.md
@@ -1,4 +1,4 @@
-# Ikanos Specification - Schema
+﻿# Ikanos Specification - Schema
 
 **Version:** {{RELEASE_TAG}}
 
@@ -114,7 +114,7 @@ Provides metadata about the capability.
 
 | Field Name | Type | Description |
 | --- | --- | --- |
-| **label** | `string` | **REQUIRED**. The display name of the capability. |
+| **display** | `string` | **REQUIRED**. The display name of the capability. |
 | **description** | `string` | *Recommended*. A description of the capability. The more meaningful it is, the easier for agent discovery. |
 | **tags** | `string[]` | List of tags to help categorize the capability for discovery and filtering. |
 | **created** | `string` | Date the capability was created (format: `YYYY-MM-DD`). |
@@ -123,14 +123,14 @@ Provides metadata about the capability.
 
 #### 3.2.2 Rules
 
-- The `label` field is mandatory. The `description` field is recommended to improve agent discovery.
+- The `display` field is mandatory. The `description` field is recommended to improve agent discovery.
 - No additional properties are allowed.
 
 #### 3.2.3 Info Object Example
 
 ```yaml
 info:
-  label: Notion Page Creator
+  display: Notion Page Creator
   description: Creates and manages Notion pages with rich content formatting
   tags:
     - notion
@@ -218,7 +218,7 @@ capability:
           description: "Endpoint to create tasks via the external API"
           operations:
             - method: POST
-              label: Create Task
+              display: Create Task
               call: api.create-task
               outputParameters:
                 - type: string
@@ -229,11 +229,11 @@ capability:
       baseUri: https://api.example.com
       resources:
         - name: tasks
-          label: Tasks API
+          display: Tasks API
           path: /tasks
           operations:
             - name: create-task
-              label: Create Task
+              display: Create Task
               method: POST
               inputParameters:
                 - name: task_id
@@ -248,7 +248,7 @@ capability:
 
 ### 3.4.5 Aggregate Object
 
-A domain aggregate in the sense of [Domain-Driven Design (DDD)](https://en.wikipedia.org/wiki/Domain-driven_design#Building_blocks). Each aggregate groups reusable **functions** — transport-neutral invocable units that adapters reference via `ref`. This factorizes domain behavior so it is defined once and reused across REST, MCP, Skill, and future adapters without duplication.
+A domain aggregate in the sense of [Domain-Driven Design (DDD)](https://en.wikipedia.org/wiki/Domain-driven-design#Building_blocks). Each aggregate groups reusable **functions** — transport-neutral invocable units that adapters reference via `ref`. This factorizes domain behavior so it is defined once and reused across REST, MCP, Skill, and future adapters without duplication.
 
 > New in schema v1.0.0-alpha1.
 
@@ -256,7 +256,7 @@ A domain aggregate in the sense of [Domain-Driven Design (DDD)](https://en.wikip
 
 | Field Name | Type | Description |
 | --- | --- | --- |
-| **label** | `string` | **REQUIRED**. Human-readable name for this aggregate (e.g. `"Forecast"`). |
+| **display** | `string` | **REQUIRED**. Human-readable name for this aggregate (e.g. `"Forecast"`). |
 | **namespace** | `string` | **REQUIRED**. Machine-readable qualifier (`IdentifierKebab`). Used as the first segment in `ref` values (`{aggregate-namespace}.{function-name}`). |
 | **functions** | `AggregateFunction[]` | **REQUIRED**. Reusable invocable units within this aggregate (minimum 1). |
 
@@ -276,6 +276,7 @@ A reusable invocable unit within an aggregate. Adapter units (MCP tools, REST op
 | --- | --- | --- |
 | **name** | `string` | **REQUIRED**. Function name (`IdentifierKebab`). Combined with aggregate namespace to form the ref target. |
 | **description** | `string` | **REQUIRED**. A meaningful description of the function. Inherited by adapter units that omit their own. |
+| **tags** | `string[]` | Arbitrary string tags for filtering and discovery. |
 | **semantics** | `Semantics` | Transport-neutral behavioral metadata. Automatically derived into adapter-specific metadata (e.g. MCP hints). See [3.4.5.2 Semantics Object](#3452-semantics-object). |
 | **inputParameters** | `McpToolInputParameter[]` | Input parameters for this function. |
 | **call** | `string` | **Simple mode**. Reference to consumed operation (`{namespace}.{operationId}`). |
@@ -338,7 +339,7 @@ When an MCP tool references an aggregate function via `ref`, the function's `sem
 ```yaml
 capability:
   aggregates:
-    - label: "Forecast"
+    - display: "Forecast"
       namespace: "forecast"
       functions:
         - name: "get-forecast"
@@ -441,7 +442,8 @@ An exposed resource with **operations** and/or **forward** configuration.
 | **path** | `string` | **REQUIRED**. Path of the resource (supports `param` placeholders). |
 | **description** | `string` | *Recommended*. Used to provide *meaningful* information about the resource. In a world of agents, context is king. |
 | **name** | `string` | Technical name for the resource (used for references, pattern `^[a-zA-Z0-9-]+$`). |
-| **label** | `string` | Display name for the resource (likely used in UIs). |
+| **display** | `string` | Display name for the resource (likely used in UIs). |
+| **tags** | `string[]` | Arbitrary string tags for filtering and discovery. |
 | **inputParameters** | `ExposedInputParameter[]` | Input parameters attached to the resource. |
 | **operations** | `ExposedOperation[]` | Operations available on this resource. |
 | **forward** | `ForwardConfig` | Forwarding configuration to a consumed namespace. |
@@ -509,7 +511,8 @@ An MCP tool definition. Each tool maps to one or more consumed HTTP operations, 
 | Field Name | Type | Description |
 | --- | --- | --- |
 | **name** | `string` | Technical name for the tool. Used as the MCP tool name. MUST match pattern `^[a-zA-Z0-9-]+$`. **REQUIRED** unless `ref` is used (inherited from function). |
-| **label** | `string` | Human-readable display name for the tool. Mapped to MCP `title` in protocol responses. |
+| **display** | `string` | Human-readable display name for the tool. Mapped to MCP `title` in protocol responses. |
+| **tags** | `string[]` | Arbitrary string tags for filtering and discovery. |
 | **description** | `string` | A meaningful description of the tool. Essential for agent discovery. **REQUIRED** unless `ref` is used (inherited from function). |
 | **ref** | `string` | Reference to an aggregate function. Format: `{aggregate-namespace}.{function-name}`. Inherited fields are merged; explicit fields override. See [3.4.5 Aggregate Object](#345-aggregate-object). |
 | **hints** | `McpToolHints` | Optional behavioral hints for MCP clients. Mapped to `ToolAnnotations` in the MCP protocol. When `ref` is used, hints are automatically derived from the function's `semantics`; explicit values override derived ones. See [3.5.5.1 McpToolHints Object](#3551-mctoolhints-object). |
@@ -632,7 +635,7 @@ An MCP resource definition. Resources expose data that agents can **read** (but 
 | Field Name | Type | Description |
 | --- | --- | --- |
 | **name** | `string` | **REQUIRED**. Technical name for the resource. MUST match pattern `^[a-zA-Z0-9-]+$`. |
-| **label** | `string` | Human-readable display name. Mapped to MCP `title` in protocol responses. |
+| **display** | `string` | Human-readable display name. Mapped to MCP `title` in protocol responses. |
 | **uri** | `string` | **REQUIRED**. The URI that identifies this resource in MCP. Can use any scheme (e.g. `config://app/current`, `docs://api/reference`). For resource templates, use `{param}` placeholders. |
 | **description** | `string` | *Recommended*. A meaningful description of the resource. In a world of agents, context is king. |
 | **mimeType** | `string` | MIME type of the resource content per RFC 6838 (e.g. `application/json`, `text/markdown`). Optional parameters are supported (e.g. `charset=utf-8`). |
@@ -673,7 +676,7 @@ An MCP resource definition. Resources expose data that agents can **read** (but 
 # Dynamic resource (simple mode)
 resources:
   - name: current-config
-    label: Current Configuration
+    display: Current Configuration
     uri: config://app/current
     description: "Current application configuration"
     mimeType: application/json
@@ -682,7 +685,7 @@ resources:
 # Dynamic resource (orchestrated mode)
 resources:
   - name: user-summary
-    label: User Summary
+    display: User Summary
     uri: data://users/summary
     description: "Aggregated user summary from multiple API calls"
     mimeType: application/json
@@ -702,7 +705,7 @@ resources:
 # Static resource (local files)
 resources:
   - name: api-docs
-    label: API Documentation
+    display: API Documentation
     uri: docs://api/reference
     description: "API reference documentation served from local markdown files"
     mimeType: text/markdown
@@ -723,7 +726,7 @@ An MCP prompt template definition. Prompts provide reusable, parameterized messa
 | Field Name | Type | Description |
 | --- | --- | --- |
 | **name** | `string` | **REQUIRED**. Technical name for the prompt. Used as the MCP prompt name. MUST match pattern `^[a-zA-Z0-9-]+$`. |
-| **label** | `string` | Human-readable display name. Mapped to MCP `title` in protocol responses. |
+| **display** | `string` | Human-readable display name. Mapped to MCP `title` in protocol responses. |
 | **description** | `string` | *Recommended*. A meaningful description of the prompt's purpose. Essential for agent discovery. |
 | **arguments** | `McpPromptArgument[]` | List of arguments accepted by this prompt template. These become the prompt's input schema. |
 | **messages** | `McpPromptMessage[]` | **REQUIRED**. List of messages that form the prompt template (minimum 1). Each message defines a role and its content. |
@@ -780,7 +783,7 @@ Defines a single message in the prompt template. Messages can be static (inline 
 ```yaml
 prompts:
   - name: code-review
-    label: Code Review Request
+    display: Code Review Request
     description: "Generates a structured code review prompt for a given pull request"
     arguments:
       - name: pr_title
@@ -831,7 +834,7 @@ A named skill that groups one or more MCP tools.
 | Field Name | Type | Description |
 | --- | --- | --- |
 | **name** | `string` | **REQUIRED**. Technical name for the skill. MUST match pattern `^[a-zA-Z0-9-]+$`. |
-| **label** | `string` | Human-readable display name for the skill. |
+| **display** | `string` | Human-readable display name for the skill. |
 | **description** | `string` | *Recommended*. A meaningful description of the skill's purpose. Essential for agent discovery. |
 | **tools** | `SkillTool[]` | **REQUIRED**. List of MCP tools included in this skill (minimum 1). |
 
@@ -882,7 +885,7 @@ namespace: my-skills
 description: "Skill-based interface grouping Notion tools by domain"
 skills:
   - name: database-ops
-    label: Database Operations
+    display: Database Operations
     description: "Skills for reading and querying Notion databases"
     tools:
       - name: get-database
@@ -890,7 +893,7 @@ skills:
         from:
           namespace: notion-tools
   - name: page-ops
-    label: Page Operations
+    display: Page Operations
     description: "Skills for creating and retrieving Notion pages"
     tools:
       - name: create-page
@@ -1200,11 +1203,11 @@ inputParameters:
     value: "application/vnd.github.v3+json"
 resources:
   - name: users
-    label: Users API
+    display: Users API
     path: /users/{username}
     operations:
       - name: get-user
-        label: Get User
+        display: Get User
         method: GET
         inputParameters:
           - name: username
@@ -1214,11 +1217,11 @@ resources:
             type: string
             value: $.id
   - name: repos
-    label: Repositories API
+    display: Repositories API
     path: /users/{username}/repos
     operations:
       - name: list-repos
-        label: List Repositories
+        display: List Repositories
         method: GET
         inputParameters:
           - name: username
@@ -1240,7 +1243,8 @@ Describes an API resource that can be consumed from an external API.
 | Field Name | Type | Description |
 | --- | --- | --- |
 | **name** | `string` | **REQUIRED**. Technical name for the resource. MUST match pattern `^[a-zA-Z0-9-]+$`. |
-| **label** | `string` | Display name of the resource. |
+| **display** | `string` | Display name of the resource. |
+| **tags** | `string[]` | Arbitrary string tags for filtering and discovery. |
 | **description** | `string` | Description of the resource. |
 | **path** | `string` | **REQUIRED**. Path of the resource, relative to the consumes `baseUri`. |
 | **inputParameters** | `ConsumedInputParameter[]` | Input parameters for this resource. |
@@ -1258,14 +1262,14 @@ Describes an API resource that can be consumed from an external API.
 
 ```yaml
 name: users
-label: Users API
+display: Users API
 path: /users/{username}
 inputParameters:
   - name: username
     in: path
 operations:
   - name: get-user
-    label: Get User
+    display: Get User
     method: GET
     outputParameters:
       - name: userId
@@ -1284,7 +1288,8 @@ Describes an operation that can be performed on a consumed resource.
 | Field Name | Type | Description |
 | --- | --- | --- |
 | **name** | `string` | **REQUIRED**. Technical name for the operation. MUST match pattern `^[a-zA-Z0-9-]+$`. |
-| **label** | `string` | Display name of the operation. |
+| **display** | `string` | Display name of the operation. |
+| **tags** | `string[]` | Arbitrary string tags for filtering and discovery. |
 | **description** | `string` | A longer description of the operation for documentation purposes. |
 | **method** | `string` | **REQUIRED**. HTTP method. One of: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`. Default: `GET`. |
 | **inputParameters** | `ConsumedInputParameter[]` | Input parameters for the operation. |
@@ -1304,7 +1309,7 @@ Describes an operation that can be performed on a consumed resource.
 
 ```yaml
 name: get-user
-label: Get User Profile
+display: Get User Profile
 method: GET
 inputParameters:
   - name: username
@@ -1340,7 +1345,7 @@ All fields available on ExposesObject:
 | --- | --- | --- |
 | **method** | `string` | **REQUIRED**. HTTP method. One of: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`. |
 | **name** | `string` | Technical name for the operation (pattern `^[a-zA-Z0-9-]+$`). **REQUIRED in orchestrated mode.** Optional when `ref` is used (inherited from function). |
-| **label** | `string` | Display name for the operation (likely used in UIs). |
+| **display** | `string` | Display name for the operation (likely used in UIs). |
 | **description** | `string` | A longer description of the operation. Useful for agent discovery and documentation. Optional when `ref` is used (inherited from function). |
 | **ref** | `string` | Reference to an aggregate function. Format: `{aggregate-namespace}.{function-name}`. Inherited fields are merged; explicit fields override. See [3.4.5 Aggregate Object](#345-aggregate-object). |
 | **inputParameters** | `ExposedInputParameter[]` | Input parameters attached to the operation. |
@@ -1391,7 +1396,7 @@ All fields available on ExposesObject:
 
 ```yaml
 method: GET
-label: Get User Profile
+display: Get User Profile
 call: github.get-user
 with:
   username: sample.username
@@ -1407,7 +1412,7 @@ outputParameters:
 ```yaml
 name: get-db
 method: GET
-label: Get Database
+display: Get Database
 inputParameters:
   - name: database_id
     in: path
@@ -2023,7 +2028,7 @@ exposes:
     resources:
       - path: "/databases/{database_id}"
         name: "db"
-        label: "Database resource"
+        display: "Database resource"
         description: "Retrieve information about a Notion database"
         inputParameters:
           - name: "database_id"
@@ -2033,7 +2038,7 @@ exposes:
         operations:
           - name: "get-db"
             method: "GET"
-            label: "Get Database"
+            display: "Get Database"
             outputParameters:
               - name: "db_name"
                 type: "string"
@@ -2427,7 +2432,7 @@ The simplest capability: forward incoming requests to a consumed API without any
 ---
 ikanos: "0.5"
 info:
-  label: "Notion Proxy"
+  display: "Notion Proxy"
   description: "Pass-through proxy to the Notion API for development and debugging"
   tags:
     - proxy
@@ -2474,7 +2479,7 @@ binds:
     keys:
       GITHUB_TOKEN: "GITHUB_TOKEN"
 info:
-  label: "GitHub User Lookup"
+  display: "GitHub User Lookup"
   description: "Exposes a simplified endpoint to retrieve GitHub user profiles"
   tags:
     - github
@@ -2498,7 +2503,7 @@ capability:
               description: "The GitHub username to look up"
           operations:
             - method: "GET"
-              label: "Get User"
+              display: "Get User"
               call: "github.get-user"
               with:
                 username: "app.username"
@@ -2521,10 +2526,10 @@ capability:
       resources:
         - name: "users"
           path: "/users/{username}"
-          label: "Users"
+          display: "Users"
           operations:
             - name: "get-user"
-              label: "Get User"
+              display: "Get User"
               method: "GET"
               inputParameters:
                 - name: "username"
@@ -2553,7 +2558,7 @@ binds:
     keys:
       NOTION_TOKEN: "NOTION_TOKEN"
 info:
-  label: "Database Inspector"
+  display: "Database Inspector"
   description: "Retrieves a Notion database then queries its contents in a single exposed operation"
   tags:
     - notion
@@ -2578,7 +2583,7 @@ capability:
           operations:
             - name: "get-summary"
               method: "GET"
-              label: "Get Database Summary"
+              display: "Get Database Summary"
               steps:
                 - type: "call"
                   name: "fetch-db"
@@ -2616,10 +2621,10 @@ capability:
       resources:
         - name: "databases"
           path: "/databases/{{database_id}}"
-          label: "Databases"
+          display: "Databases"
           operations:
             - name: "get-database"
-              label: "Get Database"
+              display: "Get Database"
               method: "GET"
               inputParameters:
                 - name: "database_id"
@@ -2633,10 +2638,10 @@ capability:
                   value: "{{$.id}}"
         - name: "queries"
           path: "/databases/{{database_id}}/query"
-          label: "Database queries"
+          display: "Database queries"
           operations:
             - name: "query-database"
-              label: "Query Database"
+              display: "Query Database"
               method: "POST"
               inputParameters:
                 - name: "database_id"
@@ -2662,7 +2667,7 @@ binds:
     keys:
       HR_API_KEY: "HR_API_KEY"
 info:
-  label: "Team Member Resolver"
+  display: "Team Member Resolver"
   description: "Resolves team member details by matching email addresses from a project tracker"
   tags:
     - hr
@@ -2687,7 +2692,7 @@ capability:
           operations:
             - name: "resolve-member"
               method: "GET"
-              label: "Resolve Team Member"
+              display: "Resolve Team Member"
               steps:
                 - type: "call"
                   name: "list-members"
@@ -2729,10 +2734,10 @@ capability:
       resources:
         - name: "employees"
           path: "/employees"
-          label: "Employees"
+          display: "Employees"
           operations:
             - name: "list-employees"
-              label: "List All Employees"
+              display: "List All Employees"
               method: "GET"
               outputParameters:
                 - name: "email"
@@ -2762,7 +2767,7 @@ binds:
       NOTION_TOKEN: "NOTION_TOKEN"
       GITHUB_TOKEN: "GITHUB_TOKEN"
 info:
-  label: "Project Dashboard"
+  display: "Project Dashboard"
   description: "Aggregates project data from Notion and GitHub into a unified API, with a pass-through proxy for direct access"
   tags:
     - dashboard
@@ -2807,7 +2812,7 @@ capability:
               description: "Repository name"
           operations:
             - method: "GET"
-              label: "Get Repository"
+              display: "Get Repository"
               call: "github.get-repo"
               with:
                 owner: "dashboard.owner"
@@ -2832,7 +2837,7 @@ capability:
           operations:
             - name: "list-contributors"
               method: "GET"
-              label: "List Project Contributors"
+              display: "List Project Contributors"
               steps:
                 - type: "call"
                   name: "query-tasks"
@@ -2884,10 +2889,10 @@ capability:
       resources:
         - name: "db-query"
           path: "/databases/{database_id}/query"
-          label: "Database Query"
+          display: "Database Query"
           operations:
             - name: "query-database"
-              label: "Query Database"
+              display: "Query Database"
               method: "POST"
               inputParameters:
                 - name: "database_id"
@@ -2910,10 +2915,10 @@ capability:
       resources:
         - name: "repos"
           path: "/repos/{owner}/{repo}"
-          label: "Repositories"
+          display: "Repositories"
           operations:
             - name: "get-repo"
-              label: "Get Repository"
+              display: "Get Repository"
               method: "GET"
               inputParameters:
                 - name: "owner"
@@ -2932,10 +2937,10 @@ capability:
                   value: "$.language"
         - name: "org-members"
           path: "/orgs/{org}/members"
-          label: "Organization Members"
+          display: "Organization Members"
           operations:
             - name: "list-org-members"
-              label: "List Organization Members"
+              display: "List Organization Members"
               method: "GET"
               inputParameters:
                 - name: "org"
@@ -2966,7 +2971,7 @@ binds:
     keys:
       NOTION_TOKEN: "NOTION_TOKEN"
 info:
-  label: "Notion MCP Tools"
+  display: "Notion MCP Tools"
   description: "Exposes Notion database retrieval as an MCP tool"
 
 capability:

--- a/ikanos-docs/wiki/Specification-‐-Schema.md
+++ b/ikanos-docs/wiki/Specification-‐-Schema.md
@@ -183,7 +183,7 @@ Defines the technical configuration of the capability.
 | **exposes** | `Exposes[]` | List of exposed server adapters. Each entry is a REST Expose (`type: "rest"`), an MCP Expose (`type: "mcp"`), a Skill Expose (`type: "skill"`), or a Control Expose (`type: "control"`). |
 | **consumes** | `Consumes[]`  | List of consumed client adapters. |
 | **binds** | `Bind[]` | List of external bindings for variable injection. Each entry declares injected variables via a `keys` map. |
-| **aggregates** | `Aggregate[]` | Domain aggregates defining reusable functions. Adapter units (tools, operations) reference them via `ref`. See [3.4.5 Aggregate Object](#345-aggregate-object). |
+| **aggregates** | `Aggregate[]` | Domain aggregates defining reusable flows. Adapter units (tools, operations) reference them via `ref`. See [3.4.5 Aggregate Object](#345-aggregate-object). |
 
 
 #### 3.4.2 Rules
@@ -248,7 +248,7 @@ capability:
 
 ### 3.4.5 Aggregate Object
 
-A domain aggregate in the sense of [Domain-Driven Design (DDD)](https://en.wikipedia.org/wiki/Domain-driven-design#Building_blocks). Each aggregate groups reusable **functions** — transport-neutral invocable units that adapters reference via `ref`. This factorizes domain behavior so it is defined once and reused across REST, MCP, Skill, and future adapters without duplication.
+A domain aggregate in the sense of [Domain-Driven Design (DDD)](https://en.wikipedia.org/wiki/Domain-driven-design#Building_blocks). Each aggregate groups reusable **flows** — transport-neutral callable units that adapters reference via `ref`. This factorizes domain behavior so it is defined once and reused across REST, MCP, Skill, and future adapters without duplication.
 
 > New in schema v1.0.0-alpha1.
 
@@ -257,8 +257,8 @@ A domain aggregate in the sense of [Domain-Driven Design (DDD)](https://en.wikip
 | Field Name | Type | Description |
 | --- | --- | --- |
 | **display** | `string` | **REQUIRED**. Human-readable name for this aggregate (e.g. `"Forecast"`). |
-| **namespace** | `string` | **REQUIRED**. Machine-readable qualifier (`IdentifierKebab`). Used as the first segment in `ref` values (`{aggregate-namespace}.{function-name}`). |
-| **functions** | `AggregateFunction[]` | **REQUIRED**. Reusable invocable units within this aggregate (minimum 1). |
+| **namespace** | `string` | **REQUIRED**. Machine-readable qualifier (`IdentifierKebab`). Used as the first segment in `ref` values (`{aggregate-namespace}.{flow-name}`). |
+| **functions** | `AggregateFlow[]` | **REQUIRED**. Reusable callable flows within this aggregate (minimum 1). |
 
 **Rules:**
 
@@ -266,19 +266,19 @@ A domain aggregate in the sense of [Domain-Driven Design (DDD)](https://en.wikip
 - The `namespace` MUST be unique across all aggregates.
 - No additional properties are allowed.
 
-#### 3.4.5.1 AggregateFunction Object
+#### 3.4.5.1 AggregateFlow Object
 
-A reusable invocable unit within an aggregate. Adapter units (MCP tools, REST operations) reference it via `ref: {aggregate-namespace}.{function-name}`. Referenced fields are merged into the adapter unit; adapter-local explicit fields override inherited ones.
+A reusable callable flow within an aggregate. Adapter units (MCP tools, REST operations) reference it via `ref: {aggregate-namespace}.{flow-name}`. Referenced fields are merged into the adapter unit; adapter-local explicit fields override inherited ones.
 
 **Fixed Fields:**
 
 | Field Name | Type | Description |
 | --- | --- | --- |
-| **name** | `string` | **REQUIRED**. Function name (`IdentifierKebab`). Combined with aggregate namespace to form the ref target. |
-| **description** | `string` | **REQUIRED**. A meaningful description of the function. Inherited by adapter units that omit their own. |
+| **name** | `string` | **REQUIRED**. Flow name (`IdentifierKebab`). Combined with aggregate namespace to form the ref target. |
+| **description** | `string` | **REQUIRED**. A meaningful description of the flow. Inherited by adapter units that omit their own. |
 | **tags** | `string[]` | Arbitrary string tags for filtering and discovery. |
 | **semantics** | `Semantics` | Transport-neutral behavioral metadata. Automatically derived into adapter-specific metadata (e.g. MCP hints). See [3.4.5.2 Semantics Object](#3452-semantics-object). |
-| **inputParameters** | `McpToolInputParameter[]` | Input parameters for this function. |
+| **inputParameters** | `McpToolInputParameter[]` | Input parameters for this flow. |
 | **call** | `string` | **Simple mode**. Reference to consumed operation (`{namespace}.{operationId}`). |
 | **with** | `WithInjector` | **Simple mode**. Parameter injection for the called operation. |
 | **steps** | `OperationStep[]` | **Orchestrated mode**. Sequence of calls to consumed operations (minimum 1). |
@@ -297,13 +297,13 @@ Same two modes as McpTool and ExposedOperation:
 
 - `name` and `description` are mandatory.
 - Exactly one mode MUST be used.
-- Function names MUST be unique within an aggregate.
-- No chained refs — a function cannot itself use `ref`.
+- Flow names MUST be unique within an aggregate.
+- No chained refs — a flow cannot itself use `ref`.
 - No additional properties are allowed.
 
 #### 3.4.5.2 Semantics Object
 
-Transport-neutral behavioral metadata for an invocable unit. These properties describe the function's intent independent of any transport protocol. The framework automatically derives adapter-specific metadata from semantics — for example, MCP tool `hints` are derived from `semantics` at capability load time (see [Semantics-to-Hints derivation](#3453-semantics-to-hints-derivation)).
+Transport-neutral behavioral metadata for an invocable unit. These properties describe the flow's intent independent of any transport protocol. The framework automatically derives adapter-specific metadata from semantics — for example, MCP tool `hints` are derived from `semantics` at capability load time (see [Semantics-to-Hints derivation](#3453-semantics-to-hints-derivation)).
 
 **Fixed Fields:**
 
@@ -320,7 +320,7 @@ Transport-neutral behavioral metadata for an invocable unit. These properties de
 
 #### 3.4.5.3 Semantics-to-Hints Derivation
 
-When an MCP tool references an aggregate flow via `ref`, the function's `semantics` are automatically derived into MCP `hints` (`McpToolHints`). Explicit `hints` on the MCP tool override derived values field by field.
+When an MCP tool references an aggregate flow via `ref`, the flow's `semantics` are automatically derived into MCP `hints` (`McpToolHints`). Explicit `hints` on the MCP tool override derived values field by field.
 
 **Mapping table:**
 
@@ -510,12 +510,12 @@ An MCP tool definition. Each tool maps to one or more consumed HTTP operations, 
 
 | Field Name | Type | Description |
 | --- | --- | --- |
-| **name** | `string` | Technical name for the tool. Used as the MCP tool name. MUST match pattern `^[a-zA-Z0-9-]+$`. **REQUIRED** unless `ref` is used (inherited from function). |
+| **name** | `string` | Technical name for the tool. Used as the MCP tool name. MUST match pattern `^[a-zA-Z0-9-]+$`. **REQUIRED** unless `ref` is used (inherited from the flow). |
 | **display** | `string` | Human-readable display name for the tool. Mapped to MCP `title` in protocol responses. |
 | **tags** | `string[]` | Arbitrary string tags for filtering and discovery. |
-| **description** | `string` | A meaningful description of the tool. Essential for agent discovery. **REQUIRED** unless `ref` is used (inherited from function). |
-| **ref** | `string` | Reference to an aggregate flow. Format: `{aggregate-namespace}.{function-name}`. Inherited fields are merged; explicit fields override. See [3.4.5 Aggregate Object](#345-aggregate-object). |
-| **hints** | `McpToolHints` | Optional behavioral hints for MCP clients. Mapped to `ToolAnnotations` in the MCP protocol. When `ref` is used, hints are automatically derived from the function's `semantics`; explicit values override derived ones. See [3.5.5.1 McpToolHints Object](#3551-mctoolhints-object). |
+| **description** | `string` | A meaningful description of the tool. Essential for agent discovery. **REQUIRED** unless `ref` is used (inherited from the flow). |
+| **ref** | `string` | Reference to an aggregate flow. Format: `{aggregate-namespace}.{flow-name}`. Inherited fields are merged; explicit fields override. See [3.4.5 Aggregate Object](#345-aggregate-object). |
+| **hints** | `McpToolHints` | Optional behavioral hints for MCP clients. Mapped to `ToolAnnotations` in the MCP protocol. When `ref` is used, hints are automatically derived from the flow's `semantics`; explicit values override derived ones. See [3.5.5.1 McpToolHints Object](#3551-mctoolhints-object). |
 | **inputParameters** | `McpToolInputParameter[]` | Tool input parameters. These become the MCP tool's input schema (JSON Schema). |
 | **call** | `string` | **Simple mode only**. Reference to a consumed operation. Format: `{namespace}.{operationId}`. MUST match pattern `^[a-zA-Z0-9-]+\.[a-zA-Z0-9-]+$`. |
 | **with** | `WithInjector` | **Simple mode only**. Parameter injection for the called operation. |
@@ -545,13 +545,13 @@ An MCP tool definition. Each tool maps to one or more consumed HTTP operations, 
 - `ref` is **REQUIRED**
 - All other fields are optional — inherited from the referenced function
 - Explicit fields override inherited ones (field-level merge)
-- `hints` are automatically derived from the function's `semantics` (see [3.4.5.3](#3453-semantics-to-hints-derivation))
+- `hints` are automatically derived from the flow's `semantics` (see [3.4.5.3](#3453-semantics-to-hints-derivation))
 
 **Rules:**
 
 - Exactly one mode MUST be used: simple (`call`), orchestrated (`steps`), or ref (`ref`).
 - In simple and orchestrated modes, `name` and `description` are mandatory.
-- In ref mode, `name` and `description` are optional (inherited from the function).
+- In ref mode, `name` and `description` are optional (inherited from the flow).
 - In simple mode, `call` MUST follow the format `{namespace}.{operationId}` and reference a valid consumed operation.
 - In orchestrated mode, the `steps` array MUST contain at least one entry.
 - Input parameters are accessed via namespace-qualified references of the form `{mcpNamespace}.{paramName}`.
@@ -1344,10 +1344,10 @@ All fields available on ExposesObject:
 | Field Name | Type | Description |
 | --- | --- | --- |
 | **method** | `string` | **REQUIRED**. HTTP method. One of: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`. |
-| **name** | `string` | Technical name for the operation (pattern `^[a-zA-Z0-9-]+$`). **REQUIRED in orchestrated mode.** Optional when `ref` is used (inherited from function). |
+| **name** | `string` | Technical name for the operation (pattern `^[a-zA-Z0-9-]+$`). **REQUIRED in orchestrated mode.** Optional when `ref` is used (inherited from the flow). |
 | **display** | `string` | Display name for the operation (likely used in UIs). |
-| **description** | `string` | A longer description of the operation. Useful for agent discovery and documentation. Optional when `ref` is used (inherited from function). |
-| **ref** | `string` | Reference to an aggregate flow. Format: `{aggregate-namespace}.{function-name}`. Inherited fields are merged; explicit fields override. See [3.4.5 Aggregate Object](#345-aggregate-object). |
+| **description** | `string` | A longer description of the operation. Useful for agent discovery and documentation. Optional when `ref` is used (inherited from the flow). |
+| **ref** | `string` | Reference to an aggregate flow. Format: `{aggregate-namespace}.{flow-name}`. Inherited fields are merged; explicit fields override. See [3.4.5 Aggregate Object](#345-aggregate-object). |
 | **inputParameters** | `ExposedInputParameter[]` | Input parameters attached to the operation. |
 | **call** | `string` | **Simple mode only**. Direct reference to a consumed operation. Format: `{namespace}.{operationId}`. MUST match pattern `^[a-zA-Z0-9-]+\.[a-zA-Z0-9-]+$`. |
 | **with** | `WithInjector` | **Simple mode only**. Parameter injection for the called operation. |

--- a/ikanos-docs/wiki/Specification-‐-Schema.md
+++ b/ikanos-docs/wiki/Specification-‐-Schema.md
@@ -1,4 +1,4 @@
-﻿# Ikanos Specification - Schema
+# Ikanos Specification - Schema
 
 **Version:** {{RELEASE_TAG}}
 

--- a/ikanos-docs/wiki/Tutorial-‐-Part-2.md
+++ b/ikanos-docs/wiki/Tutorial-‐-Part-2.md
@@ -1,4 +1,4 @@
-# The Shipyard — Tutorial — Part 2
+﻿# The Shipyard — Tutorial — Part 2
 
 At the end of Part 1, your capability could list, inspect, plan, and enrich. Five tools, two APIs, one contract that survived the journey from mock to production. Good for an MCP client sitting next to the capability. But the Shipyard doesn't live alone: partner agents want a *catalog* they can discover, some logic keeps getting copy-pasted between tools, the operations dashboard speaks REST not MCP, and ops walks in one morning asking for *"one document that has everything."*
 
@@ -73,7 +73,7 @@ Something's starting to smell. Step 7 defined a three-step chain inside `get-shi
 ~~~yaml
 aggregates:
   - namespace: crew-resolver
-    functions:
+    flows:
       - name: resolve-crew-for-ship
         semantics:
           safe: true
@@ -133,7 +133,7 @@ The tool output is byte-for-byte identical to Step 7. The *spec* got dramaticall
 
 Not every consumer is an AI agent. The operations dashboard is a plain React app. The partner logistics company speaks OpenAPI. The mobile team doesn't care what MCP is — they want `GET /ships/{imo}` and they want it *now*.
 
-Same capability, different front door. `type: rest` exposes HTTP endpoints that map to the same consumed operations — or, better, the same aggregate functions we defined in Step 9. Write logic once, expose it three times.
+Same capability, different front door. `type: rest` exposes HTTP endpoints that map to the same consumed operations — or, better, the same aggregate flows we defined in Step 9. Write logic once, expose it three times.
 
 ~~~yaml
 - type: rest
@@ -192,12 +192,12 @@ Two things to notice. First, REST operations declare HTTP-level parameter placem
 
 The voyage is planned. The crew is confirmed. Oslo to Singapore, Northern Star, Captain Erik, Aiko in the galley. And now operations walks in with the final ask: *"I need one document. Voyage, ship, crew, cargo — all of it, resolved, in one payload. Before the ship leaves."*
 
-Three separate calls and client-side stitching would work. But we already have the pattern (Step 7) and the abstraction (Step 9). This is the same lookup mechanic, scaled up: **four `call` steps and three `lookup` steps**, defined once as an aggregate function, referenced from MCP, Skills, and REST simultaneously.
+Three separate calls and client-side stitching would work. But we already have the pattern (Step 7) and the abstraction (Step 9). This is the same lookup mechanic, scaled up: **four `call` steps and three `lookup` steps**, defined once as an aggregate flow, referenced from MCP, Skills, and REST simultaneously.
 
 ~~~yaml
 aggregates:
   - namespace: manifest
-    functions:
+    flows:
       - name: build-voyage-manifest
         semantics:
           safe: true

--- a/ikanos-docs/wiki/Tutorial-‐-Part-2.md
+++ b/ikanos-docs/wiki/Tutorial-‐-Part-2.md
@@ -1,4 +1,4 @@
-﻿# The Shipyard — Tutorial — Part 2
+# The Shipyard — Tutorial — Part 2
 
 At the end of Part 1, your capability could list, inspect, plan, and enrich. Five tools, two APIs, one contract that survived the journey from mock to production. Good for an MCP client sitting next to the capability. But the Shipyard doesn't live alone: partner agents want a *catalog* they can discover, some logic keeps getting copy-pasted between tools, the operations dashboard speaks REST not MCP, and ops walks in one morning asking for *"one document that has everything."*
 

--- a/ikanos-engine/src/main/java/io/ikanos/Capability.java
+++ b/ikanos-engine/src/main/java/io/ikanos/Capability.java
@@ -253,15 +253,15 @@ public class Capability {
         }
 
         IkanosSpec currentSpec = spec.get();
-        String capabilityName = currentSpec.getInfo() != null && currentSpec.getInfo().getLabel() != null
-                ? currentSpec.getInfo().getLabel() : "unknown";
+        String capabilityName = currentSpec.getInfo() != null && currentSpec.getInfo().getDisplay() != null
+                ? currentSpec.getInfo().getDisplay() : "unknown";
         TelemetryBootstrap.get().getMetrics().capabilityStarted(capabilityName);
     }
 
     public void stop() throws Exception {
         IkanosSpec currentSpec = spec.get();
-        String capabilityName = currentSpec.getInfo() != null && currentSpec.getInfo().getLabel() != null
-                ? currentSpec.getInfo().getLabel() : "unknown";
+        String capabilityName = currentSpec.getInfo() != null && currentSpec.getInfo().getDisplay() != null
+                ? currentSpec.getInfo().getDisplay() : "unknown";
         TelemetryBootstrap.get().getMetrics().capabilityStopped(capabilityName);
 
         for (ServerAdapter adapter : getServerAdapters()) {
@@ -367,8 +367,8 @@ public class Capability {
             try {
                 if (telemetryEnabled) {
                     String serviceName = "ikanos";
-                    if (spec.getInfo() != null && spec.getInfo().getLabel() != null) {
-                        serviceName = "ikanos-" + spec.getInfo().getLabel();
+                    if (spec.getInfo() != null && spec.getInfo().getDisplay() != null) {
+                        serviceName = "ikanos-" + spec.getInfo().getDisplay();
                     }
                     TelemetryBootstrap.init(serviceName);
                 }

--- a/ikanos-engine/src/main/java/io/ikanos/Capability.java
+++ b/ikanos-engine/src/main/java/io/ikanos/Capability.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.ikanos.engine.aggregates.Aggregate;
-import io.ikanos.engine.aggregates.AggregateFunction;
+import io.ikanos.engine.aggregates.AggregateFlow;
 import io.ikanos.engine.aggregates.AggregateRefResolver;
 import io.ikanos.engine.step.StepHandler;
 import io.ikanos.engine.step.StepHandlerRegistry;
@@ -206,32 +206,32 @@ public class Capability {
     }
 
     /**
-     * Look up an aggregate function by ref key ({@code "namespace.functionName"}).
+     * Look up an aggregate flow by ref key ({@code "namespace.flowName"}).
      *
      * @param ref the ref key, e.g. {@code "forecast.get-forecast"}
-     * @return the matching {@link AggregateFunction}
+     * @return the matching {@link AggregateFlow}
      * @throws IllegalArgumentException if the ref cannot be resolved
      */
-    public AggregateFunction lookupFunction(String ref) {
+    public AggregateFlow lookupFlow(String ref) {
         int dot = ref.indexOf('.');
         if (dot <= 0 || dot == ref.length() - 1) {
             throw new IllegalArgumentException(
-                    "Invalid aggregate function ref format: '" + ref
-                            + "'. Expected 'namespace.functionName'");
+                    "Invalid aggregate flow ref format: '" + ref
+                            + "'. Expected 'namespace.flowName'");
         }
         String namespace = ref.substring(0, dot);
-        String functionName = ref.substring(dot + 1);
+        String flowName = ref.substring(dot + 1);
 
         for (Aggregate agg : aggregates.get()) {
             if (agg.getNamespace().equals(namespace)) {
-                AggregateFunction fn = agg.findFunction(functionName);
-                if (fn != null) {
-                    return fn;
+                AggregateFlow flow = agg.findFlow(flowName);
+                if (flow != null) {
+                    return flow;
                 }
             }
         }
         throw new IllegalArgumentException(
-                "Unknown aggregate function ref: '" + ref + "'");
+                "Unknown aggregate flow ref: '" + ref + "'");
     }
 
     /**

--- a/ikanos-engine/src/main/java/io/ikanos/bootstrap/CapabilityRuntime.java
+++ b/ikanos-engine/src/main/java/io/ikanos/bootstrap/CapabilityRuntime.java
@@ -64,8 +64,8 @@ public class CapabilityRuntime {
         IkanosSpec spec = mapper.readValue(file, IkanosSpec.class);
 
         String serviceName = "ikanos";
-        if (spec.getInfo() != null && spec.getInfo().getLabel() != null) {
-            serviceName = "ikanos-" + spec.getInfo().getLabel();
+        if (spec.getInfo() != null && spec.getInfo().getDisplay() != null) {
+            serviceName = "ikanos-" + spec.getInfo().getDisplay();
         }
         TelemetryBootstrap.init(serviceName, resolveObservabilitySpec(spec));
 

--- a/ikanos-engine/src/main/java/io/ikanos/engine/aggregates/Aggregate.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/aggregates/Aggregate.java
@@ -16,25 +16,25 @@ package io.ikanos.engine.aggregates;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import io.ikanos.engine.util.OperationStepExecutor;
-import io.ikanos.spec.aggregates.AggregateFunctionSpec;
+import io.ikanos.spec.aggregates.AggregateFlowSpec;
 import io.ikanos.spec.aggregates.AggregateSpec;
 
 /**
  * Runtime representation of a domain aggregate.
  *
  * <p>Wraps an {@link AggregateSpec} (YAML data) and owns executable
- * {@link AggregateFunction} instances for each function defined in the spec.</p>
+ * {@link AggregateFlow} instances for each flow defined in the spec.</p>
  */
 public class Aggregate {
 
     private final String namespace;
-    private final List<AggregateFunction> functions;
+    private final List<AggregateFlow> flows;
 
     public Aggregate(AggregateSpec spec, OperationStepExecutor stepExecutor) {
         this.namespace = spec.getNamespace();
-        this.functions = new CopyOnWriteArrayList<>();
-        for (AggregateFunctionSpec fnSpec : spec.getFunctions().values()) {
-            this.functions.add(new AggregateFunction(fnSpec, stepExecutor, this.namespace));
+        this.flows = new CopyOnWriteArrayList<>();
+        for (AggregateFlowSpec flowSpec : spec.getFlows().values()) {
+            this.flows.add(new AggregateFlow(flowSpec, stepExecutor, this.namespace));
         }
     }
 
@@ -42,20 +42,20 @@ public class Aggregate {
         return namespace;
     }
 
-    public List<AggregateFunction> getFunctions() {
-        return functions;
+    public List<AggregateFlow> getFlows() {
+        return flows;
     }
 
     /**
-     * Find a function by name within this aggregate.
+     * Find a flow by name within this aggregate.
      *
-     * @param name the function name
-     * @return the function, or {@code null} if not found
+     * @param name the flow name
+     * @return the flow, or {@code null} if not found
      */
-    public AggregateFunction findFunction(String name) {
-        for (AggregateFunction fn : functions) {
-            if (fn.getName().equals(name)) {
-                return fn;
+    public AggregateFlow findFlow(String name) {
+        for (AggregateFlow flow : flows) {
+            if (flow.getName().equals(name)) {
+                return flow;
             }
         }
         return null;

--- a/ikanos-engine/src/main/java/io/ikanos/engine/aggregates/AggregateFlow.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/aggregates/AggregateFlow.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.ikanos.engine.observability.TelemetryBootstrap;
 import io.ikanos.engine.util.OperationStepExecutor;
 import io.ikanos.engine.util.Resolver;
-import io.ikanos.spec.aggregates.AggregateFunctionSpec;
+import io.ikanos.spec.aggregates.AggregateFlowSpec;
 import io.ikanos.spec.InputParameterSpec;
 import io.ikanos.spec.OutputParameterSpec;
 import io.ikanos.spec.aggregates.SemanticsSpec;
@@ -32,19 +32,19 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Scope;
 
 /**
- * Runtime-executable wrapper around an {@link AggregateFunctionSpec}.
+ * Runtime-executable wrapper around an {@link AggregateFlowSpec}.
  *
  * <p>Holds the spec data (from YAML) plus the {@link OperationStepExecutor} needed to actually
- * run the function. Adapters (MCP tools, REST operations) that reference an aggregate function
- * delegate execution here instead of duplicating the function's fields.</p>
+ * run the flow. Adapters (MCP tools, REST operations) that reference an aggregate flow
+ * delegate execution here instead of duplicating the flow's fields.</p>
  */
-public class AggregateFunction {
+public class AggregateFlow {
 
-    private final AggregateFunctionSpec spec;
+    private final AggregateFlowSpec spec;
     private final OperationStepExecutor stepExecutor;
     private final String namespace;
 
-    AggregateFunction(AggregateFunctionSpec spec, OperationStepExecutor stepExecutor,
+    AggregateFlow(AggregateFlowSpec spec, OperationStepExecutor stepExecutor,
             String namespace) {
         this.spec = spec;
         this.stepExecutor = stepExecutor;
@@ -89,7 +89,7 @@ public class AggregateFunction {
     }
 
     /**
-     * Execute this aggregate function with the given parameters.
+     * Execute this aggregate flow with the given parameters.
      *
      * <p>Supports three modes:
      * <ol>
@@ -99,11 +99,11 @@ public class AggregateFunction {
      * </ol>
      *
      * @param parameters resolved input parameters (merged with adapter-level 'with')
-     * @return a transport-neutral {@link FunctionResult}
+     * @return a transport-neutral {@link FlowResult}
      */
-    public FunctionResult execute(Map<String, Object> parameters) throws Exception {
+    public FlowResult execute(Map<String, Object> parameters) throws Exception {
         String ref = namespace + "." + spec.getName();
-        Span span = TelemetryBootstrap.get().startAggregateFunctionSpan(ref);
+        Span span = TelemetryBootstrap.get().startAggregateFlowSpan(ref);
         try (Scope scope = span.makeCurrent()) {
             return doExecute(parameters);
         } catch (Exception e) {
@@ -114,13 +114,13 @@ public class AggregateFunction {
         }
     }
 
-    FunctionResult doExecute(Map<String, Object> parameters) throws Exception {
+    FlowResult doExecute(Map<String, Object> parameters) throws Exception {
         Map<String, Object> merged = new HashMap<>();
         if (parameters != null) {
             merged.putAll(parameters);
         }
 
-        // Merge function-level 'with' parameters
+        // Merge flow-level 'with' parameters
         OperationStepExecutor.mergeWithParameters(spec.getWith(), merged, namespace);
 
         boolean hasCall = spec.getCall() != null;
@@ -130,7 +130,7 @@ public class AggregateFunction {
         if (!hasCall && !isOrchestrated) {
             ObjectMapper mapper = new ObjectMapper();
             JsonNode mockRoot = Resolver.buildMockData(spec.getOutputParameters(), mapper, merged);
-            return new FunctionResult(null, null, mockRoot);
+            return new FlowResult(null, null, mockRoot);
         }
 
         // Covers both orchestrated and simple-call paths
@@ -145,19 +145,19 @@ public class AggregateFunction {
                 String mapped = stepExecutor.resolveStepMappings(
                         spec.getMappings(), stepResult.stepContext);
                 if (mapped != null) {
-                    return new FunctionResult(stepResult.lastContext, mapped, null);
+                    return new FlowResult(stepResult.lastContext, mapped, null);
                 }
             }
 
-            return new FunctionResult(stepResult.lastContext, null, null);
+            return new FlowResult(stepResult.lastContext, null, null);
         }
 
         // Simple call mode
         OperationStepExecutor.HandlingContext found =
                 stepExecutor.execute(spec.getCall(), spec.getSteps(), merged,
-                        "Function '" + spec.getName() + "'");
+                        "Flow '" + spec.getName() + "'");
 
-        // Apply output parameter mappings if defined on the function
+        // Apply output parameter mappings if defined on the flow
         if (spec.getOutputParameters() != null && !spec.getOutputParameters().isEmpty()
                 && found != null && found.clientResponse != null
                 && found.clientResponse.getEntity() != null) {
@@ -169,11 +169,11 @@ public class AggregateFunction {
             String mapped = stepExecutor.applyOutputMappings(responseText,
                     spec.getOutputParameters(), outputRawFormat, outputSchema);
             if (mapped != null) {
-                return new FunctionResult(found, mapped, null);
+                return new FlowResult(found, mapped, null);
             }
         }
 
-        return new FunctionResult(found, null, null);
+        return new FlowResult(found, null, null);
     }
 
 }

--- a/ikanos-engine/src/main/java/io/ikanos/engine/aggregates/AggregateRefResolver.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/aggregates/AggregateRefResolver.java
@@ -17,7 +17,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import org.restlet.Context;
-import io.ikanos.spec.aggregates.AggregateFunctionSpec;
+import io.ikanos.spec.aggregates.AggregateFlowSpec;
 import io.ikanos.spec.aggregates.AggregateSpec;
 import io.ikanos.spec.CapabilitySpec;
 import io.ikanos.spec.IkanosSpec;
@@ -31,26 +31,26 @@ import io.ikanos.spec.exposes.rest.RestServerSpec;
 import io.ikanos.spec.exposes.ServerSpec;
 
 /**
- * Validates aggregate function references ({@code ref}) in adapter units (MCP tools, REST
+ * Validates aggregate flow references ({@code ref}) in adapter units (MCP tools, REST
  * operations) and derives MCP-specific metadata. Runs at capability load time, before server
  * startup.
  *
  * <p>
- * Validation ensures all refs point to known aggregate functions. For MCP tools, semantics are
+ * Validation ensures all refs point to known aggregate flows. For MCP tools, semantics are
  * automatically derived into hints (with field-level override). Adapter-specific metadata
  * (name, description) is inherited when not explicitly set on the adapter unit.
  *
  * <p>
  * Execution fields ({@code call}, {@code steps}, {@code with}, {@code inputParameters},
  * {@code outputParameters}, {@code mappings}) are <b>not</b> copied — at runtime, adapters
- * delegate to {@link AggregateFunction} instances held by the {@link io.ikanos.Capability}.
+ * delegate to {@link AggregateFlow} instances held by the {@link io.ikanos.Capability}.
  */
 public class AggregateRefResolver {
 
     /**
      * Validate all {@code ref} fields across adapter units in the given spec and derive
      * adapter-specific metadata.
-     * 
+     *
      * @param spec The root Naftiko spec to resolve
      * @throws IllegalArgumentException if a ref target is unknown
      */
@@ -60,22 +60,22 @@ public class AggregateRefResolver {
             return;
         }
 
-        // Build lookup map: "namespace.functionName" → AggregateFunctionSpec
-        Map<String, AggregateFunctionSpec> functionMap = buildFunctionMap(capability);
+        // Build lookup map: "namespace.flowName" → AggregateFlowSpec
+        Map<String, AggregateFlowSpec> flowMap = buildFlowMap(capability);
 
         // Validate refs and derive metadata in all adapter units
         for (ServerSpec serverSpec : capability.getExposes()) {
             if (serverSpec instanceof McpServerSpec mcpSpec) {
                 for (McpServerToolSpec tool : mcpSpec.getTools().values()) {
                     if (tool.getRef() != null) {
-                        resolveMcpToolRef(tool, functionMap);
+                        resolveMcpToolRef(tool, flowMap);
                     }
                 }
             } else if (serverSpec instanceof RestServerSpec restSpec) {
                 for (RestServerResourceSpec resource : restSpec.getResources().values()) {
                     for (RestServerOperationSpec op : resource.getOperations().values()) {
                         if (op.getRef() != null) {
-                            resolveRestOperationRef(op, functionMap);
+                            resolveRestOperationRef(op, flowMap);
                         }
                     }
                 }
@@ -84,49 +84,49 @@ public class AggregateRefResolver {
     }
 
     /**
-     * Build the lookup map of aggregate functions keyed by "namespace.functionName".
+     * Build the lookup map of aggregate flows keyed by "namespace.flowName".
      */
-    Map<String, AggregateFunctionSpec> buildFunctionMap(CapabilitySpec capability) {
-        Map<String, AggregateFunctionSpec> map = new HashMap<>();
+    Map<String, AggregateFlowSpec> buildFlowMap(CapabilitySpec capability) {
+        Map<String, AggregateFlowSpec> map = new HashMap<>();
 
         for (AggregateSpec aggregate : capability.getAggregates().values()) {
-            for (AggregateFunctionSpec function : aggregate.getFunctions().values()) {
-                String key = aggregate.getNamespace() + "." + function.getName();
+            for (AggregateFlowSpec flow : aggregate.getFlows().values()) {
+                String key = aggregate.getNamespace() + "." + flow.getName();
                 if (map.containsKey(key)) {
                     throw new IllegalArgumentException(
-                            "Duplicate aggregate function ref: '" + key + "'");
+                            "Duplicate aggregate flow ref: '" + key + "'");
                 }
-                map.put(key, function);
+                map.put(key, flow);
             }
         }
 
         Context.getCurrentLogger().log(Level.INFO,
-                "Built aggregate function map with {0} entries", map.size());
+                "Built aggregate flow map with {0} entries", map.size());
         return map;
     }
 
     /**
      * Validate a ref on an MCP tool, inherit adapter-specific metadata, and derive MCP hints
      * from semantics. Execution fields are not copied — they are resolved at runtime via
-     * {@link AggregateFunction}.
+     * {@link AggregateFlow}.
      */
     void resolveMcpToolRef(McpServerToolSpec tool,
-            Map<String, AggregateFunctionSpec> functionMap) {
-        AggregateFunctionSpec function = lookupFunction(tool.getRef(), functionMap);
+            Map<String, AggregateFlowSpec> flowMap) {
+        AggregateFlowSpec flow = lookupFlow(tool.getRef(), flowMap);
 
         // Inherit name (adapter-specific metadata)
         if (tool.getName() == null || tool.getName().isEmpty()) {
-            tool.setName(function.getName());
+            tool.setName(flow.getName());
         }
 
         // Inherit description (adapter-specific metadata)
         if (tool.getDescription() == null || tool.getDescription().isEmpty()) {
-            tool.setDescription(function.getDescription());
+            tool.setDescription(flow.getDescription());
         }
 
-        // Derive MCP hints from function semantics, with tool-level override
-        if (function.getSemantics() != null) {
-            McpToolHintsSpec derived = deriveHints(function.getSemantics());
+        // Derive MCP hints from flow semantics, with tool-level override
+        if (flow.getSemantics() != null) {
+            McpToolHintsSpec derived = deriveHints(flow.getSemantics());
             tool.setHints(mergeHints(derived, tool.getHints()));
         }
     }
@@ -134,35 +134,35 @@ public class AggregateRefResolver {
     /**
      * Validate a ref on a REST operation and inherit adapter-specific metadata.
      * Execution fields are not copied — they are resolved at runtime via
-     * {@link AggregateFunction}.
+     * {@link AggregateFlow}.
      */
     void resolveRestOperationRef(RestServerOperationSpec op,
-            Map<String, AggregateFunctionSpec> functionMap) {
-        AggregateFunctionSpec function = lookupFunction(op.getRef(), functionMap);
+            Map<String, AggregateFlowSpec> flowMap) {
+        AggregateFlowSpec flow = lookupFlow(op.getRef(), flowMap);
 
         // Inherit name
         if (op.getName() == null || op.getName().isEmpty()) {
-            op.setName(function.getName());
+            op.setName(flow.getName());
         }
 
         // Inherit description
         if (op.getDescription() == null || op.getDescription().isEmpty()) {
-            op.setDescription(function.getDescription());
+            op.setDescription(flow.getDescription());
         }
     }
 
     /**
-     * Look up a function by ref key. Fails fast on unknown refs.
+     * Look up a flow by ref key. Fails fast on unknown refs.
      */
-    AggregateFunctionSpec lookupFunction(String ref,
-            Map<String, AggregateFunctionSpec> functionMap) {
-        AggregateFunctionSpec function = functionMap.get(ref);
-        if (function == null) {
+    AggregateFlowSpec lookupFlow(String ref,
+            Map<String, AggregateFlowSpec> flowMap) {
+        AggregateFlowSpec flow = flowMap.get(ref);
+        if (flow == null) {
             throw new IllegalArgumentException(
-                    "Unknown aggregate function ref: '" + ref
-                            + "'. Available refs: " + functionMap.keySet());
+                    "Unknown aggregate flow ref: '" + ref
+                            + "'. Available refs: " + flowMap.keySet());
         }
-        return function;
+        return flow;
     }
 
     /**

--- a/ikanos-engine/src/main/java/io/ikanos/engine/aggregates/FlowResult.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/aggregates/FlowResult.java
@@ -17,11 +17,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.ikanos.engine.util.OperationStepExecutor;
 
 /**
- * Transport-neutral result of executing an aggregate function.
+ * Transport-neutral result of executing an aggregate flow.
  *
  * <p>Adapters (MCP, REST) convert this into their protocol-specific response format.</p>
  */
-public class FunctionResult {
+public class FlowResult {
 
     /** The last HTTP handling context (simple call or last orchestrated step). May be null in mock mode. */
     public final OperationStepExecutor.HandlingContext lastContext;
@@ -32,7 +32,7 @@ public class FunctionResult {
     /** Mock output built from outputParameter value fields. May be null. */
     public final JsonNode mockOutput;
 
-    FunctionResult(OperationStepExecutor.HandlingContext lastContext, String mappedOutput,
+    FlowResult(OperationStepExecutor.HandlingContext lastContext, String mappedOutput,
             JsonNode mockOutput) {
         this.lastContext = lastContext;
         this.mappedOutput = mappedOutput;

--- a/ikanos-engine/src/main/java/io/ikanos/engine/exposes/control/StatusResource.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/exposes/control/StatusResource.java
@@ -48,7 +48,7 @@ public class StatusResource extends ServerResource {
         // Capability info
         ObjectNode capNode = MAPPER.createObjectNode();
         if (capability.getSpec().getInfo() != null) {
-            capNode.put("label", capability.getSpec().getInfo().getLabel());
+            capNode.put("display", capability.getSpec().getInfo().getDisplay());
         }
         capNode.put("specVersion", capability.getSpec().getIkanos());
         root.set("capability", capNode);

--- a/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/McpServerAdapter.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/McpServerAdapter.java
@@ -79,8 +79,8 @@ public class McpServerAdapter extends ServerAdapter {
             }
 
             this.tools.add(buildMcpTool(toolSpec));
-            if (toolSpec.getLabel() != null) {
-                this.toolLabels.put(toolSpec.getName(), toolSpec.getLabel());
+            if (toolSpec.getDisplay() != null) {
+                this.toolLabels.put(toolSpec.getName(), toolSpec.getDisplay());
             }
         }
 
@@ -113,9 +113,9 @@ public class McpServerAdapter extends ServerAdapter {
         context.getAttributes().put("dispatcher", dispatcher);
         context.getAttributes().put("activeSessions", activeSessions);
         if (getCapability().getSpec().getInfo() != null
-                && getCapability().getSpec().getInfo().getLabel() != null) {
+                && getCapability().getSpec().getInfo().getDisplay() != null) {
             context.getAttributes().put("capabilityName",
-                    getCapability().getSpec().getInfo().getLabel());
+                    getCapability().getSpec().getInfo().getDisplay());
         }
 
         Router router = new Router(context);
@@ -194,13 +194,13 @@ public class McpServerAdapter extends ServerAdapter {
      */
     McpSchema.ToolAnnotations buildToolAnnotations(McpServerToolSpec toolSpec) {
         McpToolHintsSpec hints = toolSpec.getHints();
-        String label = toolSpec.getLabel();
+        String display = toolSpec.getDisplay();
 
-        if (hints == null && label == null) {
+        if (hints == null && display == null) {
             return null;
         }
 
-        return new McpSchema.ToolAnnotations(label,
+        return new McpSchema.ToolAnnotations(display,
                 hints != null ? hints.getReadOnly() : null,
                 hints != null ? hints.getDestructive() : null,
                 hints != null ? hints.getIdempotent() : null,

--- a/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/McpServerAdapter.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/McpServerAdapter.java
@@ -26,7 +26,7 @@ import org.restlet.Restlet;
 import org.restlet.routing.Router;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.ikanos.Capability;
-import io.ikanos.engine.aggregates.AggregateFunction;
+import io.ikanos.engine.aggregates.AggregateFlow;
 import io.ikanos.engine.exposes.ServerAdapter;
 import io.ikanos.spec.InputParameterSpec;
 import io.ikanos.spec.consumes.http.OAuth2AuthenticationSpec;
@@ -149,10 +149,10 @@ public class McpServerAdapter extends ServerAdapter {
         Map<String, Object> schemaProperties = new LinkedHashMap<>();
         List<String> required = new ArrayList<>();
 
-        // Resolve inputParameters: prefer tool-level, fall back to aggregate function
+        // Resolve inputParameters: prefer tool-level, fall back to aggregate flow
         List<InputParameterSpec> inputParams = toolSpec.getInputParameters();
         if ((inputParams == null || inputParams.isEmpty()) && toolSpec.getRef() != null) {
-            AggregateFunction fn = getCapability().lookupFunction(toolSpec.getRef());
+            AggregateFlow fn = getCapability().lookupFlow(toolSpec.getRef());
             inputParams = fn.getInputParameters();
         }
 

--- a/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/ProtocolDispatcher.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/ProtocolDispatcher.java
@@ -245,7 +245,7 @@ public class ProtocolDispatcher {
             ObjectNode node = mapper.createObjectNode();
             node.put("uri", entry.get("uri"));
             node.put("name", entry.get("name"));
-            String title = entry.get("label");
+            String title = entry.get("display");
             if (title != null) {
                 node.put("title", title);
             }
@@ -314,8 +314,8 @@ public class ProtocolDispatcher {
             ObjectNode node = mapper.createObjectNode();
             node.put("uriTemplate", spec.getUri());
             node.put("name", spec.getName());
-            if (spec.getLabel() != null) {
-                node.put("title", spec.getLabel());
+            if (spec.getDisplay() != null) {
+                node.put("title", spec.getDisplay());
             }
             if (spec.getDescription() != null) {
                 node.put("description", spec.getDescription());
@@ -339,8 +339,8 @@ public class ProtocolDispatcher {
         for (McpServerPromptSpec spec : adapter.getPromptHandler().listAll()) {
             ObjectNode promptNode = mapper.createObjectNode();
             promptNode.put("name", spec.getName());
-            if (spec.getLabel() != null) {
-                promptNode.put("title", spec.getLabel());
+            if (spec.getDisplay() != null) {
+                promptNode.put("title", spec.getDisplay());
             }
             if (spec.getDescription() != null) {
                 promptNode.put("description", spec.getDescription());
@@ -350,8 +350,8 @@ public class ProtocolDispatcher {
                 for (McpPromptArgumentSpec arg : spec.getArguments().values()) {
                     ObjectNode argNode = mapper.createObjectNode();
                     argNode.put("name", arg.getName());
-                    if (arg.getLabel() != null) {
-                        argNode.put("title", arg.getLabel());
+                    if (arg.getDisplay() != null) {
+                        argNode.put("title", arg.getDisplay());
                     }
                     if (arg.getDescription() != null) {
                         argNode.put("description", arg.getDescription());

--- a/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/ResourceHandler.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/ResourceHandler.java
@@ -124,7 +124,7 @@ public class ResourceHandler {
                 Map<String, String> entry = new HashMap<>();
                 entry.put("uri", spec.getUri());
                 entry.put("name", spec.getName());
-                entry.put("label", spec.getLabel() != null ? spec.getLabel() : spec.getName());
+                entry.put("display", spec.getDisplay() != null ? spec.getDisplay() : spec.getName());
                 entry.put("description", spec.getDescription());
                 if (spec.getMimeType() != null) {
                     entry.put("mimeType", spec.getMimeType());
@@ -212,7 +212,7 @@ public class ResourceHandler {
                         Map<String, String> entry = new HashMap<>();
                         entry.put("uri", fileUri);
                         entry.put("name", spec.getName());
-                        entry.put("label", spec.getLabel() != null ? spec.getLabel() : spec.getName());
+                        entry.put("display", spec.getDisplay() != null ? spec.getDisplay() : spec.getName());
                         entry.put("description", spec.getDescription());
                         if (mimeType != null) {
                             entry.put("mimeType", mimeType);

--- a/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/ToolHandler.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/ToolHandler.java
@@ -21,8 +21,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.restlet.Context;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.ikanos.Capability;
-import io.ikanos.engine.aggregates.AggregateFunction;
-import io.ikanos.engine.aggregates.FunctionResult;
+import io.ikanos.engine.aggregates.AggregateFlow;
+import io.ikanos.engine.aggregates.FlowResult;
 import io.ikanos.engine.observability.TelemetryBootstrap;
 import io.ikanos.engine.util.OperationStepExecutor;
 import io.ikanos.engine.util.Resolver;
@@ -185,13 +185,13 @@ public class ToolHandler {
     }
 
     /**
-     * Execute a tool call by delegating to its referenced aggregate function.
+     * Execute a tool call by delegating to its referenced aggregate flow.
      */
     private McpSchema.CallToolResult executeViaAggregate(McpServerToolSpec toolSpec,
             String toolName, Map<String, Object> parameters) throws Exception {
         try {
-            AggregateFunction fn = capability.lookupFunction(toolSpec.getRef());
-            FunctionResult result = fn.execute(parameters);
+            AggregateFlow fn = capability.lookupFlow(toolSpec.getRef());
+            FlowResult result = fn.execute(parameters);
 
             if (result.isMock()) {
                 ObjectMapper mapper = new ObjectMapper();

--- a/ikanos-engine/src/main/java/io/ikanos/engine/exposes/rest/ResourceRestlet.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/exposes/rest/ResourceRestlet.java
@@ -70,7 +70,7 @@ public class ResourceRestlet extends Restlet {
 
         String operationId = resourceSpec.getPath() + " " + request.getMethod().getName();
         String capabilityName = capability.getSpec().getInfo() != null
-                ? capability.getSpec().getInfo().getLabel() : null;
+                ? capability.getSpec().getInfo().getDisplay() : null;
         Span span = telemetry.startServerSpan("rest", operationId, extractedContext,
                 request.getMethod().getName(), capabilityName);
 

--- a/ikanos-engine/src/main/java/io/ikanos/engine/exposes/rest/ResourceRestlet.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/exposes/rest/ResourceRestlet.java
@@ -20,8 +20,8 @@ import org.restlet.Restlet;
 import org.restlet.data.MediaType;
 import org.restlet.data.Status;
 import io.ikanos.Capability;
-import io.ikanos.engine.aggregates.AggregateFunction;
-import io.ikanos.engine.aggregates.FunctionResult;
+import io.ikanos.engine.aggregates.AggregateFlow;
+import io.ikanos.engine.aggregates.FlowResult;
 import io.ikanos.engine.consumes.ClientAdapter;
 import io.ikanos.engine.consumes.http.HttpClientAdapter;
 import io.ikanos.engine.observability.OtelRestletBridge;
@@ -230,13 +230,13 @@ public class ResourceRestlet extends Restlet {
     }
 
     /**
-     * Execute an operation by delegating to its referenced aggregate function.
+     * Execute an operation by delegating to its referenced aggregate flow.
      */
     private boolean executeViaAggregate(RestServerOperationSpec serverOp, Request request,
             Response response, Map<String, Object> inputParameters) {
         try {
-            AggregateFunction fn = capability.lookupFunction(serverOp.getRef());
-            FunctionResult result = fn.execute(inputParameters);
+            AggregateFlow fn = capability.lookupFlow(serverOp.getRef());
+            FlowResult result = fn.execute(inputParameters);
 
             if (result.isMock()) {
                 ObjectMapper mapper = new ObjectMapper();

--- a/ikanos-engine/src/main/java/io/ikanos/engine/exposes/skill/SkillServerAdapter.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/exposes/skill/SkillServerAdapter.java
@@ -61,9 +61,9 @@ public class SkillServerAdapter extends ServerAdapter {
         context.getAttributes().put("skillServerSpec", serverSpec);
         context.getAttributes().put("namespaceMode", namespaceMode);
         if (getCapability().getSpec().getInfo() != null
-                && getCapability().getSpec().getInfo().getLabel() != null) {
+                && getCapability().getSpec().getInfo().getDisplay() != null) {
             context.getAttributes().put("capabilityName",
-                    getCapability().getSpec().getInfo().getLabel());
+                    getCapability().getSpec().getInfo().getDisplay());
         }
 
         Router router = new Router(context);

--- a/ikanos-engine/src/main/java/io/ikanos/engine/observability/TelemetryBootstrap.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/observability/TelemetryBootstrap.java
@@ -376,7 +376,7 @@ public class TelemetryBootstrap {
     /**
      * Start an INTERNAL span for an aggregate function execution.
      */
-    public Span startAggregateFunctionSpan(String ref) {
+    public Span startAggregateFlowSpan(String ref) {
         if (!enabled) return Span.getInvalid();
         SpanBuilder builder = tracer.spanBuilder("aggregate.function")
             .setSpanKind(SpanKind.INTERNAL);

--- a/ikanos-engine/src/main/java/io/ikanos/engine/observability/TelemetryBootstrap.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/observability/TelemetryBootstrap.java
@@ -378,7 +378,7 @@ public class TelemetryBootstrap {
      */
     public Span startAggregateFlowSpan(String ref) {
         if (!enabled) return Span.getInvalid();
-        SpanBuilder builder = tracer.spanBuilder("aggregate.function")
+        SpanBuilder builder = tracer.spanBuilder("aggregate.flow")
             .setSpanKind(SpanKind.INTERNAL);
         setStringAttribute(builder, ATTR_AGGREGATE_REF, ref != null ? ref : "unknown");
         return builder.startSpan();

--- a/ikanos-engine/src/main/java/io/ikanos/engine/util/ConversionFormat.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/util/ConversionFormat.java
@@ -33,10 +33,10 @@ public enum ConversionFormat {
     PROTOBUF("protobuf"),
     AVRO("avro");
 
-    public final String label;
+    public final String display;
 
-    ConversionFormat(String label) {
-        this.label = label;
+    ConversionFormat(String display) {
+        this.display = display;
     }
 
     /**
@@ -50,7 +50,7 @@ public enum ConversionFormat {
             return null;
         }
         for (ConversionFormat f : values()) {
-            if (f.label.equalsIgnoreCase(format)) {
+            if (f.display.equalsIgnoreCase(format)) {
                 return f;
             }
         }

--- a/ikanos-engine/src/main/java/io/ikanos/engine/util/ConversionFormat.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/util/ConversionFormat.java
@@ -17,7 +17,7 @@ package io.ikanos.engine.util;
  * Centralized enum for the output raw formats declared in the Ikanos specification
  * ({@code outputRawFormat} in {@code ikanos-schema.json}).
  *
- * <p>Labels are lowercase to match the JSON schema enum values. Use {@link #fromLabel(String)}
+ * <p>Labels are lowercase to match the JSON schema enum values. Use {@link #fromDisplay(String)}
  * for case-insensitive lookup from user-supplied strings.</p>
  */
 public enum ConversionFormat {
@@ -45,7 +45,7 @@ public enum ConversionFormat {
      * @param format the raw format string (may be {@code null})
      * @return the matching constant, or {@code null} if {@code format} is {@code null} or unknown
      */
-    public static ConversionFormat fromLabel(String format) {
+    public static ConversionFormat fromDisplay(String format) {
         if (format == null) {
             return null;
         }

--- a/ikanos-engine/src/main/java/io/ikanos/engine/util/Converter.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/util/Converter.java
@@ -80,7 +80,7 @@ public class Converter {
     /** Convert various formats to JSON */
     public static JsonNode convertToJson(String format, String schema, Representation entity)
             throws IOException {
-        ConversionFormat fmt = ConversionFormat.fromLabel(format);
+        ConversionFormat fmt = ConversionFormat.fromDisplay(format);
 
         if (fmt == null && format != null) {
             throw new IOException("Unsupported \"" + format + "\" format specified");
@@ -132,7 +132,7 @@ public class Converter {
      */
     public static JsonNode convertToJson(String format, String schema, String text)
             throws IOException {
-        ConversionFormat fmt = ConversionFormat.fromLabel(format);
+        ConversionFormat fmt = ConversionFormat.fromDisplay(format);
 
         if (fmt == null && format != null) {
             throw new IOException("Unsupported \"" + format + "\" format specified");

--- a/ikanos-engine/src/main/java/io/ikanos/engine/util/Converter.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/util/Converter.java
@@ -151,7 +151,7 @@ public class Converter {
             case PSV -> Converter.convertDelimitedToJson(new StringReader(text), '|');
             case HTML -> Converter.convertHtmlToJson(new StringReader(text), schema);
             case MARKDOWN -> Converter.convertMarkdownToJson(new StringReader(text), schema);
-            case PROTOBUF, AVRO -> throw new IOException(fmt.label
+            case PROTOBUF, AVRO -> throw new IOException(fmt.display
                     + " format cannot be converted from a text string; "
                     + "use the Representation-based overload instead");
             case JSON -> new ObjectMapper().readTree(text);

--- a/ikanos-engine/src/main/java/io/ikanos/engine/util/OperationStepExecutor.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/util/OperationStepExecutor.java
@@ -93,9 +93,9 @@ public class OperationStepExecutor {
     /**
      * Override the expose namespace after construction.
      *
-     * <p>This setter exists for {@link io.ikanos.engine.aggregates.AggregateFunction}, which
-     * shares a single {@code OperationStepExecutor} across multiple aggregate functions that may
-     * belong to different namespaces. The function sets its own namespace before each execution.
+     * <p>This setter exists for {@link io.ikanos.engine.aggregates.AggregateFlow}, which
+     * shares a single {@code OperationStepExecutor} across multiple aggregate flows that may
+     * belong to different namespaces. The flow sets its own namespace before each execution.
      * Handlers whose namespace is known at construction time should use
      * {@link #OperationStepExecutor(Capability, String)} instead.</p>
      */

--- a/ikanos-engine/src/test/java/io/ikanos/engine/CapabilityBuilderTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/CapabilityBuilderTest.java
@@ -33,7 +33,7 @@ class CapabilityBuilderTest {
                 .build();
 
         assertNotNull(capability);
-        assertEquals("Embedding Test", capability.getSpec().getInfo().getLabel());
+        assertEquals("Embedding Test", capability.getSpec().getInfo().getDisplay());
     }
 
     @Test

--- a/ikanos-engine/src/test/java/io/ikanos/engine/aggregates/AggregateFlowTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/aggregates/AggregateFlowTest.java
@@ -21,17 +21,17 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
-import io.ikanos.spec.aggregates.AggregateFunctionSpec;
+import io.ikanos.spec.aggregates.AggregateFlowSpec;
 import io.ikanos.spec.OutputParameterSpec;
 
 /**
- * Unit tests for {@link AggregateFunction} — namespace-qualified reference resolution
- * in function-level {@code with} blocks.
+ * Unit tests for {@link AggregateFlow} — namespace-qualified reference resolution
+ * in flow-level {@code with} blocks.
  */
-public class AggregateFunctionTest {
+public class AggregateFlowTest {
 
     /**
-     * When a mock-mode function has {@code with: {voyage-id: "shipyard.voyage-id"}} and the
+     * When a mock-mode flow has {@code with: {voyage-id: "shipyard.voyage-id"}} and the
      * aggregate namespace is "shipyard", calling execute should resolve the qualified reference
      * to the caller's argument and use it for mock data output.
      *
@@ -39,8 +39,8 @@ public class AggregateFunctionTest {
      * "shipyard.voyage-id" overwrote the caller's "VOY-2026-042" and appeared in the mock output.
      */
     @Test
-    void executeShouldResolveNamespaceQualifiedReferencesInFunctionWith() throws Exception {
-        AggregateFunctionSpec spec = new AggregateFunctionSpec();
+    void executeShouldResolveNamespaceQualifiedReferencesInFlowWith() throws Exception {
+        AggregateFlowSpec spec = new AggregateFlowSpec();
         spec.setName("get-voyage");
         spec.setDescription("Get a voyage manifest.");
         Map<String, Object> withBlock = new HashMap<>();
@@ -55,11 +55,11 @@ public class AggregateFunctionTest {
         spec.setOutputParameters(List.of(outParam));
 
         // No call, no steps -> mock mode
-        AggregateFunction fn = new AggregateFunction(spec, null, "shipyard");
+        AggregateFlow fn = new AggregateFlow(spec, null, "shipyard");
 
         Map<String, Object> callerParams = new HashMap<>();
         callerParams.put("voyage-id", "VOY-2026-042");
-        FunctionResult result = fn.execute(callerParams);
+        FlowResult result = fn.execute(callerParams);
 
         assertTrue(result.isMock(), "Should be mock mode");
         assertNotNull(result.mockOutput, "Mock output should not be null");

--- a/ikanos-engine/src/test/java/io/ikanos/engine/aggregates/AggregateRefResolverTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/aggregates/AggregateRefResolverTest.java
@@ -92,28 +92,28 @@ public class AggregateRefResolverTest {
     @Test
     void buildFunctionMapShouldThrowOnDuplicateRefViaDirectInjection() {
         // Simulate a cross-aggregate collision by injecting two aggregates
-        // that produce the same "namespace.functionName" key.
-        // This exercises the duplicate-ref guard in buildFunctionMap directly.
+        // that produce the same "namespace.flowName" key.
+        // This exercises the duplicate-ref guard in buildFlowMap directly.
         CapabilitySpec cap = new CapabilitySpec();
 
         AggregateSpec agg1 = new AggregateSpec();
         agg1.setNamespace("shared");
-        AggregateFunctionSpec fn1 = new AggregateFunctionSpec();
+        AggregateFlowSpec fn1 = new AggregateFlowSpec();
         fn1.setName("action");
-        agg1.getFunctions().put(fn1.getName(), fn1);
+        agg1.getFlows().put(fn1.getName(), fn1);
 
         AggregateSpec agg2 = new AggregateSpec();
         agg2.setNamespace("shared");
-        AggregateFunctionSpec fn2 = new AggregateFunctionSpec();
+        AggregateFlowSpec fn2 = new AggregateFlowSpec();
         fn2.setName("action");
-        agg2.getFunctions().put(fn2.getName(), fn2);
+        agg2.getFlows().put(fn2.getName(), fn2);
 
         // Use raw map to bypass the single-key-per-namespace constraint of the POJO model
         cap.getAggregates().put("shared-1", agg1);
         cap.getAggregates().put("shared-2", agg2);
 
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                () -> resolver.buildFunctionMap(cap));
+                () -> resolver.buildFlowMap(cap));
         assertTrue(ex.getMessage().contains("shared.action"));
     }
 

--- a/ikanos-engine/src/test/java/io/ikanos/engine/aggregates/AggregateRefResolverTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/aggregates/AggregateRefResolverTest.java
@@ -48,7 +48,7 @@ public class AggregateRefResolverTest {
         CapabilitySpec cap = new CapabilitySpec();
         AggregateSpec agg = new AggregateSpec();
         agg.setNamespace("forecast");
-        agg.setLabel("Forecast");
+        agg.setDisplay("Forecast");
 
         AggregateFunctionSpec fn = new AggregateFunctionSpec();
         fn.setName("get-forecast");
@@ -76,7 +76,7 @@ public class AggregateRefResolverTest {
 
         AggregateSpec agg = new AggregateSpec();
         agg.setNamespace("data");
-        agg.setLabel("Data");
+        agg.setDisplay("Data");
         AggregateFunctionSpec fn1 = new AggregateFunctionSpec();
         fn1.setName("read");
         fn1.setDescription("Read1");
@@ -428,7 +428,7 @@ public class AggregateRefResolverTest {
 
         AggregateSpec agg = new AggregateSpec();
         agg.setNamespace("data");
-        agg.setLabel("Data");
+        agg.setDisplay("Data");
         AggregateFunctionSpec fn = new AggregateFunctionSpec();
         fn.setName("read");
         fn.setDescription("Read data");

--- a/ikanos-engine/src/test/java/io/ikanos/engine/aggregates/AggregateRefResolverTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/aggregates/AggregateRefResolverTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
-import io.ikanos.spec.aggregates.AggregateFunctionSpec;
+import io.ikanos.spec.aggregates.AggregateFlowSpec;
 import io.ikanos.spec.aggregates.AggregateSpec;
 import io.ikanos.spec.CapabilitySpec;
 import io.ikanos.spec.IkanosSpec;
@@ -41,22 +41,22 @@ public class AggregateRefResolverTest {
         resolver = new AggregateRefResolver();
     }
 
-    // ── buildFunctionMap ──
+    // ── buildFlowMap ──
 
     @Test
-    void buildFunctionMapShouldIndexByNamespaceAndName() {
+    void buildFlowMapShouldIndexByNamespaceAndName() {
         CapabilitySpec cap = new CapabilitySpec();
         AggregateSpec agg = new AggregateSpec();
         agg.setNamespace("forecast");
         agg.setDisplay("Forecast");
 
-        AggregateFunctionSpec fn = new AggregateFunctionSpec();
+        AggregateFlowSpec fn = new AggregateFlowSpec();
         fn.setName("get-forecast");
         fn.setDescription("Get forecast");
-        agg.getFunctions().put(fn.getName(), fn);
+        agg.getFlows().put(fn.getName(), fn);
         cap.getAggregates().put(agg.getNamespace(), agg);
 
-        Map<String, AggregateFunctionSpec> map = resolver.buildFunctionMap(cap);
+        Map<String, AggregateFlowSpec> map = resolver.buildFlowMap(cap);
 
         assertEquals(1, map.size());
         assertTrue(map.containsKey("forecast.get-forecast"));
@@ -64,28 +64,28 @@ public class AggregateRefResolverTest {
     }
 
     @Test
-    void buildFunctionMapShouldFailOnDuplicateRef() {
+    void buildFlowMapShouldFailOnDuplicateRef() {
         // With named-object maps, two aggregates cannot share the same namespace key
         // (the second put overwrites the first). Duplicate detection now applies to
         // functions within different aggregates that share the same namespace.functionName
         // ref, which is architecturally impossible via the POJO model but can be simulated
         // by placing two functions with the same name in the same aggregate's function map.
-        // The duplicate-ref guard in buildFunctionMap protects against future injection;
+        // The duplicate-ref guard in buildFlowMap protects against future injection;
         // we verify it never fires when refs are distinct.
         CapabilitySpec cap = new CapabilitySpec();
 
         AggregateSpec agg = new AggregateSpec();
         agg.setNamespace("data");
         agg.setDisplay("Data");
-        AggregateFunctionSpec fn1 = new AggregateFunctionSpec();
+        AggregateFlowSpec fn1 = new AggregateFlowSpec();
         fn1.setName("read");
         fn1.setDescription("Read1");
-        agg.getFunctions().put(fn1.getName(), fn1);
+        agg.getFlows().put(fn1.getName(), fn1);
 
         cap.getAggregates().put(agg.getNamespace(), agg);
 
         // Single function → no duplicate → should not throw
-        Map<String, AggregateFunctionSpec> map = resolver.buildFunctionMap(cap);
+        Map<String, AggregateFlowSpec> map = resolver.buildFlowMap(cap);
         assertTrue(map.containsKey("data.read"));
     }
 
@@ -117,17 +117,16 @@ public class AggregateRefResolverTest {
         assertTrue(ex.getMessage().contains("shared.action"));
     }
 
-    // ── lookupFunction ──
-
+    // ── lookupFlow ──
     @Test
-    void lookupFunctionShouldFailOnUnknownRef() {
-        Map<String, AggregateFunctionSpec> map = new HashMap<>();
-        AggregateFunctionSpec fn = new AggregateFunctionSpec();
+    void lookupFlowShouldFailOnUnknownRef() {
+        Map<String, AggregateFlowSpec> map = new HashMap<>();
+        AggregateFlowSpec fn = new AggregateFlowSpec();
         fn.setName("read");
         map.put("data.read", fn);
 
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                () -> resolver.lookupFunction("unknown.nonexistent", map));
+                () -> resolver.lookupFlow("unknown.nonexistent", map));
         assertTrue(ex.getMessage().contains("unknown.nonexistent"));
     }
 
@@ -135,11 +134,11 @@ public class AggregateRefResolverTest {
 
     @Test
     void resolveMcpToolRefShouldInheritNameFromFunction() {
-        AggregateFunctionSpec fn = new AggregateFunctionSpec();
+        AggregateFlowSpec fn = new AggregateFlowSpec();
         fn.setName("get-data");
         fn.setDescription("Get data");
 
-        Map<String, AggregateFunctionSpec> map = Map.of("data.get-data", fn);
+        Map<String, AggregateFlowSpec> map = Map.of("data.get-data", fn);
 
         McpServerToolSpec tool = new McpServerToolSpec(null, null, null);
         tool.setRef("data.get-data");
@@ -151,11 +150,11 @@ public class AggregateRefResolverTest {
 
     @Test
     void resolveMcpToolRefShouldNotOverrideExplicitName() {
-        AggregateFunctionSpec fn = new AggregateFunctionSpec();
+        AggregateFlowSpec fn = new AggregateFlowSpec();
         fn.setName("get-data");
         fn.setDescription("Get data");
 
-        Map<String, AggregateFunctionSpec> map = Map.of("data.get-data", fn);
+        Map<String, AggregateFlowSpec> map = Map.of("data.get-data", fn);
 
         McpServerToolSpec tool = new McpServerToolSpec("custom-name", null, null);
         tool.setRef("data.get-data");
@@ -167,24 +166,24 @@ public class AggregateRefResolverTest {
 
     @Test
     void resolveMcpToolRefShouldNotCopyCallFromFunction() {
-        AggregateFunctionSpec fn = new AggregateFunctionSpec();
+        AggregateFlowSpec fn = new AggregateFlowSpec();
         fn.setName("get-data");
         fn.setDescription("Get data");
         fn.setCall(new ServerCallSpec("mock-api.get-data"));
 
-        Map<String, AggregateFunctionSpec> map = Map.of("data.get-data", fn);
+        Map<String, AggregateFlowSpec> map = Map.of("data.get-data", fn);
 
         McpServerToolSpec tool = new McpServerToolSpec("get-data", null, "Get data");
         tool.setRef("data.get-data");
 
         resolver.resolveMcpToolRef(tool, map);
 
-        assertNull(tool.getCall(), "call should not be copied — resolved at runtime via AggregateFunction");
+        assertNull(tool.getCall(), "call should not be copied — resolved at runtime via aggregate flow");
     }
 
     @Test
     void resolveMcpToolRefShouldNotCopyInputParametersFromFunction() {
-        AggregateFunctionSpec fn = new AggregateFunctionSpec();
+        AggregateFlowSpec fn = new AggregateFlowSpec();
         fn.setName("get-data");
         fn.setDescription("Get data");
         io.ikanos.spec.InputParameterSpec param = new io.ikanos.spec.InputParameterSpec();
@@ -192,7 +191,7 @@ public class AggregateRefResolverTest {
         param.setType("string");
         fn.setInputParameters(Map.of("location", param));
 
-        Map<String, AggregateFunctionSpec> map = Map.of("data.get-data", fn);
+        Map<String, AggregateFlowSpec> map = Map.of("data.get-data", fn);
 
         McpServerToolSpec tool = new McpServerToolSpec("get-data", null, "Get data");
         tool.setRef("data.get-data");
@@ -200,16 +199,16 @@ public class AggregateRefResolverTest {
         resolver.resolveMcpToolRef(tool, map);
 
         assertTrue(tool.getInputParameters().isEmpty(),
-                "inputParameters should not be copied — resolved at runtime via AggregateFunction");
+                "inputParameters should not be copied — resolved at runtime via aggregate flow");
     }
 
     @Test
     void resolveMcpToolRefShouldInheritDescription() {
-        AggregateFunctionSpec fn = new AggregateFunctionSpec();
+        AggregateFlowSpec fn = new AggregateFlowSpec();
         fn.setName("get-data");
         fn.setDescription("Function description");
 
-        Map<String, AggregateFunctionSpec> map = Map.of("data.get-data", fn);
+        Map<String, AggregateFlowSpec> map = Map.of("data.get-data", fn);
 
         McpServerToolSpec tool = new McpServerToolSpec("get-data", null, null);
         tool.setRef("data.get-data");
@@ -221,11 +220,11 @@ public class AggregateRefResolverTest {
 
     @Test
     void resolveMcpToolRefShouldNotOverrideExplicitDescription() {
-        AggregateFunctionSpec fn = new AggregateFunctionSpec();
+        AggregateFlowSpec fn = new AggregateFlowSpec();
         fn.setName("get-data");
         fn.setDescription("Function description");
 
-        Map<String, AggregateFunctionSpec> map = Map.of("data.get-data", fn);
+        Map<String, AggregateFlowSpec> map = Map.of("data.get-data", fn);
 
         McpServerToolSpec tool = new McpServerToolSpec("get-data", null, "Tool description");
         tool.setRef("data.get-data");
@@ -239,11 +238,11 @@ public class AggregateRefResolverTest {
 
     @Test
     void resolveRestOperationRefShouldInheritNameFromFunction() {
-        AggregateFunctionSpec fn = new AggregateFunctionSpec();
+        AggregateFlowSpec fn = new AggregateFlowSpec();
         fn.setName("get-data");
         fn.setDescription("Get data");
 
-        Map<String, AggregateFunctionSpec> map = Map.of("data.get-data", fn);
+        Map<String, AggregateFlowSpec> map = Map.of("data.get-data", fn);
 
         RestServerOperationSpec op = new RestServerOperationSpec();
         op.setRef("data.get-data");
@@ -255,19 +254,19 @@ public class AggregateRefResolverTest {
 
     @Test
     void resolveRestOperationRefShouldNotCopyCallFromFunction() {
-        AggregateFunctionSpec fn = new AggregateFunctionSpec();
+        AggregateFlowSpec fn = new AggregateFlowSpec();
         fn.setName("get-data");
         fn.setDescription("Get data");
         fn.setCall(new ServerCallSpec("mock-api.get-data"));
 
-        Map<String, AggregateFunctionSpec> map = Map.of("data.get-data", fn);
+        Map<String, AggregateFlowSpec> map = Map.of("data.get-data", fn);
 
         RestServerOperationSpec op = new RestServerOperationSpec();
         op.setRef("data.get-data");
 
         resolver.resolveRestOperationRef(op, map);
 
-        assertNull(op.getCall(), "call should not be copied — resolved at runtime via AggregateFunction");
+        assertNull(op.getCall(), "call should not be copied — resolved at runtime via aggregate flow");
     }
 
     // ── deriveHints ──
@@ -429,12 +428,12 @@ public class AggregateRefResolverTest {
         AggregateSpec agg = new AggregateSpec();
         agg.setNamespace("data");
         agg.setDisplay("Data");
-        AggregateFunctionSpec fn = new AggregateFunctionSpec();
+        AggregateFlowSpec fn = new AggregateFlowSpec();
         fn.setName("read");
         fn.setDescription("Read data");
         fn.setSemantics(semantics);
         fn.setCall(new ServerCallSpec("mock.read"));
-        agg.getFunctions().put(fn.getName(), fn);
+        agg.getFlows().put(fn.getName(), fn);
         cap.getAggregates().put(agg.getNamespace(), agg);
 
         McpServerSpec mcpSpec = new McpServerSpec();

--- a/ikanos-engine/src/test/java/io/ikanos/engine/aggregates/AggregateStepNamespaceIntegrationTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/aggregates/AggregateStepNamespaceIntegrationTest.java
@@ -29,9 +29,9 @@ import io.ikanos.spec.aggregates.AggregateSpec;
 import io.ikanos.spec.IkanosSpec;
 
 /**
- * Integration test for issue #290: namespace-qualified references in aggregate function steps.
+ * Integration test for issue #290: namespace-qualified references in aggregate flow steps.
  *
- * Loads a capability YAML where an aggregate function has a step with
+ * Loads a capability YAML where an aggregate flow has a step with
  * {@code with: {voyage-id: shipyard.voyage-id}} and verifies that executing the function
  * resolves the namespace-qualified reference before building the HTTP request URL.
  *
@@ -59,18 +59,18 @@ public class AggregateStepNamespaceIntegrationTest {
     }
 
     /**
-     * Execute the aggregate function and verify the step-level namespace-qualified reference
+     * Execute the aggregate flow and verify the step-level namespace-qualified reference
      * resolves correctly. A CapturingStepExecutor captures the resolved parameters before the
      * HTTP call, so the assertion does not depend on error message contents.
      */
     @Test
-    void aggregateFunctionExecuteShouldResolveNamespaceQualifiedWithInSteps() {
+    void aggregateFlowExecuteShouldResolveNamespaceQualifiedWithInSteps() {
         CapturingStepExecutor executor = new CapturingStepExecutor(capability);
 
         AggregateSpec aggregateSpec = spec.getCapability().getAggregates().get("shipyard");
         Aggregate aggregate = new Aggregate(aggregateSpec, executor);
-        AggregateFunction fn = aggregate.findFunction("get-voyage-manifest");
-        assertNotNull(fn, "Aggregate function should be found");
+        AggregateFlow fn = aggregate.findFlow("get-voyage-manifest");
+        assertNotNull(fn, "aggregate flow should be found");
 
         Map<String, Object> params = new HashMap<>();
         params.put("voyage-id", "VOY-2026-042");

--- a/ikanos-engine/src/test/java/io/ikanos/engine/aggregates/AggregateStepNamespaceIntegrationTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/aggregates/AggregateStepNamespaceIntegrationTest.java
@@ -70,7 +70,7 @@ public class AggregateStepNamespaceIntegrationTest {
         AggregateSpec aggregateSpec = spec.getCapability().getAggregates().get("shipyard");
         Aggregate aggregate = new Aggregate(aggregateSpec, executor);
         AggregateFlow fn = aggregate.findFlow("get-voyage-manifest");
-        assertNotNull(fn, "aggregate flow should be found");
+        assertNotNull(fn, "Aggregate flow should be found");
 
         Map<String, Object> params = new HashMap<>();
         params.put("voyage-id", "VOY-2026-042");

--- a/ikanos-engine/src/test/java/io/ikanos/engine/consumes/http/ImportIntegrationTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/consumes/http/ImportIntegrationTest.java
@@ -83,7 +83,7 @@ public class ImportIntegrationTest {
         String capabilityYaml = """
             ikanos: "%s"
             info:
-              label: "Test Capability"
+              display: "Test Capability"
               description: "Tests imported adapters"
             capability:
               consumes:
@@ -131,7 +131,7 @@ public class ImportIntegrationTest {
         String capabilityYaml = """
             ikanos: "%s"
             info:
-              label: "Mixed Capability"
+              display: "Mixed Capability"
               description: "Tests both inline and imported consumes"
             capability:
               consumes:
@@ -187,7 +187,7 @@ public class ImportIntegrationTest {
         String capabilityYaml = """
             ikanos: "%s"
             info:
-              label: "Aliased Capability"
+              display: "Aliased Capability"
               description: "Tests import with alias"
             capability:
               consumes:
@@ -224,7 +224,7 @@ public class ImportIntegrationTest {
         String capabilityYaml = """
             ikanos: "%s"
             info:
-              label: "Bad Capability"
+              display: "Bad Capability"
               description: "Bad import path"
             capability:
               consumes:

--- a/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/AggregateIntegrationTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/AggregateIntegrationTest.java
@@ -20,14 +20,14 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.ikanos.Capability;
-import io.ikanos.engine.aggregates.AggregateFunction;
+import io.ikanos.engine.aggregates.AggregateFlow;
 import io.ikanos.spec.IkanosSpec;
 import io.ikanos.spec.exposes.mcp.McpServerSpec;
 import io.ikanos.spec.exposes.mcp.McpServerToolSpec;
 import java.io.File;
 
 /**
- * Integration tests for aggregate function ref resolution and semantics-to-hints derivation
+ * Integration tests for aggregate flow ref resolution and semantics-to-hints derivation
  * through the full capability loading pipeline.
  */
 public class AggregateIntegrationTest {
@@ -46,7 +46,7 @@ public class AggregateIntegrationTest {
     // ── Basic ref resolution ──
 
     @Test
-    void refShouldResolveCallFromAggregateFunction() throws Exception {
+    void refShouldResolveCallFromAggregateFlow() throws Exception {
         Capability capability = loadCapability("src/test/resources/aggregates/aggregate-basic.yaml");
         McpServerAdapter adapter = (McpServerAdapter) capability.getServerAdapters().get(0);
         McpServerSpec serverSpec = adapter.getMcpServerSpec();
@@ -56,9 +56,9 @@ public class AggregateIntegrationTest {
         // call is no longer copied to the tool spec — it is resolved at runtime
         assertNull(tool.getCall(), "call should not be on tool spec — delegated to aggregate");
 
-        // Verify call is available via the runtime aggregate function
-        AggregateFunction fn = capability.lookupFunction(tool.getRef());
-        assertNotNull(fn.getCall(), "call should be available on the aggregate function");
+        // Verify call is available via the runtime aggregate flow
+        AggregateFlow fn = capability.lookupFlow(tool.getRef());
+        assertNotNull(fn.getCall(), "call should be available on the aggregate flow");
         assertEquals("weather-api.get-forecast", fn.getCall().getOperation());
     }
 
@@ -73,8 +73,8 @@ public class AggregateIntegrationTest {
         assertTrue(tool.getInputParameters().isEmpty(),
                 "inputParameters should not be on tool spec — delegated to aggregate");
 
-        // Verify inputParameters are available via the runtime aggregate function
-        AggregateFunction fn = capability.lookupFunction(tool.getRef());
+        // Verify inputParameters are available via the runtime aggregate flow
+        AggregateFlow fn = capability.lookupFlow(tool.getRef());
         assertEquals(1, fn.getInputParameters().size());
         assertEquals("location", fn.getInputParameters().get(0).getName());
     }
@@ -101,7 +101,7 @@ public class AggregateIntegrationTest {
         io.ikanos.spec.exposes.rest.RestServerSpec restSpec =
                 (io.ikanos.spec.exposes.rest.RestServerSpec) restAdapter.getSpec();
 
-        // POST operation uses key "get-forecast" — name inherited from aggregate function key
+        // POST operation uses key "get-forecast" — name inherited from aggregate flow key
         io.ikanos.spec.exposes.rest.RestServerOperationSpec op =
                 restSpec.getResources().get("forecast").getOperations().get("get-forecast");
         assertEquals("POST", op.getMethod());

--- a/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/McpAuthenticationIntegrationTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/McpAuthenticationIntegrationTest.java
@@ -262,7 +262,7 @@ class McpAuthenticationIntegrationTest {
         String yaml = """
                 ikanos: "%s"
                 info:
-                  label: "MCP Auth Test"
+                  display: "MCP Auth Test"
                   description: "Bearer auth integration test"
                 capability:
                   exposes:
@@ -291,7 +291,7 @@ class McpAuthenticationIntegrationTest {
         String yaml = """
                 ikanos: "%s"
                 info:
-                  label: "MCP Auth Test"
+                  display: "MCP Auth Test"
                   description: "API key auth integration test"
                 capability:
                   exposes:
@@ -322,7 +322,7 @@ class McpAuthenticationIntegrationTest {
         String yaml = """
                 ikanos: "%s"
                 info:
-                  label: "MCP Auth Test"
+                  display: "MCP Auth Test"
                   description: "No auth integration test"
                 capability:
                   exposes:

--- a/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/McpOAuth2IntegrationTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/McpOAuth2IntegrationTest.java
@@ -278,7 +278,7 @@ class McpOAuth2IntegrationTest {
         String yaml = """
                 ikanos: "%s"
                 info:
-                  label: "OAuth2 MCP Test"
+                  display: "OAuth2 MCP Test"
                   description: "OAuth2 integration test"
                 capability:
                   exposes:
@@ -311,7 +311,7 @@ class McpOAuth2IntegrationTest {
         String yaml = """
                 ikanos: "%s"
                 info:
-                  label: "OAuth2 MCP Test"
+                  display: "OAuth2 MCP Test"
                   description: "OAuth2 scope integration test"
                 capability:
                   exposes:

--- a/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/McpToolHintsIntegrationTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/McpToolHintsIntegrationTest.java
@@ -103,7 +103,7 @@ public class McpToolHintsIntegrationTest {
     }
 
     @Test
-    void buildToolAnnotationsShouldReturnNullWhenNoHintsAndNoLabel() {
+    void buildToolAnnotationsShouldReturnNullWhenNoHintsAndNoDisplay() {
         McpServerToolSpec toolSpec = new McpServerToolSpec("test", null, "desc");
 
         McpSchema.ToolAnnotations annotations = adapter.buildToolAnnotations(toolSpec);

--- a/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ObservabilityMcpIntegrationTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ObservabilityMcpIntegrationTest.java
@@ -107,11 +107,11 @@ public class ObservabilityMcpIntegrationTest {
 
         List<SpanData> spans = exporter.getFinishedSpanItems();
 
-        // Find aggregate.function span
+        // Find aggregate.flow span
         SpanData aggregateSpan = spans.stream()
-                .filter(s -> s.getName().equals("aggregate.function"))
+                .filter(s -> s.getName().equals("aggregate.flow"))
                 .findFirst()
-                .orElseThrow(() -> new AssertionError("Missing aggregate.function span"));
+                .orElseThrow(() -> new AssertionError("Missing aggregate.flow span"));
 
         assertEquals(SpanKind.INTERNAL, aggregateSpan.getKind());
         assertEquals("forecast.get-forecast",
@@ -123,7 +123,7 @@ public class ObservabilityMcpIntegrationTest {
                 .findFirst().orElseThrow();
 
         assertEquals(toolSpan.getSpanId(), aggregateSpan.getParentSpanId(),
-                "aggregate.function should be a child of mcp.tool");
+                "aggregate.flow should be a child of mcp.tool");
         assertEquals(toolSpan.getTraceId(), aggregateSpan.getTraceId(),
                 "Both spans should share the same trace");
     }

--- a/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ResourcesPromptsIntegrationTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ResourcesPromptsIntegrationTest.java
@@ -94,7 +94,7 @@ public class ResourcesPromptsIntegrationTest {
                 .orElseThrow(() -> new AssertionError("database-schema resource not found"));
 
         assertEquals("database-schema", dbSchema.getName());
-        assertEquals("Database Schema", dbSchema.getLabel());
+        assertEquals("Database Schema", dbSchema.getDisplay());
         assertEquals("data://databases/pre-release/schema", dbSchema.getUri());
         assertTrue(dbSchema.getDescription().contains("pre-release participants database"));
         assertEquals("application/json", dbSchema.getMimeType());
@@ -112,7 +112,7 @@ public class ResourcesPromptsIntegrationTest {
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("user-profile resource not found"));
 
-        assertEquals("User Profile", userProfile.getLabel());
+        assertEquals("User Profile", userProfile.getDisplay());
         assertEquals("data://users/{userId}/profile", userProfile.getUri());
         assertTrue(userProfile.isTemplate(), "URI with {param} should be a template");
         assertFalse(userProfile.isStatic(), "Dynamic resource should not be static");
@@ -134,7 +134,7 @@ public class ResourcesPromptsIntegrationTest {
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("participant-outreach prompt not found"));
 
-        assertEquals("Participant Outreach", outreach.getLabel());
+        assertEquals("Participant Outreach", outreach.getDisplay());
         assertTrue(outreach.getDescription().contains("pre-release participants"));
         assertFalse(outreach.isFileBased(), "Inline prompt should not be file-based");
         assertEquals(2, outreach.getArguments().size(), "Should have 2 arguments");
@@ -175,7 +175,7 @@ public class ResourcesPromptsIntegrationTest {
         McpServerSpec spec = adapter.getMcpServerSpec();
         McpServerToolSpec tool = spec.getTools().values().iterator().next();
 
-        assertEquals("Query Database", tool.getLabel(), "Tool label should be deserialized");
+        assertEquals("Query Database", tool.getDisplay(), "Tool label should be deserialized");
     }
 
     // ── Handler wiring ────────────────────────────────────────────────────────────────────────────

--- a/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ToolHandlerTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ToolHandlerTest.java
@@ -126,7 +126,11 @@ public class ToolHandlerTest {
         ToolHandler handler = assertDoesNotThrow(
                 () -> new ToolHandler(null, toolMap));
 
+        // Valid tool must be registered and callable
         assertNotNull(handler.handleToolCall("valid-tool", Map.of()));
+        // Malformed entries (null/blank name) must have been dropped — calling them must throw
+        assertThrows(IllegalArgumentException.class,
+                () -> handler.handleToolCall("   ", Map.of()));
     }
 }
 

--- a/ikanos-engine/src/test/java/io/ikanos/engine/exposes/rest/AggregateSharedMockIntegrationTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/exposes/rest/AggregateSharedMockIntegrationTest.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.ikanos.Capability;
-import io.ikanos.engine.aggregates.AggregateFunction;
+import io.ikanos.engine.aggregates.AggregateFlow;
 import io.ikanos.engine.exposes.mcp.McpServerAdapter;
 import io.ikanos.engine.exposes.mcp.ProtocolDispatcher;
 import io.ikanos.spec.IkanosSpec;
@@ -36,7 +36,7 @@ import io.ikanos.spec.exposes.rest.RestServerOperationSpec;
 import io.ikanos.spec.exposes.rest.RestServerSpec;
 
 /**
- * Integration test proving that a single aggregate function mock can be reused unchanged by
+ * Integration test proving that a single aggregate flow mock can be reused unchanged by
  * both MCP and REST adapters.
  */
 public class AggregateSharedMockIntegrationTest {
@@ -64,13 +64,13 @@ public class AggregateSharedMockIntegrationTest {
         RestServerSpec restSpec = (RestServerSpec) restAdapter.getSpec();
         RestServerOperationSpec restOperation = restSpec.getResources().values().iterator().next().getOperations().values().iterator().next();
 
-        // Output parameters are no longer copied — they live on the aggregate function
-        AggregateFunction fn = capability.lookupFunction(restOperation.getRef());
-        assertNotNull(fn, "Aggregate function should be resolvable from ref");
+        // Output parameters are no longer copied — they live on the aggregate flow
+        AggregateFlow fn = capability.lookupFlow(restOperation.getRef());
+        assertNotNull(fn, "aggregate flow should be resolvable from ref");
         assertEquals(2, fn.getOutputParameters().size(),
-                "Aggregate function should have two output parameters");
+                "aggregate flow should have two output parameters");
 
-        // Exercise REST path through the normal flow (delegating to aggregate function)
+        // Exercise REST path through the normal flow (delegating to aggregate flow)
         ResourceRestlet restlet = new ResourceRestlet(capability, restSpec,
                 restSpec.getResources().values().iterator().next());
         Request request = new Request(Method.GET, new Reference("http://localhost/hello?name=Nina"));

--- a/ikanos-engine/src/test/java/io/ikanos/engine/exposes/rest/AggregateSharedMockIntegrationTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/exposes/rest/AggregateSharedMockIntegrationTest.java
@@ -66,9 +66,9 @@ public class AggregateSharedMockIntegrationTest {
 
         // Output parameters are no longer copied — they live on the aggregate flow
         AggregateFlow fn = capability.lookupFlow(restOperation.getRef());
-        assertNotNull(fn, "aggregate flow should be resolvable from ref");
+        assertNotNull(fn, "Aggregate flow should be resolvable from ref");
         assertEquals(2, fn.getOutputParameters().size(),
-                "aggregate flow should have two output parameters");
+                "Aggregate flow should have two output parameters");
 
         // Exercise REST path through the normal flow (delegating to aggregate flow)
         ResourceRestlet restlet = new ResourceRestlet(capability, restSpec,

--- a/ikanos-engine/src/test/java/io/ikanos/engine/exposes/rest/AuthenticationIntegrationTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/exposes/rest/AuthenticationIntegrationTest.java
@@ -46,7 +46,7 @@ public class AuthenticationIntegrationTest {
         String yaml = """
                 ikanos: "%s"
                 info:
-                  label: "Auth test"
+                  display: "Auth test"
                   description: "Auth test"
                 capability:
                   exposes:
@@ -96,7 +96,7 @@ public class AuthenticationIntegrationTest {
         String yaml = """
                 ikanos: "%s"
                 info:
-                  label: "Auth test"
+                  display: "Auth test"
                   description: "Auth test"
                 capability:
                   exposes:

--- a/ikanos-engine/src/test/java/io/ikanos/engine/observability/TelemetryBootstrapTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/observability/TelemetryBootstrapTest.java
@@ -170,13 +170,13 @@ public class TelemetryBootstrapTest {
         assertEquals("vessel-name", stringAttribute(data.getAttributes(), TelemetryBootstrap.ATTR_STEP_MATCH));
     }
 
-    // ── Aggregate function span factory ──
+    // ── aggregate flow span factory ──
 
     @Test
-    void startAggregateFunctionSpanShouldCreateInternalSpanWithRef() {
+    void startAggregateFlowSpanShouldCreateInternalSpanWithRef() {
         initWithInMemoryExporter();
 
-        Span span = TelemetryBootstrap.get().startAggregateFunctionSpan("forecast.get-forecast");
+        Span span = TelemetryBootstrap.get().startAggregateFlowSpan("forecast.get-forecast");
         span.end();
 
         SpanData data = exporter.getFinishedSpanItems().get(0);
@@ -187,10 +187,10 @@ public class TelemetryBootstrapTest {
     }
 
     @Test
-    void startAggregateFunctionSpanShouldDefaultRefWhenNull() {
+    void startAggregateFlowSpanShouldDefaultRefWhenNull() {
         initWithInMemoryExporter();
 
-        Span span = TelemetryBootstrap.get().startAggregateFunctionSpan(null);
+        Span span = TelemetryBootstrap.get().startAggregateFlowSpan(null);
         span.end();
 
         SpanData data = exporter.getFinishedSpanItems().get(0);

--- a/ikanos-engine/src/test/java/io/ikanos/engine/observability/TelemetryBootstrapTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/observability/TelemetryBootstrapTest.java
@@ -180,7 +180,7 @@ public class TelemetryBootstrapTest {
         span.end();
 
         SpanData data = exporter.getFinishedSpanItems().get(0);
-        assertEquals("aggregate.function", data.getName());
+        assertEquals("aggregate.flow", data.getName());
         assertEquals(SpanKind.INTERNAL, data.getKind());
         assertEquals("forecast.get-forecast",
             stringAttribute(data.getAttributes(), TelemetryBootstrap.ATTR_AGGREGATE_REF));

--- a/ikanos-engine/src/test/java/io/ikanos/engine/step/EngineStepHandlerOverrideTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/step/EngineStepHandlerOverrideTest.java
@@ -125,6 +125,7 @@ class EngineStepHandlerOverrideTest {
         LinkedHashMap<String, OperationStepSpec> steps1 = new LinkedHashMap<>();
         steps1.put(step1.getName(), step1);
         steps1.put(step2.getName(), step2);
+        Map<String, Object> params = new HashMap<>();
         OperationStepExecutor.StepExecutionResult result =
                 executor.executeSteps(steps1, params);
 

--- a/ikanos-engine/src/test/java/io/ikanos/engine/util/ConversionFormatTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/util/ConversionFormatTest.java
@@ -18,38 +18,38 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import org.junit.jupiter.api.Test;
 
 /**
- * Unit tests for {@link ConversionFormat#fromLabel(String)}.
+ * Unit tests for {@link ConversionFormat#fromDisplay(String)}.
  */
 public class ConversionFormatTest {
 
     @Test
-    void fromLabelShouldReturnNullForNullInput() {
-        assertNull(ConversionFormat.fromLabel(null),
+    void fromDisplayShouldReturnNullForNullInput() {
+        assertNull(ConversionFormat.fromDisplay(null),
                 "null input must return null — callers treat null as 'use default JSON'");
     }
 
     @Test
-    void fromLabelShouldReturnNullForUnknownFormat() {
-        assertNull(ConversionFormat.fromLabel("ini"),
+    void fromDisplayShouldReturnNullForUnknownFormat() {
+        assertNull(ConversionFormat.fromDisplay("ini"),
                 "unknown format must return null, not throw");
     }
 
     @Test
-    void fromLabelShouldMatchCaseInsensitively() {
-        assertEquals(ConversionFormat.JSON, ConversionFormat.fromLabel("JSON"));
-        assertEquals(ConversionFormat.JSON, ConversionFormat.fromLabel("json"));
-        assertEquals(ConversionFormat.XML,  ConversionFormat.fromLabel("Xml"));
-        assertEquals(ConversionFormat.CSV,  ConversionFormat.fromLabel("CSV"));
+    void fromDisplayShouldMatchCaseInsensitively() {
+        assertEquals(ConversionFormat.JSON, ConversionFormat.fromDisplay("JSON"));
+        assertEquals(ConversionFormat.JSON, ConversionFormat.fromDisplay("json"));
+        assertEquals(ConversionFormat.XML,  ConversionFormat.fromDisplay("Xml"));
+        assertEquals(ConversionFormat.CSV,  ConversionFormat.fromDisplay("CSV"));
     }
 
     @Test
-    void fromLabelShouldReturnCorrectConstantForEachKnownFormat() {
-        assertEquals(ConversionFormat.YAML,     ConversionFormat.fromLabel("yaml"));
-        assertEquals(ConversionFormat.TSV,      ConversionFormat.fromLabel("tsv"));
-        assertEquals(ConversionFormat.PSV,      ConversionFormat.fromLabel("psv"));
-        assertEquals(ConversionFormat.HTML,     ConversionFormat.fromLabel("html"));
-        assertEquals(ConversionFormat.MARKDOWN, ConversionFormat.fromLabel("markdown"));
-        assertEquals(ConversionFormat.PROTOBUF, ConversionFormat.fromLabel("protobuf"));
-        assertEquals(ConversionFormat.AVRO,     ConversionFormat.fromLabel("avro"));
+    void fromDisplayShouldReturnCorrectConstantForEachKnownFormat() {
+        assertEquals(ConversionFormat.YAML,     ConversionFormat.fromDisplay("yaml"));
+        assertEquals(ConversionFormat.TSV,      ConversionFormat.fromDisplay("tsv"));
+        assertEquals(ConversionFormat.PSV,      ConversionFormat.fromDisplay("psv"));
+        assertEquals(ConversionFormat.HTML,     ConversionFormat.fromDisplay("html"));
+        assertEquals(ConversionFormat.MARKDOWN, ConversionFormat.fromDisplay("markdown"));
+        assertEquals(ConversionFormat.PROTOBUF, ConversionFormat.fromDisplay("protobuf"));
+        assertEquals(ConversionFormat.AVRO,     ConversionFormat.fromDisplay("avro"));
     }
 }

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-basic.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-basic.yaml
@@ -1,6 +1,6 @@
 ikanos: 1.0.0-alpha3
 info:
-  label: Aggregate Basic Test
+  display: Aggregate Basic Test
   description: Test capability for aggregate function ref resolution
   tags:
   - Test
@@ -10,7 +10,7 @@ info:
 capability:
   aggregates:
     forecast:
-      label: Forecast
+      display: Forecast
       namespace: forecast
       functions:
         get-forecast:

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-basic.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-basic.yaml
@@ -1,4 +1,4 @@
-﻿ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha3
 info:
   display: Aggregate Basic Test
   description: Test capability for aggregate function ref resolution

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-basic.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-basic.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+﻿ikanos: 1.0.0-alpha3
 info:
   display: Aggregate Basic Test
   description: Test capability for aggregate function ref resolution
@@ -12,7 +12,7 @@ capability:
     forecast:
       display: Forecast
       namespace: forecast
-      functions:
+      flows:
         get-forecast:
           description: Fetch current weather forecast for a location.
           semantics:

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-hints-override.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-hints-override.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+﻿ikanos: 1.0.0-alpha3
 info:
   display: Aggregate Hints Override Test
   description: Test capability for semantics-to-hints derivation with override
@@ -12,7 +12,7 @@ capability:
     data:
       display: Data
       namespace: data
-      functions:
+      flows:
         read-items:
           description: Read items from the data store.
           semantics:

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-hints-override.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-hints-override.yaml
@@ -1,4 +1,4 @@
-﻿ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha3
 info:
   display: Aggregate Hints Override Test
   description: Test capability for semantics-to-hints derivation with override

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-hints-override.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-hints-override.yaml
@@ -1,6 +1,6 @@
 ikanos: 1.0.0-alpha3
 info:
-  label: Aggregate Hints Override Test
+  display: Aggregate Hints Override Test
   description: Test capability for semantics-to-hints derivation with override
   tags:
   - Test
@@ -10,7 +10,7 @@ info:
 capability:
   aggregates:
     data:
-      label: Data
+      display: Data
       namespace: data
       functions:
         read-items:

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-invalid-ref.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-invalid-ref.yaml
@@ -1,6 +1,6 @@
 ikanos: "1.0.0-alpha3"
 info:
-  label: "Aggregate Invalid Ref Test"
+  display: "Aggregate Invalid Ref Test"
   description: "Test capability with an unknown aggregate ref"
   tags:
   - Test
@@ -11,7 +11,7 @@ info:
 capability:
   aggregates:
     "data":
-      label: "Data"
+      display: "Data"
       namespace: "data"
       functions:
         "read-items":

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-invalid-ref.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-invalid-ref.yaml
@@ -1,4 +1,4 @@
-﻿ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha3"
 info:
   display: "Aggregate Invalid Ref Test"
   description: "Test capability with an unknown aggregate ref"

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-invalid-ref.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-invalid-ref.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+﻿ikanos: "1.0.0-alpha3"
 info:
   display: "Aggregate Invalid Ref Test"
   description: "Test capability with an unknown aggregate ref"
@@ -13,7 +13,7 @@ capability:
     "data":
       display: "Data"
       namespace: "data"
-      functions:
+      flows:
         "read-items":
           description: "Read items."
           call: "mock-api.get-items"

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-shared-mock.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-shared-mock.yaml
@@ -1,6 +1,6 @@
 ikanos: 1.0.0-alpha3
 info:
-  label: Aggregate Shared Mock Test
+  display: Aggregate Shared Mock Test
   description: Shared aggregate mock function consumed by MCP and REST refs
   tags:
   - Test
@@ -10,7 +10,7 @@ info:
 capability:
   aggregates:
     greeting:
-      label: Greeting
+      display: Greeting
       namespace: greeting
       functions:
         hello:

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-shared-mock.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-shared-mock.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+﻿ikanos: 1.0.0-alpha3
 info:
   display: Aggregate Shared Mock Test
   description: Shared aggregate mock function consumed by MCP and REST refs
@@ -12,7 +12,7 @@ capability:
     greeting:
       display: Greeting
       namespace: greeting
-      functions:
+      flows:
         hello:
           description: Builds a greeting payload from input parameters.
           inputParameters:

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-shared-mock.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-shared-mock.yaml
@@ -1,4 +1,4 @@
-﻿ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha3
 info:
   display: Aggregate Shared Mock Test
   description: Shared aggregate mock function consumed by MCP and REST refs

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-step-with-namespace.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-step-with-namespace.yaml
@@ -1,6 +1,6 @@
 ikanos: 1.0.0-alpha3
 info:
-  label: Aggregate Step Namespace Test
+  display: Aggregate Step Namespace Test
   description: Test capability for namespace-qualified references in aggregate function
     steps
   tags:
@@ -11,7 +11,7 @@ info:
 capability:
   aggregates:
     shipyard:
-      label: Shipyard
+      display: Shipyard
       namespace: shipyard
       functions:
         get-voyage-manifest:

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-step-with-namespace.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-step-with-namespace.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+﻿ikanos: 1.0.0-alpha3
 info:
   display: Aggregate Step Namespace Test
   description: Test capability for namespace-qualified references in aggregate function
@@ -13,7 +13,7 @@ capability:
     shipyard:
       display: Shipyard
       namespace: shipyard
-      functions:
+      flows:
         get-voyage-manifest:
           description: Assemble a voyage manifest using an orchestrated step.
           inputParameters:

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-step-with-namespace.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-step-with-namespace.yaml
@@ -1,4 +1,4 @@
-﻿ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha3
 info:
   display: Aggregate Step Namespace Test
   description: Test capability for namespace-qualified references in aggregate function

--- a/ikanos-engine/src/test/resources/baseuri-trailing-slash-capability.yaml
+++ b/ikanos-engine/src/test/resources/baseuri-trailing-slash-capability.yaml
@@ -1,6 +1,6 @@
 ikanos: "1.0.0-alpha3"
 info:
-  label: "BaseUri Trailing Slash Regression Test"
+  display: "BaseUri Trailing Slash Regression Test"
   description: "Capability intentionally using a trailing-slash baseUri to test strict validation"
   created: "2026-01-01"
   modified: "2026-01-01"

--- a/ikanos-engine/src/test/resources/control/control-capability.yaml
+++ b/ikanos-engine/src/test/resources/control/control-capability.yaml
@@ -2,7 +2,7 @@
 ---
 ikanos: "1.0.0-alpha3"
 info:
-  label: "Control Port Test Capability"
+  display: "Control Port Test Capability"
   description: "Test capability for Control Server Adapter deserialization and wiring"
   tags:
   - Test

--- a/ikanos-engine/src/test/resources/control/control-observability-disabled.yaml
+++ b/ikanos-engine/src/test/resources/control/control-observability-disabled.yaml
@@ -1,6 +1,6 @@
 ikanos: "1.0.0-alpha3"
 info:
-  label: "Control Port — Observability Disabled"
+  display: "Control Port — Observability Disabled"
   description: "Test fixture: observability.enabled=false should suppress /metrics and /traces"
   tags:
   - Test

--- a/ikanos-engine/src/test/resources/control/control-scripting-capability.yaml
+++ b/ikanos-engine/src/test/resources/control/control-scripting-capability.yaml
@@ -1,6 +1,6 @@
 ikanos: "1.0.0-alpha3"
 info:
-  label: "Control Port Scripting Test"
+  display: "Control Port Scripting Test"
   description: "Test capability for scripting governance on the Control Port"
   tags:
   - Test

--- a/ikanos-engine/src/test/resources/embedding/embedding-capability.yaml
+++ b/ikanos-engine/src/test/resources/embedding/embedding-capability.yaml
@@ -1,6 +1,6 @@
 ikanos: 1.0.0-alpha3
 info:
-  label: Embedding Test
+  display: Embedding Test
   description: Test capability for step handler registry integration
   tags:
   - Test

--- a/ikanos-engine/src/test/resources/formats/avro-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/avro-capability.yaml
@@ -1,6 +1,6 @@
 ikanos: 1.0.0-alpha3
 info:
-  label: Avro Test Capability
+  display: Avro Test Capability
   description: Test capability for Avro message decoding from API responses
   tags:
   - Test
@@ -16,7 +16,7 @@ capability:
     resources:
       records:
         path: /avro/records
-        label: Avro Records Resource
+        display: Avro Records Resource
         description: Test resource that parses Avro messages
         operations:
           get-records:
@@ -48,9 +48,9 @@ capability:
     resources:
       records:
         path: api/records
-        label: Mock Records API
+        display: Mock Records API
         operations:
           get-records:
             method: GET
-            label: Get Records
+            display: Get Records
             outputRawFormat: avro

--- a/ikanos-engine/src/test/resources/formats/csv-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/csv-capability.yaml
@@ -1,6 +1,6 @@
 ikanos: 1.0.0-alpha3
 info:
-  label: CSV Test Capability
+  display: CSV Test Capability
   description: Test capability for CSV parsing from API responses
   tags:
   - Test
@@ -16,7 +16,7 @@ capability:
     resources:
       users:
         path: /csv/users
-        label: CSV Users Resource
+        display: CSV Users Resource
         description: Test resource that parses CSV responses
         operations:
           get-users:
@@ -48,9 +48,9 @@ capability:
     resources:
       users:
         path: api/users
-        label: Mock Users API
+        display: Mock Users API
         operations:
           get-users:
             method: GET
-            label: Get Users
+            display: Get Users
             outputRawFormat: csv

--- a/ikanos-engine/src/test/resources/formats/html-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/html-capability.yaml
@@ -1,6 +1,6 @@
 ikanos: "1.0.0-alpha3"
 info:
-  label: "HTML Test Capability"
+  display: "HTML Test Capability"
   description: "Test capability for HTML table parsing"
   tags:
   - Test

--- a/ikanos-engine/src/test/resources/formats/markdown-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/markdown-capability.yaml
@@ -1,6 +1,6 @@
 ikanos: "1.0.0-alpha3"
 info:
-  label: "Markdown Test Capability"
+  display: "Markdown Test Capability"
   description: "Test capability for Markdown parsing"
   tags:
   - Test

--- a/ikanos-engine/src/test/resources/formats/proto-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/proto-capability.yaml
@@ -1,6 +1,6 @@
 ikanos: 1.0.0-alpha3
 info:
-  label: Protobuf Test Capability
+  display: Protobuf Test Capability
   description: Test capability for Protobuf message decoding from API responses
   tags:
   - Test
@@ -16,7 +16,7 @@ capability:
     resources:
       records:
         path: /proto/records
-        label: Protobuf Records Resource
+        display: Protobuf Records Resource
         description: Test resource that parses Protobuf messages
         operations:
           get-records:
@@ -48,9 +48,9 @@ capability:
     resources:
       records:
         path: api/records
-        label: Mock Records API
+        display: Mock Records API
         operations:
           get-records:
             method: GET
-            label: Get Records
+            display: Get Records
             outputRawFormat: protobuf

--- a/ikanos-engine/src/test/resources/formats/xml-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/xml-capability.yaml
@@ -1,6 +1,6 @@
 ikanos: 1.0.0-alpha3
 info:
-  label: XML Test Capability
+  display: XML Test Capability
   description: Test capability for XML parsing from API responses
   tags:
   - Test
@@ -16,7 +16,7 @@ capability:
     resources:
       users:
         path: /xml/users
-        label: XML Users Resource
+        display: XML Users Resource
         description: Test resource that parses XML responses
         operations:
           get-users:
@@ -48,9 +48,9 @@ capability:
     resources:
       users:
         path: api/users
-        label: Mock Users API
+        display: Mock Users API
         operations:
           get-users:
             method: GET
-            label: Get Users
+            display: Get Users
             outputRawFormat: xml

--- a/ikanos-engine/src/test/resources/formats/yaml-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/yaml-capability.yaml
@@ -1,6 +1,6 @@
 ikanos: 1.0.0-alpha3
 info:
-  label: YAML Test Capability
+  display: YAML Test Capability
   description: Test capability for YAML parsing from API responses
   tags:
   - Test
@@ -16,7 +16,7 @@ capability:
     resources:
       users:
         path: /yaml/users
-        label: YAML Users Resource
+        display: YAML Users Resource
         description: Test resource that parses YAML responses
         operations:
           get-users:
@@ -48,9 +48,9 @@ capability:
     resources:
       users:
         path: api/users
-        label: Mock Users API
+        display: Mock Users API
         operations:
           get-users:
             method: GET
-            label: Get Users
+            display: Get Users
             outputRawFormat: yaml

--- a/ikanos-engine/src/test/resources/http/http-forward-value-capability.yaml
+++ b/ikanos-engine/src/test/resources/http/http-forward-value-capability.yaml
@@ -1,6 +1,6 @@
 ikanos: 1.0.0-alpha3
 info:
-  label: HTTP Forward with Value Field Test
+  display: HTTP Forward with Value Field Test
   description: Test capability for forward spec with value field supporting Mustache
     templates
   created: '2026-03-03'

--- a/ikanos-engine/src/test/resources/mcp/mcp-capability.yaml
+++ b/ikanos-engine/src/test/resources/mcp/mcp-capability.yaml
@@ -1,6 +1,6 @@
 ikanos: 1.0.0-alpha3
 info:
-  label: MCP Test Capability
+  display: MCP Test Capability
   description: Test capability for MCP Server Adapter deserialization and wiring
   tags:
   - Test
@@ -43,10 +43,10 @@ capability:
     resources:
       query:
         path: databases/{{datasource_id}}/query
-        label: Query database resource
+        display: Query database resource
         operations:
           query-db:
             method: POST
-            label: Query Database
+            display: Query Database
             body: "{\n  \"filter\": {\n    \"property\": \"Status\",\n    \"select\"\
               : {\n      \"equals\": \"Committed\"\n    }\n  }\n}\n"

--- a/ikanos-engine/src/test/resources/mcp/mcp-hints-capability.yaml
+++ b/ikanos-engine/src/test/resources/mcp/mcp-hints-capability.yaml
@@ -1,6 +1,6 @@
 ikanos: 1.0.0-alpha3
 info:
-  label: MCP Hints Test Capability
+  display: MCP Hints Test Capability
   description: Test capability for MCP tool hints (ToolAnnotations) support
   tags:
   - Test
@@ -16,7 +16,7 @@ capability:
     description: Test MCP server for validating tool hints mapped to ToolAnnotations.
     tools:
       read-data:
-        label: Read Data
+        display: Read Data
         description: Read-only data retrieval tool.
         hints:
           readOnly: true

--- a/ikanos-engine/src/test/resources/mcp/mcp-resources-prompts-capability.yaml
+++ b/ikanos-engine/src/test/resources/mcp/mcp-resources-prompts-capability.yaml
@@ -1,6 +1,6 @@
 ikanos: 1.0.0-alpha3
 info:
-  label: MCP Resources & Prompts Test Capability
+  display: MCP Resources & Prompts Test Capability
   description: Test capability for MCP Server Adapter resources and prompts support
   tags:
   - Test
@@ -16,7 +16,7 @@ capability:
     description: Test MCP server for validating resources and prompts support.
     tools:
       query-database:
-        label: Query Database
+        display: Query Database
         description: Query the test database to retrieve committed participants.
         call: mock-api.query-db
         with:
@@ -32,7 +32,7 @@ capability:
                 mapping: $.id
     resources:
       database-schema:
-        label: Database Schema
+        display: Database Schema
         uri: data://databases/pre-release/schema
         description: Schema of the pre-release participants database
         mimeType: application/json
@@ -40,7 +40,7 @@ capability:
         with:
           datasource_id: test-db-id-123
       user-profile:
-        label: User Profile
+        display: User Profile
         uri: data://users/{userId}/profile
         description: User profile by ID
         mimeType: application/json
@@ -49,7 +49,7 @@ capability:
           datasource_id: '{{userId}}'
     prompts:
       participant-outreach:
-        label: Participant Outreach
+        display: Participant Outreach
         description: Draft outreach message to pre-release participants
         arguments:
           participant_name:
@@ -63,7 +63,7 @@ capability:
           content: Draft a personalized outreach email to {{participant_name}} about
             the upcoming {{product_name}} pre-release. Be professional but friendly.
       summary-prompt:
-        label: Summary Prompt
+        display: Summary Prompt
         description: Summarize data in a given format
         arguments:
           data:
@@ -93,10 +93,10 @@ capability:
     resources:
       query:
         path: databases/{{datasource_id}}/query
-        label: Query database resource
+        display: Query database resource
         operations:
           query-db:
             method: POST
-            label: Query Database
+            display: Query Database
             body: "{\n  \"filter\": {\n    \"property\": \"Status\",\n    \"select\"\
               : {\n      \"equals\": \"Committed\"\n    }\n  }\n}\n"

--- a/ikanos-engine/src/test/resources/mcp/mcp-stdio-capability.yaml
+++ b/ikanos-engine/src/test/resources/mcp/mcp-stdio-capability.yaml
@@ -1,6 +1,6 @@
 ikanos: 1.0.0-alpha3
 info:
-  label: MCP Stdio Test Capability
+  display: MCP Stdio Test Capability
   description: Test capability for MCP Server Adapter with stdio transport
   tags:
   - Test
@@ -43,10 +43,10 @@ capability:
     resources:
       query:
         path: databases/{{datasource_id}}/query
-        label: Query database resource
+        display: Query database resource
         operations:
           query-db:
             method: POST
-            label: Query Database
+            display: Query Database
             body: "{\n  \"filter\": {\n    \"property\": \"Status\",\n    \"select\"\
               : {\n      \"equals\": \"Committed\"\n    }\n  }\n}\n"

--- a/ikanos-engine/src/test/resources/nested-object-output-capability.yaml
+++ b/ikanos-engine/src/test/resources/nested-object-output-capability.yaml
@@ -1,6 +1,6 @@
 ikanos: 1.0.0-alpha3
 info:
-  label: Nested Object Output Capability
+  display: Nested Object Output Capability
   description: Test fixture for verifying that output mappings correctly resolve nested
     object properties without a top-level mapping key (regression for resolver nested
     object bug).

--- a/ikanos-engine/src/test/resources/observability/observability-capability.yaml
+++ b/ikanos-engine/src/test/resources/observability/observability-capability.yaml
@@ -1,6 +1,6 @@
 ikanos: "1.0.0-alpha3"
 info:
-  label: "Observability Test Capability"
+  display: "Observability Test Capability"
   description: "Test capability for observability spec deserialization"
   tags:
   - Test

--- a/ikanos-engine/src/test/resources/observability/observability-disabled.yaml
+++ b/ikanos-engine/src/test/resources/observability/observability-disabled.yaml
@@ -1,6 +1,6 @@
 ikanos: "1.0.0-alpha3"
 info:
-  label: "Observability Disabled Capability"
+  display: "Observability Disabled Capability"
   description: "Test capability with observability disabled"
   tags:
   - Test

--- a/ikanos-engine/src/test/resources/register.capability.yml
+++ b/ikanos-engine/src/test/resources/register.capability.yml
@@ -1,6 +1,6 @@
 ikanos: "1.0.0-alpha3"
 info:
-  label: "register"
+  display: "register"
   description: "Business description of your capability"
 capability:
   exposes:
@@ -10,7 +10,7 @@ capability:
     resources:
       notion:
         path: "/notion/{{path}}"
-        label: "Notion API Pass-thru Proxy"
+        display: "Notion API Pass-thru Proxy"
         description: "A proxy to forward requests to the Notion API while the capability is being configured"
         forward:
           targetNamespace: "notion"

--- a/ikanos-engine/src/test/resources/skill-capability.yaml
+++ b/ikanos-engine/src/test/resources/skill-capability.yaml
@@ -1,6 +1,6 @@
 ikanos: 1.0.0-alpha3
 info:
-  label: Skill Test Capability
+  display: Skill Test Capability
   description: Test capability for Skill Server Adapter deserialization and wiring
   tags:
   - Test
@@ -16,12 +16,12 @@ capability:
     resources:
       orders:
         path: /orders
-        label: Orders
+        display: Orders
         description: Order management endpoint
         operations:
           list-orders:
             method: GET
-            label: List Orders
+            display: List Orders
             call: mock-orders.list
   - type: skill
     address: localhost
@@ -55,4 +55,4 @@ capability:
         operations:
           list:
             method: GET
-            label: List Orders
+            display: List Orders

--- a/ikanos-engine/src/test/resources/tutorial/step-10-shipyard-rest-adapter.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-10-shipyard-rest-adapter.yml
@@ -1,4 +1,4 @@
-﻿ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha3"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-10-shipyard-rest-adapter.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-10-shipyard-rest-adapter.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+﻿ikanos: "1.0.0-alpha3"
 
 binds:
 - namespace: "registry-env"
@@ -25,7 +25,7 @@ capability:
     crew-resolver:
       display: "Crew Resolver"
       namespace: crew-resolver
-      functions:
+      flows:
         resolve-crew-for-ship:
           description: "Resolve crew member names and roles for a given ship"
           semantics:

--- a/ikanos-engine/src/test/resources/tutorial/step-10-shipyard-rest-adapter.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-10-shipyard-rest-adapter.yml
@@ -23,7 +23,7 @@ capability:
 
   aggregates:
     crew-resolver:
-      label: "Crew Resolver"
+      display: "Crew Resolver"
       namespace: crew-resolver
       functions:
         resolve-crew-for-ship:

--- a/ikanos-engine/src/test/resources/tutorial/step-11-shipyard-fleet-manifest.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-11-shipyard-fleet-manifest.yml
@@ -1,7 +1,7 @@
 ikanos: "1.0.0-alpha3"
 
 info:
-  label: "Shipyard Fleet Management"
+  display: "Shipyard Fleet Management"
   description: "Maritime fleet management capability — exposes MCP tools, skills, and REST APIs for ship registry, legacy dockyard, and voyage planning."
   tags:
   - Maritime

--- a/ikanos-engine/src/test/resources/tutorial/step-9-shipyard-aggregates.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-9-shipyard-aggregates.yml
@@ -1,4 +1,4 @@
-﻿ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha3"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-9-shipyard-aggregates.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-9-shipyard-aggregates.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+﻿ikanos: "1.0.0-alpha3"
 
 binds:
 - namespace: "registry-env"
@@ -25,7 +25,7 @@ capability:
     crew-resolver:
       display: "Crew Resolver"
       namespace: crew-resolver
-      functions:
+      flows:
         resolve-crew-for-ship:
           description: "Resolve crew member names and roles for a given ship"
           semantics:

--- a/ikanos-engine/src/test/resources/tutorial/step-9-shipyard-aggregates.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-9-shipyard-aggregates.yml
@@ -23,7 +23,7 @@ capability:
 
   aggregates:
     crew-resolver:
-      label: "Crew Resolver"
+      display: "Crew Resolver"
       namespace: crew-resolver
       functions:
         resolve-crew-for-ship:

--- a/ikanos-spec/src/main/java/io/ikanos/spec/InfoSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/InfoSpec.java
@@ -21,7 +21,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 public class InfoSpec {
 
-    private volatile String label;
+    private volatile String display;
 
     private volatile String description;
 
@@ -33,8 +33,8 @@ public class InfoSpec {
 
     private final List<StakeholderSpec> stakeholders;
 
-    public InfoSpec(String label, String description, String created, String modified) {
-        this.label = label;
+    public InfoSpec(String display, String description, String created, String modified) {
+        this.display = display;
         this.description = description;
         this.tags = new CopyOnWriteArrayList<>();
         this.created = created;
@@ -46,12 +46,12 @@ public class InfoSpec {
         this(null, null, null, null);
     }
 
-    public String getLabel() {
-        return label;
+    public String getDisplay() {
+        return display;
     }
 
-    public void setLabel(String label) {
-        this.label = label;
+    public void setDisplay(String display) {
+        this.display = display;
     }
 
     public String getDescription() {

--- a/ikanos-spec/src/main/java/io/ikanos/spec/OperationSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/OperationSpec.java
@@ -42,7 +42,7 @@ public class OperationSpec {
 
     private final AtomicReference<String> name = new AtomicReference<>();
 
-    private final AtomicReference<String> label = new AtomicReference<>();
+    private final AtomicReference<String> display = new AtomicReference<>();
 
     private final AtomicReference<String> description = new AtomicReference<>();
 
@@ -63,19 +63,19 @@ public class OperationSpec {
         this(null, null, null, null, null, null, null);
     }
 
-    public OperationSpec(ResourceSpec parentResource, String method, String name, String label) {
-        this(parentResource, method, name, label, null, null, null);
+    public OperationSpec(ResourceSpec parentResource, String method, String name, String display) {
+        this(parentResource, method, name, display, null, null, null);
     }
 
-    public OperationSpec(ResourceSpec parentResource, String method, String name, String label, String description, String outputRawFormat) {
-        this(parentResource, method, name, label, description, outputRawFormat, null);
+    public OperationSpec(ResourceSpec parentResource, String method, String name, String display, String description, String outputRawFormat) {
+        this(parentResource, method, name, display, description, outputRawFormat, null);
     }
 
-    public OperationSpec(ResourceSpec parentResource, String method, String name, String label, String description, String outputRawFormat, String outputSchema) {
+    public OperationSpec(ResourceSpec parentResource, String method, String name, String display, String description, String outputRawFormat, String outputSchema) {
         this.parentResource.set(parentResource);
         this.method.set(method);
         this.name.set(name);
-        this.label.set(label);
+        this.display.set(display);
         this.description.set(description);
         this.outputRawFormat.set(outputRawFormat);
         this.outputSchema.set(outputSchema);
@@ -105,12 +105,12 @@ public class OperationSpec {
         this.name.set(name);
     }
 
-    public String getLabel() {
-        return label.get();
+    public String getDisplay() {
+        return display.get();
     }
 
-    public void setLabel(String label) {
-        this.label.set(label);
+    public void setDisplay(String display) {
+        this.display.set(display);
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/ikanos-spec/src/main/java/io/ikanos/spec/OperationSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/OperationSpec.java
@@ -47,6 +47,9 @@ public class OperationSpec {
     private final AtomicReference<String> description = new AtomicReference<>();
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private final CopyOnWriteArrayList<String> tags = new CopyOnWriteArrayList<>();
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonDeserialize(using = InputParameterMapDeserializer.class)
     private final AtomicReference<Map<String, InputParameterSpec>> inputParameters =
             new AtomicReference<>(Collections.synchronizedMap(new LinkedHashMap<>()));
@@ -121,6 +124,9 @@ public class OperationSpec {
     public void setDescription(String description) {
         this.description.set(description);
     }
+
+    public List<String> getTags() { return tags; }
+    public void setTags(List<String> tags) { this.tags.clear(); if (tags != null) this.tags.addAll(tags); }
 
     public List<InputParameterSpec> getInputParameters() {
         return List.copyOf(inputParameters.get().values());

--- a/ikanos-spec/src/main/java/io/ikanos/spec/ResourceSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/ResourceSpec.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -40,6 +41,9 @@ public class ResourceSpec {
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private volatile String description;
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private final CopyOnWriteArrayList<String> tags = new CopyOnWriteArrayList<>();
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonDeserialize(using = InputParameterMapDeserializer.class)
@@ -88,6 +92,9 @@ public class ResourceSpec {
     public void setDescription(String description) {
         this.description = description;
     }
+
+    public List<String> getTags() { return tags; }
+    public void setTags(List<String> tags) { this.tags.clear(); if (tags != null) this.tags.addAll(tags); }
 
     /**
      * Returns input parameters in declaration order. Consumers (engine) are unchanged

--- a/ikanos-spec/src/main/java/io/ikanos/spec/ResourceSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/ResourceSpec.java
@@ -36,7 +36,7 @@ public class ResourceSpec {
 
     private volatile String name;
 
-    private volatile String label;
+    private volatile String display;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private volatile String description;
@@ -50,10 +50,10 @@ public class ResourceSpec {
         this(null, null, null, null);
     }
 
-    public ResourceSpec(String path, String name, String label, String description) {
+    public ResourceSpec(String path, String name, String display, String description) {
         this.path = path;
         this.name = name;
-        this.label = label;
+        this.display = display;
         this.description = description;
     }
 
@@ -73,12 +73,12 @@ public class ResourceSpec {
         this.name = name;
     }
 
-    public String getLabel() {
-        return label;
+    public String getDisplay() {
+        return display;
     }
 
-    public void setLabel(String label) {
-        this.label = label;
+    public void setDisplay(String display) {
+        this.display = display;
     }
 
     public String getDescription() {

--- a/ikanos-spec/src/main/java/io/ikanos/spec/StakeholderSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/StakeholderSpec.java
@@ -46,8 +46,8 @@ public class StakeholderSpec {
         return fullName;
     }
 
-    public void setFullName(String label) {
-        this.fullName = label;
+    public void setFullName(String display) {
+        this.fullName = display;
     }
 
     public String getEmail() {

--- a/ikanos-spec/src/main/java/io/ikanos/spec/StakeholderSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/StakeholderSpec.java
@@ -46,8 +46,8 @@ public class StakeholderSpec {
         return fullName;
     }
 
-    public void setFullName(String display) {
-        this.fullName = display;
+    public void setFullName(String fullName) {
+        this.fullName = fullName;
     }
 
     public String getEmail() {

--- a/ikanos-spec/src/main/java/io/ikanos/spec/aggregates/AggregateFlowMapDeserializer.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/aggregates/AggregateFlowMapDeserializer.java
@@ -16,13 +16,13 @@ package io.ikanos.spec.aggregates;
 import io.ikanos.spec.util.NamedMapDeserializer;
 
 /**
- * Jackson deserializer for {@code Aggregate.functions} named-object map.
- * Reads {@code { "fn-name": { ... }, ... }} and injects the key as
- * {@link AggregateFunctionSpec#setName(String)}.
+ * Jackson deserializer for {@code Aggregate.flows} named-object map.
+ * Reads {@code { "flow-name": { ... }, ... }} and injects the key as
+ * {@link AggregateFlowSpec#setName(String)}.
  */
-public class AggregateFunctionMapDeserializer extends NamedMapDeserializer<AggregateFunctionSpec> {
+public class AggregateFlowMapDeserializer extends NamedMapDeserializer<AggregateFlowSpec> {
 
-    public AggregateFunctionMapDeserializer() {
-        super(AggregateFunctionSpec.class, AggregateFunctionSpec::setName);
+    public AggregateFlowMapDeserializer() {
+        super(AggregateFlowSpec.class, AggregateFlowSpec::setName);
     }
 }

--- a/ikanos-spec/src/main/java/io/ikanos/spec/aggregates/AggregateFlowSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/aggregates/AggregateFlowSpec.java
@@ -31,10 +31,10 @@ import io.ikanos.spec.util.OperationStepSpec;
 import io.ikanos.spec.util.StepOutputMappingSpec;
 
 /**
- * Aggregate Function Specification Element.
+ * Aggregate Flow Specification Element.
  * 
- * <p>A reusable invocable unit within an aggregate. Adapter units reference it via
- * {@code ref: aggregate-namespace.function-name}.</p>
+ * <p>A reusable callable flow within an aggregate. Adapter units reference it via
+ * {@code ref: aggregate-namespace.flow-name}.</p>
  *
  * <h2>Thread safety</h2>
  * Each scalar field is held in an {@link AtomicReference}; the {@code with} parameter map is
@@ -43,7 +43,7 @@ import io.ikanos.spec.util.StepOutputMappingSpec;
  * is a synchronized {@link LinkedHashMap} in an {@link AtomicReference}. This satisfies
  * SonarQube rule {@code java:S3077}.
  */
-public class AggregateFunctionSpec {
+public class AggregateFlowSpec {
 
     private final AtomicReference<String> name = new AtomicReference<>();
     private final AtomicReference<String> description = new AtomicReference<>();
@@ -68,7 +68,7 @@ public class AggregateFunctionSpec {
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private final CopyOnWriteArrayList<OutputParameterSpec> outputParameters = new CopyOnWriteArrayList<>();
 
-    public AggregateFunctionSpec() {}
+    public AggregateFlowSpec() {}
 
     public String getName() { return name.get(); }
     public void setName(String name) { this.name.set(name); }

--- a/ikanos-spec/src/main/java/io/ikanos/spec/aggregates/AggregateFunctionSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/aggregates/AggregateFunctionSpec.java
@@ -47,6 +47,8 @@ public class AggregateFunctionSpec {
 
     private final AtomicReference<String> name = new AtomicReference<>();
     private final AtomicReference<String> description = new AtomicReference<>();
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private final CopyOnWriteArrayList<String> tags = new CopyOnWriteArrayList<>();
     private final AtomicReference<SemanticsSpec> semantics = new AtomicReference<>();
     private final AtomicReference<ServerCallSpec> call = new AtomicReference<>();
     private final AtomicReference<Map<String, Object>> with = new AtomicReference<>();
@@ -73,6 +75,9 @@ public class AggregateFunctionSpec {
 
     public String getDescription() { return description.get(); }
     public void setDescription(String description) { this.description.set(description); }
+
+    public List<String> getTags() { return tags; }
+    public void setTags(List<String> tags) { this.tags.clear(); if (tags != null) this.tags.addAll(tags); }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public SemanticsSpec getSemantics() { return semantics.get(); }

--- a/ikanos-spec/src/main/java/io/ikanos/spec/aggregates/AggregateSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/aggregates/AggregateSpec.java
@@ -23,12 +23,12 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 /**
  * Aggregate Specification Element.
  *
- * <p>A domain aggregate grouping reusable functions. Adapters reference these functions via ref.</p>
+ * <p>A domain aggregate grouping reusable flows. Adapters reference these flows via ref.</p>
  *
  * <h2>Thread safety</h2>
  * Each scalar field is held in an {@link AtomicReference} so that fluent builders and
  * Control-port runtime edits can replace values atomically while engine threads read them.
- * The {@code functions} map is stored as a synchronized {@link LinkedHashMap} to preserve
+ * The {@code flows} map is stored as a synchronized {@link LinkedHashMap} to preserve
  * YAML insertion order (critical for step orchestration semantics). This satisfies SonarQube
  * rule {@code java:S3077}.
  */
@@ -37,8 +37,8 @@ public class AggregateSpec {
     private final AtomicReference<String> display = new AtomicReference<>();
     private final AtomicReference<String> namespace = new AtomicReference<>();
 
-    @JsonDeserialize(using = AggregateFunctionMapDeserializer.class)
-    private final Map<String, AggregateFunctionSpec> functions =
+    @JsonDeserialize(using = AggregateFlowMapDeserializer.class)
+    private final Map<String, AggregateFlowSpec> flows =
             Collections.synchronizedMap(new LinkedHashMap<>());
 
     public String getDisplay() {
@@ -57,15 +57,15 @@ public class AggregateSpec {
         this.namespace.set(namespace);
     }
 
-    public Map<String, AggregateFunctionSpec> getFunctions() {
-        return functions;
+    public Map<String, AggregateFlowSpec> getFlows() {
+        return flows;
     }
 
-    public void setFunctions(Map<String, AggregateFunctionSpec> functions) {
-        if (functions == null) return;
-        synchronized (this.functions) {
-            this.functions.clear();
-            this.functions.putAll(functions);
+    public void setFlows(Map<String, AggregateFlowSpec> flows) {
+        if (flows == null) return;
+        synchronized (this.flows) {
+            this.flows.clear();
+            this.flows.putAll(flows);
         }
     }
 }

--- a/ikanos-spec/src/main/java/io/ikanos/spec/aggregates/AggregateSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/aggregates/AggregateSpec.java
@@ -34,19 +34,19 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  */
 public class AggregateSpec {
 
-    private final AtomicReference<String> label = new AtomicReference<>();
+    private final AtomicReference<String> display = new AtomicReference<>();
     private final AtomicReference<String> namespace = new AtomicReference<>();
 
     @JsonDeserialize(using = AggregateFunctionMapDeserializer.class)
     private final Map<String, AggregateFunctionSpec> functions =
             Collections.synchronizedMap(new LinkedHashMap<>());
 
-    public String getLabel() {
-        return label.get();
+    public String getDisplay() {
+        return display.get();
     }
 
-    public void setLabel(String label) {
-        this.label.set(label);
+    public void setDisplay(String display) {
+        this.display.set(display);
     }
 
     public String getNamespace() {

--- a/ikanos-spec/src/main/java/io/ikanos/spec/consumes/http/HttpClientOperationSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/consumes/http/HttpClientOperationSpec.java
@@ -41,16 +41,16 @@ public class HttpClientOperationSpec extends OperationSpec {
         this(null, null, null, null, null, null, null);
     }
 
-    public HttpClientOperationSpec(HttpClientResourceSpec parentResource, String method, String name, String label) {
-        this(parentResource, method, name, label, null, null, null);
+    public HttpClientOperationSpec(HttpClientResourceSpec parentResource, String method, String name, String display) {
+        this(parentResource, method, name, display, null, null, null);
     }
 
-    public HttpClientOperationSpec(HttpClientResourceSpec parentResource, String method, String name, String label, String description, Object body, String outputRawFormat) {
-        this(parentResource, method, name, label, description, body, outputRawFormat, null);
+    public HttpClientOperationSpec(HttpClientResourceSpec parentResource, String method, String name, String display, String description, Object body, String outputRawFormat) {
+        this(parentResource, method, name, display, description, body, outputRawFormat, null);
     }
 
-    public HttpClientOperationSpec(HttpClientResourceSpec parentResource, String method, String name, String label, String description, Object body, String outputRawFormat, String outputSchema) {
-        super(parentResource, method, name, label, description, outputRawFormat, outputSchema);
+    public HttpClientOperationSpec(HttpClientResourceSpec parentResource, String method, String name, String display, String description, Object body, String outputRawFormat, String outputSchema) {
+        super(parentResource, method, name, display, description, outputRawFormat, outputSchema);
         this.body.set(body);
     }
 

--- a/ikanos-spec/src/main/java/io/ikanos/spec/consumes/http/HttpClientResourceSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/consumes/http/HttpClientResourceSpec.java
@@ -39,12 +39,12 @@ public class HttpClientResourceSpec extends ResourceSpec {
         this(null, null, null, null);
     }
 
-    public HttpClientResourceSpec(String path, String name, String label) {
-        this(path, name, label, null);
+    public HttpClientResourceSpec(String path, String name, String display) {
+        this(path, name, display, null);
     }
 
-    public HttpClientResourceSpec(String path, String name, String label, String description) {
-        super(path, name, label, description);
+    public HttpClientResourceSpec(String path, String name, String display, String description) {
+        super(path, name, display, description);
     }
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/ikanos-spec/src/main/java/io/ikanos/spec/exposes/mcp/McpPromptArgumentSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/exposes/mcp/McpPromptArgumentSpec.java
@@ -26,7 +26,7 @@ public class McpPromptArgumentSpec {
     private volatile String name;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private volatile String label;
+    private volatile String display;
 
     private volatile String description;
 
@@ -44,12 +44,12 @@ public class McpPromptArgumentSpec {
         this.name = name;
     }
 
-    public String getLabel() {
-        return label;
+    public String getDisplay() {
+        return display;
     }
 
-    public void setLabel(String label) {
-        this.label = label;
+    public void setDisplay(String display) {
+        this.display = display;
     }
 
     public String getDescription() {

--- a/ikanos-spec/src/main/java/io/ikanos/spec/exposes/mcp/McpServerPromptSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/exposes/mcp/McpServerPromptSpec.java
@@ -37,7 +37,7 @@ public class McpServerPromptSpec {
     private volatile String name;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private volatile String label;
+    private volatile String display;
 
     private volatile String description;
 
@@ -59,8 +59,8 @@ public class McpServerPromptSpec {
     public String getName() { return name; }
     public void setName(String name) { this.name = name; }
 
-    public String getLabel() { return label; }
-    public void setLabel(String label) { this.label = label; }
+    public String getDisplay() { return display; }
+    public void setDisplay(String display) { this.display = display; }
 
     public String getDescription() { return description; }
     public void setDescription(String description) { this.description = description; }

--- a/ikanos-spec/src/main/java/io/ikanos/spec/exposes/mcp/McpServerResourceSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/exposes/mcp/McpServerResourceSpec.java
@@ -61,6 +61,7 @@ public class McpServerResourceSpec {
     public String getName() { return name.get(); }
     public void setName(String name) { this.name.set(name); }
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getDisplay() { return display.get(); }
     public void setDisplay(String display) { this.display.set(display); }
 

--- a/ikanos-spec/src/main/java/io/ikanos/spec/exposes/mcp/McpServerResourceSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/exposes/mcp/McpServerResourceSpec.java
@@ -40,7 +40,7 @@ import io.ikanos.spec.util.OperationStepSpec;
 public class McpServerResourceSpec {
 
     private final AtomicReference<String> name = new AtomicReference<>();
-    private final AtomicReference<String> label = new AtomicReference<>();
+    private final AtomicReference<String> display = new AtomicReference<>();
     private final AtomicReference<String> uri = new AtomicReference<>();
     private final AtomicReference<String> description = new AtomicReference<>();
     private final AtomicReference<String> mimeType = new AtomicReference<>();
@@ -61,9 +61,8 @@ public class McpServerResourceSpec {
     public String getName() { return name.get(); }
     public void setName(String name) { this.name.set(name); }
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    public String getLabel() { return label.get(); }
-    public void setLabel(String label) { this.label.set(label); }
+    public String getDisplay() { return display.get(); }
+    public void setDisplay(String display) { this.display.set(display); }
 
     public String getUri() { return uri.get(); }
     public void setUri(String uri) { this.uri.set(uri); }

--- a/ikanos-spec/src/main/java/io/ikanos/spec/exposes/mcp/McpServerToolSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/exposes/mcp/McpServerToolSpec.java
@@ -46,7 +46,7 @@ import io.ikanos.spec.util.StepOutputMappingSpec;
 public class McpServerToolSpec {
 
     private final AtomicReference<String> name = new AtomicReference<>();
-    private final AtomicReference<String> label = new AtomicReference<>();
+    private final AtomicReference<String> display = new AtomicReference<>();
     private final AtomicReference<String> description = new AtomicReference<>();
     private final AtomicReference<String> ref = new AtomicReference<>();
     private final AtomicReference<ServerCallSpec> call = new AtomicReference<>();
@@ -71,9 +71,9 @@ public class McpServerToolSpec {
 
     public McpServerToolSpec() { this(null, null, null); }
 
-    public McpServerToolSpec(String name, String label, String description) {
+    public McpServerToolSpec(String name, String display, String description) {
         this.name.set(name);
-        this.label.set(label);
+        this.display.set(display);
         this.description.set(description);
     }
 
@@ -81,8 +81,8 @@ public class McpServerToolSpec {
     public void setName(String name) { this.name.set(name); }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    public String getLabel() { return label.get(); }
-    public void setLabel(String label) { this.label.set(label); }
+    public String getDisplay() { return display.get(); }
+    public void setDisplay(String display) { this.display.set(display); }
 
     public String getDescription() { return description.get(); }
     public void setDescription(String description) { this.description.set(description); }

--- a/ikanos-spec/src/main/java/io/ikanos/spec/exposes/mcp/McpServerToolSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/exposes/mcp/McpServerToolSpec.java
@@ -69,6 +69,9 @@ public class McpServerToolSpec {
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private final CopyOnWriteArrayList<OutputParameterSpec> outputParameters = new CopyOnWriteArrayList<>();
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private final CopyOnWriteArrayList<String> tags = new CopyOnWriteArrayList<>();
+
     public McpServerToolSpec() { this(null, null, null); }
 
     public McpServerToolSpec(String name, String display, String description) {
@@ -86,6 +89,8 @@ public class McpServerToolSpec {
 
     public String getDescription() { return description.get(); }
     public void setDescription(String description) { this.description.set(description); }
+
+    public List<String> getTags() { return tags; }
 
     public List<InputParameterSpec> getInputParameters() {
         return List.copyOf(inputParameters.get().values());

--- a/ikanos-spec/src/main/java/io/ikanos/spec/exposes/mcp/McpServerToolSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/exposes/mcp/McpServerToolSpec.java
@@ -91,6 +91,7 @@ public class McpServerToolSpec {
     public void setDescription(String description) { this.description.set(description); }
 
     public List<String> getTags() { return tags; }
+    public void setTags(List<String> tags) { this.tags.clear(); if (tags != null) this.tags.addAll(tags); }
 
     public List<InputParameterSpec> getInputParameters() {
         return List.copyOf(inputParameters.get().values());

--- a/ikanos-spec/src/main/java/io/ikanos/spec/exposes/rest/RestServerOperationSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/exposes/rest/RestServerOperationSpec.java
@@ -55,20 +55,20 @@ public class RestServerOperationSpec extends OperationSpec {
         this(null, null, null, null, null, null, null, null, null);
     }
 
-    public RestServerOperationSpec(RestServerResourceSpec parentResource, String method, String name, String label) {
-        this(parentResource, method, name, label, null, null, null, null, null);
+    public RestServerOperationSpec(RestServerResourceSpec parentResource, String method, String name, String display) {
+        this(parentResource, method, name, display, null, null, null, null, null);
     }
 
-    public RestServerOperationSpec(RestServerResourceSpec parentResource, String method, String name, String label, String description, String outputRawFormat, ServerCallSpec call) {
-        this(parentResource, method, name, label, description, outputRawFormat, null, call, null);
+    public RestServerOperationSpec(RestServerResourceSpec parentResource, String method, String name, String display, String description, String outputRawFormat, ServerCallSpec call) {
+        this(parentResource, method, name, display, description, outputRawFormat, null, call, null);
     }
 
-    public RestServerOperationSpec(RestServerResourceSpec parentResource, String method, String name, String label, String description, String outputRawFormat, String outputSchema, ServerCallSpec call) {
-        this(parentResource, method, name, label, description, outputRawFormat, outputSchema, call, null);
+    public RestServerOperationSpec(RestServerResourceSpec parentResource, String method, String name, String display, String description, String outputRawFormat, String outputSchema, ServerCallSpec call) {
+        this(parentResource, method, name, display, description, outputRawFormat, outputSchema, call, null);
     }
 
-    public RestServerOperationSpec(RestServerResourceSpec parentResource, String method, String name, String label, String description, String outputRawFormat, String outputSchema, ServerCallSpec call, Map<String, Object> with) {
-        super(parentResource, method, name, label, description, outputRawFormat, outputSchema);
+    public RestServerOperationSpec(RestServerResourceSpec parentResource, String method, String name, String display, String description, String outputRawFormat, String outputSchema, ServerCallSpec call, Map<String, Object> with) {
+        super(parentResource, method, name, display, description, outputRawFormat, outputSchema);
         this.call.set(call);
         this.with.set(with != null ? Map.copyOf(with) : null);
     }

--- a/ikanos-spec/src/main/java/io/ikanos/spec/exposes/rest/RestServerResourceSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/exposes/rest/RestServerResourceSpec.java
@@ -47,8 +47,8 @@ public class RestServerResourceSpec extends ResourceSpec {
         this(path, null, null, null, null);
     }
 
-    public RestServerResourceSpec(String path, String name, String label, String description, RestServerForwardSpec forward) {
-        super(path, name, label, description);
+    public RestServerResourceSpec(String path, String name, String display, String description, RestServerForwardSpec forward) {
+        super(path, name, display, description);
         this.forward.set(forward);
     }
 

--- a/ikanos-spec/src/main/java/io/ikanos/spec/openapi/OasExportBuilder.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/openapi/OasExportBuilder.java
@@ -132,8 +132,8 @@ public class OasExportBuilder {
     Info buildInfo(IkanosSpec IkanosSpec, List<String> warnings) {
         Info info = new Info();
         if (IkanosSpec.getInfo() != null) {
-            if (IkanosSpec.getInfo().getLabel() != null) {
-                info.setTitle(IkanosSpec.getInfo().getLabel());
+            if (IkanosSpec.getInfo().getDisplay() != null) {
+                info.setTitle(IkanosSpec.getInfo().getDisplay());
             }
             if (IkanosSpec.getInfo().getDescription() != null) {
                 info.setDescription(IkanosSpec.getInfo().getDescription());
@@ -141,7 +141,7 @@ public class OasExportBuilder {
         }
         if (info.getTitle() == null) {
             info.setTitle("ikanos Capability");
-            warnings.add("No info.label found; using default title");
+            warnings.add("No info.display found; using default title");
         }
         info.setVersion("1.0.0");
         return info;

--- a/ikanos-spec/src/main/java/io/ikanos/spec/openapi/OasImportConverter.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/openapi/OasImportConverter.java
@@ -236,7 +236,7 @@ public class OasImportConverter {
         opSpec.setName(name);
 
         if (operation.getSummary() != null) {
-            opSpec.setLabel(operation.getSummary());
+            opSpec.setDisplay(operation.getSummary());
         }
         if (operation.getDescription() != null) {
             opSpec.setDescription(operation.getDescription());

--- a/ikanos-spec/src/main/resources/rules/ikanos-rules.yml
+++ b/ikanos-spec/src/main/resources/rules/ikanos-rules.yml
@@ -116,24 +116,24 @@ rules:
       functionOptions:
         notMatch: "example\\.com$"
 
-  ikanos-aggregate-function-description:
-    message: "Each aggregate function should have a `description` field."
+  ikanos-aggregate-flow-description:
+    message: "Each aggregate flow should have a `description` field."
     description: >
-      Function descriptions are inherited by adapter units and improve agent
+      Flow descriptions are inherited by adapter units and improve agent
       discoverability.
     severity: warn
     recommended: true
-    given: "$.capability.aggregates[*].functions[*]"
+    given: "$.capability.aggregates[*].flows[*]"
     then:
       field: "description"
       function: truthy
 
   ikanos-aggregate-semantics-consistency:
-    message: "Aggregate function semantics must be consistent with MCP tool hints and REST operation methods."
+    message: "Aggregate flow semantics must be consistent with MCP tool hints and REST operation methods."
     description: >
-      When an MCP tool or REST operation references an aggregate function via `ref`,
-      any explicit hints or HTTP methods should not contradict the function's declared
-      semantics. For example, a safe function should not have destructive=true hints
+      When an MCP tool or REST operation references an aggregate flow via `ref`,
+      any explicit hints or HTTP methods should not contradict the flow's declared
+      semantics. For example, a safe flow should not have destructive=true hints
       or use a POST/DELETE method.
     severity: warn
     recommended: true

--- a/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
+++ b/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ikanos.io/schemas/v1.0.0-alpha3/ikanos.json",
   "name": "Ikanos Specification",

--- a/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
+++ b/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
@@ -607,7 +607,7 @@
       "type": "object",
       "description": "Information about the capability",
       "properties": {
-        "label": {
+        "display": {
           "type": "string",
           "description": "The display name of the capability"
         },
@@ -641,7 +641,7 @@
         }
       },
       "required": [
-        "label",
+        "display",
         "description"
       ],
       "additionalProperties": false
@@ -754,7 +754,7 @@
       "type": "object",
       "description": "A domain aggregate grouping reusable functions. Adapters reference these functions via ref.",
       "properties": {
-        "label": {
+        "display": {
           "type": "string",
           "description": "Human-readable name for this aggregate (e.g. 'Forecast')."
         },
@@ -775,7 +775,7 @@
         }
       },
       "required": [
-        "label",
+        "display",
         "functions"
       ],
       "additionalProperties": false
@@ -1051,7 +1051,7 @@
       "type": "object",
       "description": "An MCP tool definition. Each tool maps to one or more consumed HTTP operations.",
       "properties": {
-        "label": {
+        "display": {
           "type": "string",
           "description": "Human-readable display name of the tool. Mapped to MCP 'title' in tools/list responses."
         },
@@ -1221,7 +1221,7 @@
       "type": "object",
       "description": "An MCP resource definition. Exposes data that agents can read. Either dynamic (backed by consumed HTTP operations via call/steps) or static (served from local files via location).",
       "properties": {
-        "label": {
+        "display": {
           "type": "string",
           "description": "Human-readable display name of the resource. Mapped to MCP 'title' in protocol responses."
         },
@@ -1278,7 +1278,7 @@
         }
       },
       "required": [
-        "label",
+        "display",
         "uri",
         "description"
       ],
@@ -1348,7 +1348,7 @@
       "type": "object",
       "description": "An MCP prompt template definition. Prompts are reusable templates with typed arguments that agents can discover and render.",
       "properties": {
-        "label": {
+        "display": {
           "type": "string",
           "description": "Human-readable display name of the prompt. Mapped to MCP 'title' in protocol responses."
         },
@@ -1382,7 +1382,7 @@
         }
       },
       "required": [
-        "label",
+        "display",
         "description"
       ],
       "oneOf": [
@@ -1413,7 +1413,7 @@
       "type": "object",
       "description": "An argument for an MCP prompt template. Arguments are always strings per MCP spec.",
       "properties": {
-        "label": {
+        "display": {
           "type": "string",
           "description": "The display name of the argument. Used for agent discovery."
         },
@@ -1459,7 +1459,7 @@
       "type": "object",
       "description": "An exposed resource",
       "properties": {
-        "label": {
+        "display": {
           "type": "string",
           "description": "Display name for the resource. It will likely be used in UIs."
         },
@@ -1517,7 +1517,7 @@
       "type": "object",
       "description": "An operation exposed on a resource.",
       "properties": {
-        "label": {
+        "display": {
           "type": "string",
           "description": "Display name for the operation. Used in UIs."
         },
@@ -1686,7 +1686,7 @@
       "type": "object",
       "description": "A logical resource group on the upstream API. Combines a path segment with a set of HTTP operations and optional shared parameters.\n\n**When to use** — Each distinct REST resource (e.g. `/databases`, `/pages/{id}`) maps to one `ConsumedHttpResource`. Group operations that share the same base path and lifecycle.\n**Naming** — `name` is used as part of the call reference: `call: namespace.resource-name.operation-name`.\n**See also** — `ConsumedHttpOperation` (individual method + body), `ConsumedInputParameter` (path/query/header params).",
       "properties": {
-        "label": {
+        "display": {
           "type": "string",
           "description": "Human-readable label for editors and documentation. Does not affect runtime behavior."
         },
@@ -1730,7 +1730,7 @@
       "type": "object",
       "description": "An operation on a consumed HTTP resource",
       "properties": {
-        "label": {
+        "display": {
           "type": "string"
         },
         "description": {

--- a/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
+++ b/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
@@ -720,7 +720,7 @@
         },
         "aggregates": {
           "type": "object",
-          "description": "Domain aggregates defining reusable functions that adapters can reference via ref, keyed by aggregate namespace.",
+          "description": "Domain aggregates defining reusable flows that adapters can reference via ref, keyed by aggregate namespace.",
           "propertyNames": {
             "$ref": "#/$defs/IdentifierKebab"
           },
@@ -752,7 +752,7 @@
     },
     "Aggregate": {
       "type": "object",
-      "description": "A domain aggregate grouping reusable functions. Adapters reference these functions via ref.",
+      "description": "A domain aggregate grouping reusable flows. Adapters reference these flows via ref.",
       "properties": {
         "display": {
           "type": "string",
@@ -786,7 +786,7 @@
       "properties": {
         "description": {
           "type": "string",
-          "description": "A meaningful description of the function."
+          "description": "A meaningful description of the flow."
         },
         "tags": {
           "type": "array",

--- a/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
+++ b/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ikanos.io/schemas/v1.0.0-alpha3/ikanos.json",
   "name": "Ikanos Specification",
@@ -788,6 +788,13 @@
           "type": "string",
           "description": "A meaningful description of the function."
         },
+        "tags": {
+          "type": "array",
+          "description": "Arbitrary string tags for filtering and discovery.",
+          "items": {
+            "type": "string"
+          }
+        },
         "semantics": {
           "$ref": "#/$defs/Semantics"
         },
@@ -1054,6 +1061,13 @@
         "display": {
           "type": "string",
           "description": "Human-readable display name of the tool. Mapped to MCP 'title' in tools/list responses."
+        },
+        "tags": {
+          "type": "array",
+          "description": "Arbitrary string tags for filtering and discovery.",
+          "items": {
+            "type": "string"
+          }
         },
         "description": {
           "type": "string",
@@ -1463,6 +1477,13 @@
           "type": "string",
           "description": "Display name for the resource. It will likely be used in UIs."
         },
+        "tags": {
+          "type": "array",
+          "description": "Arbitrary string tags for filtering and discovery.",
+          "items": {
+            "type": "string"
+          }
+        },
         "description": {
           "type": "string",
           "description": "Used to provide *meaningful* information about the resource. Remember, in a world of agents, context is king."
@@ -1520,6 +1541,13 @@
         "display": {
           "type": "string",
           "description": "Display name for the operation. Used in UIs."
+        },
+        "tags": {
+          "type": "array",
+          "description": "Arbitrary string tags for filtering and discovery.",
+          "items": {
+            "type": "string"
+          }
         },
         "description": {
           "type": "string",
@@ -1690,6 +1718,13 @@
           "type": "string",
           "description": "Human-readable label for editors and documentation. Does not affect runtime behavior."
         },
+        "tags": {
+          "type": "array",
+          "description": "Arbitrary string tags for filtering and discovery.",
+          "items": {
+            "type": "string"
+          }
+        },
         "description": {
           "type": "string",
           "description": "Description of what this resource represents in the upstream API (e.g. 'A Notion database object — a structured collection of pages'). Used for agent discovery."
@@ -1732,6 +1767,13 @@
       "properties": {
         "display": {
           "type": "string"
+        },
+        "tags": {
+          "type": "array",
+          "description": "Arbitrary string tags for filtering and discovery.",
+          "items": {
+            "type": "string"
+          }
         },
         "description": {
           "type": "string",

--- a/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
+++ b/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ikanos.io/schemas/v1.0.0-alpha3/ikanos.json",
   "name": "Ikanos Specification",
@@ -762,27 +762,27 @@
           "$ref": "#/$defs/IdentifierKebab",
           "description": "Machine-readable qualifier for this aggregate. Used as the first segment in ref values. Must match the map key."
         },
-        "functions": {
+        "flows": {
           "type": "object",
           "propertyNames": {
             "$ref": "#/$defs/IdentifierKebab"
           },
           "additionalProperties": {
-            "$ref": "#/$defs/AggregateFunction"
+            "$ref": "#/$defs/AggregateFlow"
           },
-          "description": "Reusable invocable units within this aggregate, keyed by function name.",
+          "description": "Reusable callable flows within this aggregate, keyed by flow name.",
           "minProperties": 1
         }
       },
       "required": [
         "display",
-        "functions"
+        "flows"
       ],
       "additionalProperties": false
     },
-    "AggregateFunction": {
+    "AggregateFlow": {
       "type": "object",
-      "description": "A reusable invocable unit within an aggregate. Adapter units reference it via ref: aggregate-namespace.function-name.",
+      "description": "A reusable callable flow within an aggregate. Adapter units reference it via ref: aggregate-namespace.flow-name.",
       "properties": {
         "description": {
           "type": "string",
@@ -1085,7 +1085,7 @@
         },
         "ref": {
           "type": "string",
-          "description": "Reference to an aggregate function. Format: {aggregate-namespace}.{function-name}. Inherited fields are merged; explicit fields override.",
+          "description": "Reference to an aggregate flow. Format: {aggregate-namespace}.{flow-name}. Inherited fields are merged; explicit fields override.",
           "pattern": "^[a-zA-Z0-9-]+\\.[a-zA-Z0-9-]+$"
         },
         "call": {
@@ -1576,7 +1576,7 @@
         },
         "ref": {
           "type": "string",
-          "description": "Reference to an aggregate function. Format: {aggregate-namespace}.{function-name}. Inherited fields are merged; explicit fields override.",
+          "description": "Reference to an aggregate flow. Format: {aggregate-namespace}.{flow-name}. Inherited fields are merged; explicit fields override.",
           "pattern": "^[a-zA-Z0-9-]+\\.[a-zA-Z0-9-]+$"
         },
         "call": {

--- a/ikanos-spec/src/test/java/io/ikanos/spec/ParentResourceDeserializationTest.java
+++ b/ikanos-spec/src/test/java/io/ikanos/spec/ParentResourceDeserializationTest.java
@@ -36,7 +36,7 @@ public class ParentResourceDeserializationTest {
                     operations:
                       list-users:
                         method: GET
-                        label: List Users
+                        display: List Users
                 """;
 
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
@@ -71,13 +71,13 @@ public class ParentResourceDeserializationTest {
                     operations:
                       list-users:
                         method: GET
-                        label: List Users
+                        display: List Users
                       create-user:
                         method: POST
-                        label: Create User
+                        display: Create User
                       delete-user:
                         method: DELETE
-                        label: Delete User
+                        display: Delete User
                 """;
 
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
@@ -106,13 +106,13 @@ public class ParentResourceDeserializationTest {
                     operations:
                       list-users:
                         method: GET
-                        label: List Users
+                        display: List Users
                   products:
                     path: /products
                     operations:
                       list-products:
                         method: GET
-                        label: List Products
+                        display: List Products
                 """;
 
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());

--- a/ikanos-spec/src/test/java/io/ikanos/spec/RestServerAuthenticationDeserializationTest.java
+++ b/ikanos-spec/src/test/java/io/ikanos/spec/RestServerAuthenticationDeserializationTest.java
@@ -31,7 +31,7 @@ public class RestServerAuthenticationDeserializationTest {
         String yaml = """
                 ikanos: 0.4
                 info:
-                  label: Test
+                  display: Test
                   description: Test
                 capability:
                   exposes:
@@ -66,7 +66,7 @@ public class RestServerAuthenticationDeserializationTest {
         String yaml = """
                 ikanos: 0.4
                 info:
-                  label: Test
+                  display: Test
                   description: Test
                 capability:
                   exposes:

--- a/ikanos-spec/src/test/java/io/ikanos/spec/SpecFieldThreadSafetyTest.java
+++ b/ikanos-spec/src/test/java/io/ikanos/spec/SpecFieldThreadSafetyTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import io.ikanos.spec.aggregates.AggregateFunctionSpec;
+import io.ikanos.spec.aggregates.AggregateFlowSpec;
 import io.ikanos.spec.aggregates.AggregateSpec;
 import io.ikanos.spec.consumes.http.HttpClientOperationSpec;
 import io.ikanos.spec.consumes.http.HttpClientResourceSpec;
@@ -78,7 +78,7 @@ class SpecFieldThreadSafetyTest {
         return Stream.of(
                 IkanosSpec.class,
                 OperationSpec.class,
-                AggregateFunctionSpec.class,
+                AggregateFlowSpec.class,
                 AggregateSpec.class,
                 HttpClientSpec.class,
                 HttpClientResourceSpec.class,
@@ -138,3 +138,4 @@ class SpecFieldThreadSafetyTest {
                 () -> "Default constructor of " + specClass.getSimpleName() + " did not return an instance");
     }
 }
+

--- a/ikanos-spec/src/test/java/io/ikanos/spec/aggregates/AggregateFlowDeserializationTest.java
+++ b/ikanos-spec/src/test/java/io/ikanos/spec/aggregates/AggregateFlowDeserializationTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.spec.aggregates;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.ikanos.spec.IkanosSpec;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Non-regression tests for the {@code flows:} rename (#463).
+ *
+ * <p>Verifies that a YAML capability document using {@code aggregates.<ns>.flows:} is correctly
+ * deserialized into {@link AggregateFlowSpec} objects, and that the injected key becomes the
+ * flow name.
+ */
+class AggregateFlowDeserializationTest {
+
+    private static final ObjectMapper MAPPER =
+            new ObjectMapper(new YAMLFactory()).findAndRegisterModules();
+
+    private static final String CAPABILITY_WITH_FLOWS = """
+            ikanos: "1.0.0-alpha3"
+            capability:
+              exposes: []
+              consumes: []
+              aggregates:
+                forecast:
+                  display: "Forecast"
+                  flows:
+                    get-forecast:
+                      description: "Retrieve forecast for a location"
+                      call: weather-api.get-forecast
+                    list-forecasts:
+                      description: "List recent forecasts"
+                      call: weather-api.list-forecasts
+            """;
+
+    @Test
+    void flowsKeyShouldDeserializeIntoAggregateFlowSpecMap() throws Exception {
+        IkanosSpec spec = MAPPER.readValue(CAPABILITY_WITH_FLOWS, IkanosSpec.class);
+
+        AggregateSpec aggregate = spec.getCapability().getAggregates().get("forecast");
+        assertNotNull(aggregate, "aggregate 'forecast' should be present");
+        assertNotNull(aggregate.getFlows(), "flows map should not be null");
+        assertEquals(2, aggregate.getFlows().size(), "should have 2 flows");
+    }
+
+    @Test
+    void flowKeysShouldBeInjectedAsFlowNames() throws Exception {
+        IkanosSpec spec = MAPPER.readValue(CAPABILITY_WITH_FLOWS, IkanosSpec.class);
+
+        AggregateSpec aggregate = spec.getCapability().getAggregates().get("forecast");
+        AggregateFlowSpec getForecast = aggregate.getFlows().get("get-forecast");
+        AggregateFlowSpec listForecasts = aggregate.getFlows().get("list-forecasts");
+
+        assertNotNull(getForecast, "flow 'get-forecast' should be present");
+        assertEquals("get-forecast", getForecast.getName(),
+                "YAML map key must be injected as the flow name");
+
+        assertNotNull(listForecasts, "flow 'list-forecasts' should be present");
+        assertEquals("list-forecasts", listForecasts.getName(),
+                "YAML map key must be injected as the flow name");
+    }
+
+    @Test
+    void flowDescriptionShouldBeDeserializedCorrectly() throws Exception {
+        IkanosSpec spec = MAPPER.readValue(CAPABILITY_WITH_FLOWS, IkanosSpec.class);
+
+        AggregateFlowSpec getForecast =
+                spec.getCapability().getAggregates().get("forecast").getFlows().get("get-forecast");
+
+        assertEquals("Retrieve forecast for a location", getForecast.getDescription());
+    }
+}

--- a/ikanos-spec/src/test/java/io/ikanos/spec/aggregates/AggregateFlowSpecTest.java
+++ b/ikanos-spec/src/test/java/io/ikanos/spec/aggregates/AggregateFlowSpecTest.java
@@ -1,11 +1,11 @@
 /**
  * Copyright 2025-2026 Naftiko
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -26,13 +26,13 @@ import io.ikanos.spec.exposes.ServerCallSpec;
 import io.ikanos.spec.util.OperationStepCallSpec;
 import io.ikanos.spec.util.StepOutputMappingSpec;
 
-class AggregateFunctionSpecTest {
+class AggregateFlowSpecTest {
 
-    private AggregateFunctionSpec spec;
+    private AggregateFlowSpec spec;
 
     @BeforeEach
     void setUp() {
-        spec = new AggregateFunctionSpec();
+        spec = new AggregateFlowSpec();
     }
 
     // ── Name ──

--- a/ikanos-spec/src/test/java/io/ikanos/spec/exposes/mcp/McpPromptArgumentSpecTest.java
+++ b/ikanos-spec/src/test/java/io/ikanos/spec/exposes/mcp/McpPromptArgumentSpecTest.java
@@ -33,7 +33,7 @@ public class McpPromptArgumentSpecTest {
         McpPromptArgumentSpec spec = new McpPromptArgumentSpec();
 
         assertNull(spec.getName());
-        assertNull(spec.getLabel());
+        assertNull(spec.getDisplay());
         assertNull(spec.getDescription());
         assertNull(spec.getRequired());
     }
@@ -62,12 +62,12 @@ public class McpPromptArgumentSpecTest {
     public void settersShouldRoundTripValues() {
         McpPromptArgumentSpec spec = new McpPromptArgumentSpec();
         spec.setName("user");
-        spec.setLabel("User name");
+        spec.setDisplay("User name");
         spec.setDescription("The end-user name to greet");
         spec.setRequired(Boolean.TRUE);
 
         assertEquals("user", spec.getName());
-        assertEquals("User name", spec.getLabel());
+        assertEquals("User name", spec.getDisplay());
         assertEquals("The end-user name to greet", spec.getDescription());
         assertEquals(Boolean.TRUE, spec.getRequired());
     }
@@ -76,7 +76,7 @@ public class McpPromptArgumentSpecTest {
     public void shouldDeserializeFromYaml() throws Exception {
         String yaml = """
                 name: user
-                label: User name
+                display: User name
                 description: The user name
                 required: false
                 """;
@@ -85,7 +85,7 @@ public class McpPromptArgumentSpecTest {
         McpPromptArgumentSpec spec = mapper.readValue(yaml, McpPromptArgumentSpec.class);
 
         assertEquals("user", spec.getName());
-        assertEquals("User name", spec.getLabel());
+        assertEquals("User name", spec.getDisplay());
         assertEquals("The user name", spec.getDescription());
         assertFalse(spec.isRequired());
     }

--- a/ikanos-spec/src/test/java/io/ikanos/spec/exposes/mcp/McpServerPromptSpecTest.java
+++ b/ikanos-spec/src/test/java/io/ikanos/spec/exposes/mcp/McpServerPromptSpecTest.java
@@ -34,7 +34,7 @@ public class McpServerPromptSpecTest {
         McpServerPromptSpec spec = new McpServerPromptSpec();
 
         assertNull(spec.getName());
-        assertNull(spec.getLabel());
+        assertNull(spec.getDisplay());
         assertNull(spec.getDescription());
         assertNotNull(spec.getArguments());
         assertTrue(spec.getArguments().isEmpty());
@@ -48,11 +48,11 @@ public class McpServerPromptSpecTest {
     public void settersShouldRoundTripValues() {
         McpServerPromptSpec spec = new McpServerPromptSpec();
         spec.setName("greet");
-        spec.setLabel("Greet User");
+        spec.setDisplay("Greet User");
         spec.setDescription("Greets the user by name");
 
         assertEquals("greet", spec.getName());
-        assertEquals("Greet User", spec.getLabel());
+        assertEquals("Greet User", spec.getDisplay());
         assertEquals("Greets the user by name", spec.getDescription());
     }
 

--- a/ikanos-spec/src/test/java/io/ikanos/spec/exposes/mcp/McpServerResourceSpecTest.java
+++ b/ikanos-spec/src/test/java/io/ikanos/spec/exposes/mcp/McpServerResourceSpecTest.java
@@ -50,13 +50,13 @@ class McpServerResourceSpecTest {
 
     @Test
     void getLabelShouldReturnNullByDefault() {
-        assertNull(spec.getLabel());
+        assertNull(spec.getDisplay());
     }
 
     @Test
     void setLabelShouldStoreValue() {
-        spec.setLabel("My Resource");
-        assertEquals("My Resource", spec.getLabel());
+        spec.setDisplay("My Resource");
+        assertEquals("My Resource", spec.getDisplay());
     }
 
     // ── URI ──

--- a/ikanos-spec/src/test/java/io/ikanos/spec/exposes/mcp/McpServerToolSpecTest.java
+++ b/ikanos-spec/src/test/java/io/ikanos/spec/exposes/mcp/McpServerToolSpecTest.java
@@ -33,7 +33,7 @@ class McpServerToolSpecTest {
     void defaultConstructorShouldInitializeWithNullScalars() {
         McpServerToolSpec spec = new McpServerToolSpec();
         assertNull(spec.getName());
-        assertNull(spec.getLabel());
+        assertNull(spec.getDisplay());
         assertNull(spec.getDescription());
     }
 
@@ -56,7 +56,7 @@ class McpServerToolSpecTest {
     void parameterisedConstructorShouldSetNameLabelDescription() {
         McpServerToolSpec spec = new McpServerToolSpec("lookup", "Lookup", "Look up a value");
         assertEquals("lookup", spec.getName());
-        assertEquals("Lookup", spec.getLabel());
+        assertEquals("Lookup", spec.getDisplay());
         assertEquals("Look up a value", spec.getDescription());
     }
 
@@ -74,8 +74,8 @@ class McpServerToolSpecTest {
     @Test
     void setLabelShouldStoreValue() {
         McpServerToolSpec spec = new McpServerToolSpec();
-        spec.setLabel("My Tool");
-        assertEquals("My Tool", spec.getLabel());
+        spec.setDisplay("My Tool");
+        assertEquals("My Tool", spec.getDisplay());
     }
 
     // ── Description ──

--- a/ikanos-spec/src/test/java/io/ikanos/spec/openapi/OasExportBuilderTest.java
+++ b/ikanos-spec/src/test/java/io/ikanos/spec/openapi/OasExportBuilderTest.java
@@ -60,13 +60,13 @@ public class OasExportBuilderTest {
     }
 
     @Test
-    void buildShouldUseDefaultTitleWhenNoLabel() {
+    void buildShouldUseDefaultTitleWhenNoDisplay() {
         IkanosSpec spec = minimalSpec(null, null);
         OasExportResult result = builder.build(spec, null);
 
         assertEquals("ikanos Capability", result.getOpenApi().getInfo().getTitle());
         assertTrue(result.getWarnings().stream()
-                .anyMatch(w -> w.contains("No info.label")));
+                .anyMatch(w -> w.contains("No info.display")));
     }
 
     // ── Server mapping ──
@@ -551,7 +551,7 @@ public class OasExportBuilderTest {
 
         assertEquals("ikanos Capability", result.getOpenApi().getInfo().getTitle());
         assertTrue(result.getWarnings().stream()
-                .anyMatch(w -> w.contains("No info.label")));
+                .anyMatch(w -> w.contains("No info.display")));
     }
 
     @Test
@@ -803,11 +803,11 @@ public class OasExportBuilderTest {
 
     // ── Utility methods ──
 
-    private IkanosSpec minimalSpec(String label, String description) {
+    private IkanosSpec minimalSpec(String display, String description) {
         IkanosSpec spec = new IkanosSpec();
         spec.setIkanos("1.0.0-alpha1");
-        if (label != null || description != null) {
-            spec.setInfo(new InfoSpec(label, description, null, null));
+        if (display != null || description != null) {
+            spec.setInfo(new InfoSpec(display, description, null, null));
         }
         CapabilitySpec capability = new CapabilitySpec();
         RestServerSpec rest = new RestServerSpec("localhost", 8080, null);

--- a/ikanos-spec/src/test/resources/rules/spectral-semantics-consistent.yaml
+++ b/ikanos-spec/src/test/resources/rules/spectral-semantics-consistent.yaml
@@ -2,7 +2,7 @@ ikanos: 1.0.0-alpha3
 capability:
   aggregates:
     weather:
-      label: Weather Service
+      display: Weather Service
       namespace: weather
       functions:
         get-forecast:

--- a/ikanos-spec/src/test/resources/rules/spectral-semantics-consistent.yaml
+++ b/ikanos-spec/src/test/resources/rules/spectral-semantics-consistent.yaml
@@ -1,10 +1,10 @@
-ikanos: 1.0.0-alpha3
+﻿ikanos: 1.0.0-alpha3
 capability:
   aggregates:
     weather:
       display: Weather Service
       namespace: weather
-      functions:
+      flows:
         get-forecast:
           description: Get weather forecast (safe, read-only)
           semantics:

--- a/ikanos-spec/src/test/resources/rules/spectral-semantics-consistent.yaml
+++ b/ikanos-spec/src/test/resources/rules/spectral-semantics-consistent.yaml
@@ -1,4 +1,4 @@
-﻿ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha3
 capability:
   aggregates:
     weather:

--- a/ikanos-spec/src/test/resources/rules/spectral-semantics-inconsistent.yaml
+++ b/ikanos-spec/src/test/resources/rules/spectral-semantics-inconsistent.yaml
@@ -2,7 +2,7 @@ ikanos: 1.0.0-alpha3
 capability:
   aggregates:
     weather:
-      label: Weather Service
+      display: Weather Service
       namespace: weather
       functions:
         get-forecast:

--- a/ikanos-spec/src/test/resources/rules/spectral-semantics-inconsistent.yaml
+++ b/ikanos-spec/src/test/resources/rules/spectral-semantics-inconsistent.yaml
@@ -1,10 +1,10 @@
-ikanos: 1.0.0-alpha3
+﻿ikanos: 1.0.0-alpha3
 capability:
   aggregates:
     weather:
       display: Weather Service
       namespace: weather
-      functions:
+      flows:
         get-forecast:
           description: Get weather forecast (safe, read-only)
           semantics:

--- a/ikanos-spec/src/test/resources/rules/spectral-semantics-inconsistent.yaml
+++ b/ikanos-spec/src/test/resources/rules/spectral-semantics-inconsistent.yaml
@@ -1,4 +1,4 @@
-﻿ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha3
 capability:
   aggregates:
     weather:

--- a/ikanos-spec/src/test/resources/skill-capability.yaml
+++ b/ikanos-spec/src/test/resources/skill-capability.yaml
@@ -1,6 +1,6 @@
 ikanos: "1.0.0-alpha3"
 info:
-  label: "Skill Test Capability"
+  display: "Skill Test Capability"
   description: "Test capability for Skill Server Adapter deserialization and wiring"
   tags:
   - Test
@@ -17,12 +17,12 @@ capability:
     resources:
       orders:
         path: "/orders"
-        label: "Orders"
+        display: "Orders"
         description: "Order management endpoint"
         operations:
           list-orders:
             method: "GET"
-            label: "List Orders"
+            display: "List Orders"
             call: "mock-orders.list"
 
   - type: "skill"
@@ -59,5 +59,5 @@ capability:
         operations:
           list:
             method: "GET"
-            label: "List Orders"
+            display: "List Orders"
 

--- a/scripts/migrate_aggregate_flows.py
+++ b/scripts/migrate_aggregate_flows.py
@@ -14,6 +14,17 @@ This script targets the breaking rename introduced in story #463:
 
 It uses a regex-based approach rather than a full YAML parser so that
 comments and formatting are preserved verbatim.
+
+WARNING — Known false positive: Spectral configuration files (`.spectral.yaml`,
+`.spectral.yml`) use `functions:` as a built-in keyword to register custom
+JavaScript validation plugins. This pattern is NOT related to Ikanos aggregates
+and must NOT be migrated. Exclude Spectral configuration files when running this
+script, or review each match manually before accepting it. Example Spectral usage
+that must be preserved:
+
+    # .spectral.yaml
+    functions:
+      - check-binds-location-scheme
 """
 
 import re

--- a/scripts/migrate_aggregate_flows.py
+++ b/scripts/migrate_aggregate_flows.py
@@ -40,17 +40,7 @@ PATTERN = re.compile(r'^(\s+)functions:', re.MULTILINE)
 REPLACEMENT = r'\1flows:'
 
 
-def migrate_file(path: Path) -> bool:
-    """Return True if the file was modified."""
-    original = path.read_text(encoding='utf-8')
-    updated = PATTERN.sub(REPLACEMENT, original)
-    if updated != original:
-        path.write_text(updated, encoding='utf-8')
-        return True
-    return False
-
-
-def migrate(paths: list[str]) -> None:
+def migrate(paths: list[str], dry_run: bool = False) -> None:
     total = 0
     modified = 0
     for raw in paths:
@@ -65,15 +55,29 @@ def migrate(paths: list[str]) -> None:
 
         for candidate in candidates:
             total += 1
-            if migrate_file(candidate):
+            original = candidate.read_text(encoding='utf-8')
+            updated = PATTERN.sub(REPLACEMENT, original)
+            if updated != original:
                 modified += 1
-                print(f'  migrated: {candidate}')
+                if dry_run:
+                    print(f'  would migrate: {candidate}')
+                else:
+                    candidate.write_text(updated, encoding='utf-8')
+                    print(f'  migrated: {candidate}')
 
-    print(f'\nDone — {modified}/{total} file(s) updated.')
+    if dry_run:
+        print(f'\nDry run — {modified}/{total} file(s) would be updated.')
+    else:
+        print(f'\nDone — {modified}/{total} file(s) updated.')
 
 
 if __name__ == '__main__':
-    if len(sys.argv) < 2:
-        print(f'Usage: {sys.argv[0]} <path> [<path> ...]', file=sys.stderr)
-        sys.exit(1)
-    migrate(sys.argv[1:])
+    import argparse
+    parser = argparse.ArgumentParser(
+        description='Migrate Ikanos capability YAML files from alpha3 `functions:` to `flows:`.')
+    parser.add_argument('paths', nargs='+', metavar='path',
+                        help='Files or directories to migrate.')
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Print matches without modifying files.')
+    args = parser.parse_args()
+    migrate(args.paths, dry_run=args.dry_run)

--- a/scripts/migrate_aggregate_flows.py
+++ b/scripts/migrate_aggregate_flows.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+Migrate Ikanos capability YAML files from alpha3 `functions:` to `flows:`.
+
+Usage:
+    python scripts/migrate_aggregate_flows.py <path> [<path> ...]
+
+Where <path> is a file or a directory. Directories are searched recursively
+for *.yml and *.yaml files. The script is idempotent: files that already use
+`flows:` are left unchanged.
+
+This script targets the breaking rename introduced in story #463:
+    aggregates.<ns>.functions: → aggregates.<ns>.flows:
+
+It uses a regex-based approach rather than a full YAML parser so that
+comments and formatting are preserved verbatim.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+# Pattern: 'functions:' at any indentation level inside an 'aggregates' block.
+# We use a simple heuristic: replace every line that matches /^(\s+)functions:/
+# with the same indentation but 'flows:'.  This is intentionally conservative —
+# it only replaces lines where 'functions:' is the sole mapping key on that line,
+# which is the only valid form in an Ikanos capability document.
+PATTERN = re.compile(r'^(\s+)functions:', re.MULTILINE)
+REPLACEMENT = r'\1flows:'
+
+
+def migrate_file(path: Path) -> bool:
+    """Return True if the file was modified."""
+    original = path.read_text(encoding='utf-8')
+    updated = PATTERN.sub(REPLACEMENT, original)
+    if updated != original:
+        path.write_text(updated, encoding='utf-8')
+        return True
+    return False
+
+
+def migrate(paths: list[str]) -> None:
+    total = 0
+    modified = 0
+    for raw in paths:
+        p = Path(raw)
+        if p.is_dir():
+            candidates = list(p.rglob('*.yml')) + list(p.rglob('*.yaml'))
+        elif p.is_file():
+            candidates = [p]
+        else:
+            print(f'Warning: {raw} does not exist, skipping.', file=sys.stderr)
+            continue
+
+        for candidate in candidates:
+            total += 1
+            if migrate_file(candidate):
+                modified += 1
+                print(f'  migrated: {candidate}')
+
+    print(f'\nDone — {modified}/{total} file(s) updated.')
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print(f'Usage: {sys.argv[0]} <path> [<path> ...]', file=sys.stderr)
+        sys.exit(1)
+    migrate(sys.argv[1:])


### PR DESCRIPTION
## Related Issue

Closes #495

---

## What does this PR do?

Two changes to the Ikanos Specification, stacked on top of the named-object rescope (#471):

### 1. Rename `label` → `display`

Renames the `label` field to `display` across the entire spec surface:
- **JSON Schema** (`ikanos-schema.json`): all 14 occurrences renamed
- **Java Spec classes**: field, getter, setter renamed in `InfoSpec`, `ResourceSpec`, `OperationSpec`, `McpServerToolSpec`, `AggregateFunctionSpec`, `FileFormatEnum`
- **YAML fixtures**: all tutorial steps (1–11), engine test resources, spec test resources, and schema examples updated
- **Documentation**: `Specification-‐-Schema.md` — all Fixed Fields tables updated
- **SKILL.md**: ikanos-capability skill updated

### 2. Add `tags: string[]` to 6 sub-entities

Adds an optional `tags` array (arbitrary string tags for filtering and discovery) to:
- `AggregateFunction`
- `McpTool`
- `ExposedResource`
- `ExposedOperation`
- `ConsumedHttpResource`
- `ConsumedHttpOperation`

Implementation:
- **JSON Schema**: `tags` property added to each object definition
- **Java Spec classes**: `CopyOnWriteArrayList<String>` field with `@JsonInclude(NON_EMPTY)`, getter/setter — added in `AggregateFunctionSpec`, `McpServerToolSpec`, `ResourceSpec` (inherited by `HttpClientResourceSpec`), `OperationSpec` (inherited by `HttpClientOperationSpec`)
- **Documentation**: `tags` row added to each Fixed Fields table in `Specification-‐-Schema.md`

---

## Tests

- No new tests added — these are additive schema/model changes (new optional field + rename)
- All existing tests pass (`mvn clean test` = BUILD SUCCESS)
- Local v8r validation: 68/68 YAML files valid against updated schema
- CI: Quality Gate ✅, Lint Ikanos Capabilities ✅, Validate JSON Structure Schema ✅

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main` (targets `feat/issue-328-named-object-rescope`, will rebase on `main` after #471 merges)
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Claude Opus 4
tool: VS Code Copilot Chat
confidence: high
source_event: "Issue #495 — rename label to display and add tags to sub-entities"
discovery_method: user_report
review_focus: ikanos-spec/src/main/resources/schemas/ikanos-schema.json, ikanos-spec/src/main/java/io/ikanos/spec/
```
