### PR TITLE
feat: document git worktree usage for parallel agent workflows

### DIFF
--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -293,7 +293,16 @@ The handoff file must include:
 - A clear statement that the receiving agent should fix these findings
 
 The receiving agent lists `/memories/repo/` to discover pending handoffs,
-applies the fixes, commits, pushes, and deletes the handoff file.
+then executes the following steps **in order**:
+
+1. Read the handoff file with `memory view /memories/repo/pr-review-<PR>.md`
+2. Apply all fixes to the files listed
+3. Commit and push
+4. Reply to any open inline review comments on GitHub
+5. If the diff reveals net-new findings not covered by the handoff (whether spotted while applying fixes or from an independent read of the diff), post them as a review comment on GitHub before closing out — do not silently drop them
+6. **Delete the handoff file: `memory delete /memories/repo/pr-review-<PR>.md`**
+
+Step 6 is mandatory — the agent must not consider the workflow complete until the handoff file is deleted.
 
 Once written, inform the user that the handoff file is ready and which agent
 should read it (see *Inter-agent communication* in `AGENTS.md`).

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -267,15 +267,20 @@ rm -f /tmp/review-<number>.json /tmp/findings-<number>.json
 
 ### Mode B — Hand off to a local agent
 
-Write the selected findings to `/memories/repo/pr-review-<N>.md` so the agent
-working on the branch can read them and apply fixes directly — no GitHub
-round-trip.
+Write the selected findings to `/memories/repo/pr-review-<PR>.md` (where `<PR>`
+is the pull request number) using the `create_file` tool (not via a terminal
+command) so the agent working on the branch can read them and apply fixes
+directly — no GitHub round-trip. If the file already exists from a previous
+review pass, delete it first, then recreate it with updated findings.
 
 The handoff file must include:
 - PR number and branch name
 - List of changed files
 - The findings table (N, file, severity, comment)
 - A clear statement that the receiving agent should fix these findings
+
+The receiving agent lists `/memories/repo/` to discover pending handoffs,
+applies the fixes, commits, pushes, and deletes the handoff file.
 
 Once written, inform the user that the handoff file is ready and which agent
 should read it (see *Inter-agent communication* in `AGENTS.md`).

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: pr-review
-version: "2.0.2"
+version: "2.1.0"
 description: >
-  On-demand skill for reviewing GitHub Pull Requests and posting inline
-  comments via the GitHub API. Activate when the user asks to: review a PR,
-  review a pull request, do a code review, post inline comments on a PR,
-  comment on a pull request, review PR #<number>.
+  On-demand skill for reviewing GitHub Pull Requests. Supports two delivery
+  modes: posting inline comments via the GitHub API (Mode A), or handing off
+  findings to a local agent for direct fixes (Mode B). Activate when the user
+  asks to: review a PR, review a pull request, do a code review, post inline
+  comments on a PR, comment on a pull request, review PR #<number>.
 allowed-tools:
   - Read
   - Bash
@@ -18,11 +19,13 @@ This skill guides the agent through a structured PR review workflow:
 ```
 Step 1 — pr-context (1 click)
 Step 2 — Read diff → identify issues → present list WITHOUT line numbers
-Step 3 — User picks which findings to post
+Step 3 — User picks which findings to act on + chooses Mode A or Mode B
 Step 4 — Resolve line numbers for picked findings only
           Short diff (<500 lines): compute from context, 0 clicks
           Long diff  (≥500 lines): pr-find-lines-batch on picked items, 1 click
-Step 5 — pr-submit (1 click)
+Step 5 — Deliver findings
+          Mode A: post review on GitHub (1 click)
+          Mode B: write to /memories/repo/ for local agent fix (0 clicks)
 ```
 
 **Minimum 2 clicks (short diff). Maximum 3 clicks (long diff), regardless of the
@@ -39,7 +42,7 @@ point verifying a line number for a finding the user will not post.
 | `pr-context.sh <N>` | Linux / macOS | Same |
 | `pr-find-lines-batch.ps1 -Pr <N> [-InputFile <path>]` | Windows | **Once**, Step 4, long diff only |
 | `pr-find-lines-batch.sh <N> [input-file]` | Linux / macOS | Same |
-| `pr-submit-review.ps1 -Pr <N> -InputFile <path>` | Windows | **Once**, Step 5 |
+| `pr-submit-review.ps1 -Pr <N> -InputFile <path>` | Windows | **Once**, Step 5 Mode A only |
 | `pr-submit-review.sh <N> <input-json>` | Linux / macOS | Same |
 
 ---
