### PR TITLE
chore: rename vs code to crafter

### DIFF
--- a/.github/workflows/synchronize-ikanos-version-in-other-repos.yml
+++ b/.github/workflows/synchronize-ikanos-version-in-other-repos.yml
@@ -68,7 +68,7 @@ jobs:
           delete-branch: true
 
   # This job is only executed when triggered (automatically or manually) from the 'main' branch.
-  sync-vscode-version:
+  sync-crafter-version:
     runs-on: ubuntu-latest
     if: github.ref_name == 'main'
     needs: sync-warden-version
@@ -84,24 +84,24 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Checkout vscode
+      - name: Checkout crafter
         uses: actions/checkout@v4
         with:
-          repository: naftiko/vscode
-          token: ${{ secrets.VSCODE_CONTENTS_WRITE_PR_WRITE }}
-          path: vscode
+          repository: naftiko/crafter
+          token: ${{ secrets.CRAFTER_CONTENTS_WRITE_PR_WRITE }}
+          path: crafter
 
-      - name: Sync Ikanos version to vscode
+      - name: Sync Ikanos version to crafter
         id: sync
         run: |
-          VERSION=$(python3 ikanos/scripts/sync-ikanos-version-to-vscode.py \
+          VERSION=$(python3 ikanos/scripts/sync-ikanos-version-to-crafter.py \
             --pom ikanos/pom.xml \
-            --target vscode/extensions/naftiko-vscode/package.json)
+            --target crafter/extensions/naftiko-crafter/package.json)
           echo "value=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Check for changes
         id: git-check
-        working-directory: vscode
+        working-directory: crafter
         run: |
           if git diff --quiet; then
             echo "changes=false" >> $GITHUB_OUTPUT
@@ -113,8 +113,8 @@ jobs:
         if: steps.git-check.outputs.changes == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.VSCODE_CONTENTS_WRITE_PR_WRITE }}
-          path: vscode
+          token: ${{ secrets.CRAFTER_CONTENTS_WRITE_PR_WRITE }}
+          path: crafter
           base: main
           branch: "chore/sync-ikanos-version"
           commit-message: "chore: sync Ikanos version to ${{ steps.sync.outputs.value }} [skip ci]"
@@ -123,5 +123,5 @@ jobs:
             Automated sync from [ikanos@${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}).
 
             Updated files:
-            - `extensions/naftiko-vscode/package.json`
+            - `extensions/naftiko-crafter/package.json`
           delete-branch: true

--- a/.github/workflows/synchronize-schema-and-rules.yml
+++ b/.github/workflows/synchronize-schema-and-rules.yml
@@ -11,8 +11,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Synchronize schema and rules to vscode repository.
-  sync-to-vscode:
+  # Synchronize schema and rules to crafter repository.
+  sync-to-crafter:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ikanos
@@ -20,27 +20,27 @@ jobs:
         with:
           path: ikanos
 
-      - name: Checkout vscode
+      - name: Checkout crafter
         uses: actions/checkout@v4
         with:
-          repository: naftiko/vscode
-          token: ${{ secrets.VSCODE_CONTENTS_WRITE_PR_WRITE }}
-          path: vscode
+          repository: naftiko/crafter
+          token: ${{ secrets.CRAFTER_CONTENTS_WRITE_PR_WRITE }}
+          path: crafter
 
       - name: Copy schema and rules
         run: |
           cp ikanos/ikanos-spec/src/main/resources/schemas/ikanos-schema.json \
-             vscode/extensions/naftiko-vscode/src/resources/schemas/ikanos-schema.json
+             crafter/extensions/naftiko-crafter/src/resources/schemas/ikanos-schema.json
 
-          rm -rf vscode/extensions/naftiko-vscode/src/resources/rules/*
+          rm -rf crafter/extensions/naftiko-crafter/src/resources/rules/*
           cp -R ikanos/ikanos-spec/src/main/resources/rules/* \
-               vscode/extensions/naftiko-vscode/src/resources/rules/
+               crafter/extensions/naftiko-crafter/src/resources/rules/
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.VSCODE_CONTENTS_WRITE_PR_WRITE }}
-          path: vscode
+          token: ${{ secrets.CRAFTER_CONTENTS_WRITE_PR_WRITE }}
+          path: crafter
           base: main
           branch: chore/schema-and-rules
           commit-message: "chore: update schema and rules from ikanos"
@@ -49,8 +49,8 @@ jobs:
             Automated sync from [ikanos@${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}).
 
             Updated files:
-            - `ikanos-schema.json`
-            - `rules/*`
+            - `resources/schemas/ikanos-schema.json`
+            - `resources/rules/*`
           delete-branch: true
 
   # Synchronize schema to schema-viewer repository.

--- a/scripts/sync-ikanos-version-to-crafter.py
+++ b/scripts/sync-ikanos-version-to-crafter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Script to synchronize the Ikanos version from pom.xml into the VS Code extension package.json.
+Script to synchronize the Ikanos version from pom.xml into the Naftiko Crafter package.json.
 """
 
 import argparse
@@ -35,9 +35,9 @@ def update_package_json_version(file_path, new_version):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Sync Ikanos version to VS Code extension package.json")
+    parser = argparse.ArgumentParser(description="Sync Ikanos version to Naftiko Crafter package.json")
     parser.add_argument("--pom", required=True, help="Path to ikanos pom.xml")
-    parser.add_argument("--target", required=True, help="Path to extensions/naftiko-vscode/package.json")
+    parser.add_argument("--target", required=True, help="Path to extensions/naftiko-crafter/package.json")
     args = parser.parse_args()
 
     version = extract_version_from_pom(args.pom)


### PR DESCRIPTION
## Related Issue

Closes #crafter17

---

## What does this PR do?

rename vscode repo to crafter

---

## Tests

I tested the github actions manually

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main`
- [ ] Small and focused — one concern per PR
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

<!-- If this PR was created or assisted by an AI agent, provide metadata below (YAML) -->

```yaml
# agent_name:
# llm:
# tool:
# confidence:          # low | medium | high
# source_event:
# discovery_method:    # runtime_observation | code_review | test_failure | user_report
# review_focus:        # e.g. ClassName.java:line-range
```