@@ -130,7 +133,12 @@ Present findings in a working table (conversation only — never paste into GitH
 
 **All comments must be written in English** — see AGENTS.md.
 
-Wait for the user to confirm which findings to post before proceeding.
+After presenting findings, ask the user which mode to use:
+
+> **Mode A — Post review on GitHub** (default)
+> **Mode B — Hand off to a local agent for fixes**
+
+Wait for the user to confirm which findings to act on **and** which mode to use before proceeding.
 
 ---
 
@@ -187,7 +195,9 @@ numbers in the review payload.
 
 ---
 
-## Step 5 — Post the review
+## Step 5 — Deliver findings
+
+### Mode A — Post review on GitHub
 
 Build the review JSON with the confirmed line numbers and save it with `create_file`
 to `$env:TEMP\review-<number>.json` (Windows) or `/tmp/review-<number>.json`
@@ -241,7 +251,7 @@ Use `event=COMMENT` for a non-blocking review.
 Use `event=REQUEST_CHANGES` when at least one finding is 🔴 HIGH.
 Use `event=APPROVE` only when explicitly asked.
 
-### Cleanup after submission
+#### Cleanup after submission
 
 Once the submit script confirms all comments landed, delete the temp files so they
 cannot pollute a future session:
@@ -254,3 +264,18 @@ Remove-Item -Force "$env:TEMP\review-<number>.json", "$env:TEMP\findings-<number
 ```bash
 rm -f /tmp/review-<number>.json /tmp/findings-<number>.json
 ```
+
+### Mode B — Hand off to a local agent
+
+Write the selected findings to `/memories/repo/pr-review-<N>.md` so the agent
+working on the branch can read them and apply fixes directly — no GitHub
+round-trip.
+
+The handoff file must include:
+- PR number and branch name
+- List of changed files
+- The findings table (N, file, severity, comment)
+- A clear statement that the receiving agent should fix these findings
+
+Once written, inform the user that the handoff file is ready and which agent
+should read it (see *Inter-agent communication* in `AGENTS.md`).

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -28,7 +28,7 @@ Step 5 — Deliver findings
           Mode B: write to /memories/repo/ for local agent fix (0 clicks)
 ```
 
-**Minimum 2 clicks (short diff). Maximum 3 clicks (long diff), regardless of the
+**Minimum 1 click (Mode B, short diff). Maximum 3 clicks (Mode A, long diff), regardless of the
 number of findings.**
 
 Line numbers are resolved **after** the user picks — never before. There is no
@@ -111,6 +111,16 @@ requires no user confirmation). For each potential issue, note:
 >
 > If the natural target line contains Unicode or metacharacters, pick a
 > neighbouring plain-ASCII keyword or identifier from the same line instead.
+>
+> **Note:** on Windows, `pr-context.ps1` saves the diff in UTF-8. Earlier versions
+> used the system default (CP1252), which corrupted non-ASCII characters (e.g. U+2500
+> `─` became `ÔöÇ`). If you see garbled characters in the diff, regenerate it with
+> the current script — do not flag the source code as incorrect.
+>
+> **The diff is a derived artefact — the source file is always the source of truth.**
+> If a character or string looks suspicious in the diff (garbled, truncated, or
+> inconsistent with the surrounding code), use `read_file` on the actual file before
+> drawing any conclusion. Never raise a finding based solely on what the diff shows.
 
 Do **not** compute line numbers yet.
 
@@ -271,7 +281,10 @@ Write the selected findings to `/memories/repo/pr-review-<PR>.md` (where `<PR>`
 is the pull request number) using the `create_file` tool (not via a terminal
 command) so the agent working on the branch can read them and apply fixes
 directly — no GitHub round-trip. If the file already exists from a previous
-review pass, delete it first, then recreate it with updated findings.
+review pass, use `memory delete /memories/repo/pr-review-<PR>.md` (the memory
+tool) to delete the stale file before calling `create_file` — do not use
+`Remove-Item` in the terminal, which costs an extra click and is unreliable on
+Windows.
 
 The handoff file must include:
 - PR number and branch name

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,18 +66,18 @@ When multiple agents work on the same repository simultaneously, each agent must
 ```bash
 # Create an isolated worktree for each issue, branching from origin/main
 git fetch origin main
-git worktree add ../framework-issue-<N> -b feat/issue-<N>-short-description origin/main
+git worktree add ../ikanos-issue-<N> -b feat/issue-<N>-short-description origin/main
 
 # Open the worktree as an additional root in VS Code (required — agents only see open workspace folders)
-code --add /path/to/framework-issue-<N>
+code --add /path/to/ikanos-issue-<N>
 
 # Remove when the branch is merged
-git worktree remove ../framework-issue-<N>
+git worktree remove ../ikanos-issue-<N>
 ```
 
 ### For agents working in a worktree
 
-- **Your working directory is the worktree root** (e.g. `../framework-issue-<N>/`) — treat it as the repository root for all commands
+- **Your working directory is the worktree root** (e.g. `../ikanos-issue-<N>/`) — treat it as the repository root for all commands
 - **Never run `git checkout main`** inside a worktree — `main` is already checked out in the primary clone and Git will refuse. To create a new branch from up-to-date `main`, use: `git fetch origin main && git checkout -b fix/<name> origin/main`
 - **Never stash, reset, or switch branches** in a worktree that belongs to another agent — each worktree is exclusively owned by one agent for the duration of the issue
 - **`mvn clean test`** runs normally from the worktree root — the shared `~/.m2` cache is read-only-safe for parallel builds
@@ -86,7 +86,7 @@ git worktree remove ../framework-issue-<N>
 
 > One worktree = one issue = one branch = one agent.
 
-The primary clone (`framework/`) owns `main` and handles fetch/push. Agents never check out `main` directly.
+The primary clone (`ikanos/`) owns `main` and handles fetch/push. Agents never check out `main` directly.
 
 ### Inter-agent communication
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,37 @@ Trivy and Gitleaks are **not required locally** — they run automatically in CI
 
 If you still want to run the full pre-PR checks locally, install [Trivy](https://github.com/aquasecurity/trivy#installation) and [Gitleaks](https://github.com/zricethezav/gitleaks#installation).
 
+## Parallel Agent Workflows
+
+When multiple agents work on the same repository simultaneously, each agent must be fully isolated from the others. Use `git worktree` to achieve this — one worktree per issue, per agent.
+
+### For the user (setting up parallel agents)
+
+```bash
+# Create an isolated worktree for each issue, branching from origin/main
+git fetch origin main
+git worktree add ../framework-issue-<N> -b feat/issue-<N>-short-description origin/main
+
+# Open the worktree as an additional root in VS Code (required — agents only see open workspace folders)
+code --add C:\work\repos\framework-issue-<N>
+
+# Remove when the branch is merged
+git worktree remove ../framework-issue-<N>
+```
+
+### For agents working in a worktree
+
+- **Your working directory is the worktree root** (e.g. `../framework-issue-<N>/`) — treat it as the repository root for all commands
+- **Never run `git checkout main`** inside a worktree — `main` is already checked out in the primary clone and Git will refuse. To create a new branch from up-to-date `main`, use: `git fetch origin main && git checkout -b fix/<name> origin/main`
+- **Never stash, reset, or switch branches** in a worktree that belongs to another agent — each worktree is exclusively owned by one agent for the duration of the issue
+- **`mvn clean test`** runs normally from the worktree root — the shared `~/.m2` cache is read-only-safe for parallel builds
+
+### Invariant
+
+> One worktree = one issue = one branch = one agent.
+
+The primary clone (`framework/`) owns `main` and handles fetch/push. Agents never check out `main` directly.
+
 ## Code Style
 
 **Java** — follows Google Style. Configure VS Code with `Language Support for Java by Red Hat` and apply settings from [naftiko/code-standards — java](https://github.com/naftiko/code-standards/tree/main/java).
@@ -167,11 +198,11 @@ Note the stash ref or branch name so you can restore it later with `git stash po
 Then create the fix branch from up-to-date `main`:
 
 ```bash
-git checkout main
-git pull origin main
-git checkout -b fix/<short-description>
+git fetch origin main
+git checkout -b fix/<short-description> origin/main
 ```
 
+Never run `git checkout main` — if you are working in a worktree, `main` is checked out in the primary clone and the command will fail. Always branch directly from `origin/main` after a fetch.
 Never start a fix branch from a feature branch or a stale local `main`.
 When the fix is merged, remind the user to switch back to their original branch and restore the stash if needed.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,7 @@ When writing or generating tests, follow these rules:
 - When a method is not accessible from a test, make it package-private in the production code (remove `private`) rather than using reflection — this is the correct fix
 - Write one focused assertion per test, or group only closely related assertions in a single test
 - Name tests in the form `methodShouldDoSomethingWhenCondition`
+- After renaming any string constant that tests assert against (OTel span names, error messages, log markers), run a codebase-wide grep for the old string across **all** test sources — not just the test class that was directly updated. Compilation failures in unrelated tests do not exempt this search from being exhaustive
 
 **Don't:**
 - Mix unit test patterns (local mock servers, in-process stubs, hardcoded XML/JSON payloads) into integration test classes — each test class must be one type, not both

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,8 +95,11 @@ Session memory (`/memories/session/`) is scoped to one conversation and is invis
 **Pattern:**
 1. Agent A (reviewer) writes findings to `/memories/repo/<topic>.md`
 2. Agent B (fixer) reads it with `memory view /memories/repo/<topic>.md` and applies the changes
+3. Agent B deletes the file after committing the fixes
 
-Example: a PR-review agent writes findings to `/memories/repo/pr-review-<N>.md`; the agent working on the branch reads it and commits the fixes directly, without GitHub round-trip.
+**Naming convention:** use predictable paths so the receiving agent can find them without being told the exact filename. For PR reviews: `/memories/repo/pr-review-<PR>.md` where `<PR>` is the pull request number. The receiving agent lists `/memories/repo/` to discover pending handoffs.
+
+Example: a PR-review agent writes findings to `/memories/repo/pr-review-<PR>.md`; the agent working on the branch reads it and commits the fixes directly, without GitHub round-trip.
 
 ## Code Style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,10 +69,11 @@ git fetch origin main
 git worktree add ../ikanos-issue-<N> -b feat/issue-<N>-short-description origin/main
 
 # Open the worktree as an additional root in VS Code (required — agents only see open workspace folders)
-code --add /path/to/ikanos-issue-<N>
+code --add ../ikanos-issue-<N>
 
 # Remove when the branch is merged
 git worktree remove ../ikanos-issue-<N>
+# If the worktree has local modifications, use: git worktree remove --force ../ikanos-issue-<N>
 ```
 
 ### For agents working in a worktree
@@ -100,6 +101,9 @@ Session memory (`/memories/session/`) is scoped to one conversation and is invis
 **Naming convention:** use predictable paths so the receiving agent can find them without being told the exact filename. For PR reviews: `/memories/repo/pr-review-<PR>.md` where `<PR>` is the pull request number. The receiving agent lists `/memories/repo/` to discover pending handoffs.
 
 Example: a PR-review agent writes findings to `/memories/repo/pr-review-<PR>.md`; the agent working on the branch reads it and commits the fixes directly, without GitHub round-trip.
+
+> This pattern is called **Mode B** in the `pr-review` skill (`.agents/skills/pr-review/SKILL.md`).
+> Mode A posts findings as inline comments directly on GitHub instead.
 
 ## Code Style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ git fetch origin main
 git worktree add ../framework-issue-<N> -b feat/issue-<N>-short-description origin/main
 
 # Open the worktree as an additional root in VS Code (required — agents only see open workspace folders)
-code --add C:\work\repos\framework-issue-<N>
+code --add /path/to/framework-issue-<N>
 
 # Remove when the branch is merged
 git worktree remove ../framework-issue-<N>
@@ -87,6 +87,16 @@ git worktree remove ../framework-issue-<N>
 > One worktree = one issue = one branch = one agent.
 
 The primary clone (`framework/`) owns `main` and handles fetch/push. Agents never check out `main` directly.
+
+### Inter-agent communication
+
+Session memory (`/memories/session/`) is scoped to one conversation and is invisible to other agents. To pass information between agents working in parallel (e.g. review findings, task handoff), write to `/memories/repo/` — it is readable by any agent that has the repository open in its workspace.
+
+**Pattern:**
+1. Agent A (reviewer) writes findings to `/memories/repo/<topic>.md`
+2. Agent B (fixer) reads it with `memory view /memories/repo/<topic>.md` and applies the changes
+
+Example: a PR-review agent writes findings to `/memories/repo/pr-review-<N>.md`; the agent working on the branch reads it and commits the fixes directly, without GitHub round-trip.
 
 ## Code Style
 
@@ -202,7 +212,7 @@ git fetch origin main
 git checkout -b fix/<short-description> origin/main
 ```
 
-Never run `git checkout main` — if you are working in a worktree, `main` is checked out in the primary clone and the command will fail. Always branch directly from `origin/main` after a fetch.
+Never run `git checkout main` — if you are working in a worktree, `main` is checked out in the primary clone and the command will fail. Always branch directly from `origin/main` after a fetch (see *Parallel Agent Workflows* above).
 Never start a fix branch from a feature branch or a stale local `main`.
 When the fix is merged, remind the user to switch back to their original branch and restore the stash if needed.
 


### PR DESCRIPTION
## Related Issue

Closes #499

---

## What does this PR do?

Adds a **Parallel Agent Workflows** section to `AGENTS.md` that documents how to use `git worktree` to isolate each issue in its own directory when multiple agents work in parallel on the same repository.

Key additions:
- User-facing commands to create, open in VS Code, and remove a worktree per issue
- Agent-facing constraints: never `git checkout main` in a worktree, never stash/reset another agent's worktree, treat the worktree root as the repository root
- The invariant: one worktree = one issue = one branch = one agent

Also updates **Bug Workflow step 2** to replace the `git checkout main` + `git pull` sequence with a worktree-safe equivalent (`git fetch origin main` + `git checkout -b fix/... origin/main`), with an explicit note explaining why `git checkout main` fails in a worktree context.

---

## Tests

No code changes — documentation only. No tests required.

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Naftiko - Claude Sonnet 4.6
tool: VS Code Copilot Chat
confidence: high
source_event: user_question
discovery_method: user_report
review_focus: AGENTS.md
```
