### PR TITLE
feat: rename aggregate functions to flows for extensibility

### DIFF
--- a/.agents/skills/ikanos-capability/SKILL.md
+++ b/.agents/skills/ikanos-capability/SKILL.md
@@ -29,7 +29,7 @@ Key spec objects you will work with:
 - **Capability** — root technical config; contains `exposes`, `consumes`, and `aggregates`
 - **Consumes** — HTTP client adapter: baseUri, namespace, resources, operations
 - **Exposes** — server adapter: REST (`type: rest`), MCP (`type: mcp`), Skill (`type: skill`), or Control (`type: control`)
-- **Aggregates** — DDD-inspired domain building blocks; each aggregate groups reusable functions under a namespace. Tools and operations reference functions via `ref`
+- **Aggregates** — DDD-inspired domain building blocks; each aggregate groups reusable flows under a namespace. Tools and operations reference flows via `ref`
 - **Observability** — optional OTel configuration on the control adapter: trace sampling, propagation format, OTLP exporter endpoint
 - **Script Steps** — embed JavaScript, Python, or Groovy transformations between API calls using sandboxed GraalVM engines. Scripts read step results via bound variables and produce output through a `result` variable
 - **Binds** — variable injection from file (dev) or runtime (prod)
@@ -49,7 +49,7 @@ removed from the object body.
 
 **Keyed maps** (key = name, no `name` property inside):
 `tools`, `resources`, `operations`, `inputParameters` (all contexts),
-`steps`, `functions`, `aggregates`, `skills`, `prompts`
+`steps`, `flows`, `aggregates`, `skills`, `prompts`
 
 **Arrays** (keep `- item` syntax):
 `outputParameters`, `binds`, `exposes`, `consumes`, `stakeholders`, `mappings`
@@ -88,14 +88,14 @@ resources:
             mapping: "$."
 ```
 
-Example — aggregates + functions (keyed maps):
+Example — aggregates + flows (keyed maps):
 
 ```yaml
 aggregates:
   forecast:                            # ← key IS the aggregate namespace
     description: "Weather forecast domain"
-    functions:
-      get-forecast:                    # ← key IS the function name
+    flows:
+      get-forecast:                    # ← key IS the flow name
         description: "Retrieve forecast for a location"
         inputParameters:
           location:                    # ← key IS the name
@@ -117,7 +117,7 @@ for *how*.
 | "I want to proxy an API today and encapsulate it incrementally" | Read `references/proxy-then-customize.md` |
 | "I want to chain multiple HTTP calls to consumed APIs and expose the result into a single REST operation" | Read `references/chain-api-calls.md` |
 | "I need to go from local test credentials to production secrets" | Read `references/dev-to-production.md` |
-| "I want to define a domain function once and expose it via both REST and MCP" | Use `aggregates` with `ref` — read `references/design-guidelines.md` (Aggregate Design Guidelines) |
+| "I want to define a domain flow once and expose it via both REST and MCP" | Use `aggregates` with `ref` — read `references/design-guidelines.md` (Aggregate Design Guidelines) |
 | "I want to add health checks, Prometheus metrics, or trace inspection" | Read `references/control-port-observability.md` |
 | "I want to enable OpenTelemetry distributed tracing and RED metrics" | Read `references/control-port-observability.md` |
 | "I want to transform data between API calls using JavaScript, Python, or Groovy" | Read `references/inline-script-step.md` |
@@ -195,13 +195,13 @@ before writing any mock output parameters.
    exposed contract does not change.
    and `trustedHeaders` (at least one entry).
 10. MCP tools must have `name` and `description` (unless using `ref`, in which
-    case they are inherited from the referenced aggregate function). MCP tool input
+    case they are inherited from the referenced aggregate flow). MCP tool input
     parameters must have `name`, `type`, and `description`. Tools may declare optional
     `hints` (readOnly, destructive, idempotent, openWorld) — these map to
     MCP `ToolAnnotations` on the wire.
 11. ExposedOperation supports three modes (oneOf): simple (`call` +
     optional `with`), orchestrated (`steps` + optional `mappings`), or
-    ref (`ref` to an aggregate function). Never mix fields from
+    ref (`ref` to an aggregate flow). Never mix fields from
     incompatible modes.
 12. Do not modify `scripts/lint-capability.sh` unless explicitly asked —
     it wraps Spectral with the correct ruleset and flags.
@@ -217,14 +217,14 @@ before writing any mock output parameters.
     resource name — variables are already scoped to their context.
     Redundant prefixes reduce readability without adding disambiguation.
 17. When using `ref` on MCP tools or REST operations, the `ref` value must
-    follow the format `{aggregate-namespace}.{function-name}` and resolve
-    to an existing function in the capability's `aggregates` array.
+    follow the format `{aggregate-namespace}.{flow-name}` and resolve
+    to an existing flow in the capability's `aggregates` section.
 18. Do not chain `ref` through multiple levels of aggregates — `ref`
-    resolves to a function in a single aggregate, not transitively.
-19. Aggregate functions can declare `semantics` (safe, idempotent, cacheable).
+    resolves to a flow in a single aggregate, not transitively.
+19. Aggregate flows can declare `semantics` (safe, idempotent, cacheable).
     When exposed via MCP, the engine auto-derives `hints` from semantics.
     Explicit `hints` on the MCP tool override derived values.
-20. Do not duplicate a full function definition inline on both MCP tools
+20. Do not duplicate a full flow definition inline on both MCP tools
     and REST operations — use `aggregates` + `ref` instead.
 21. In mock mode, use `value` on output parameters — never `const`.
     `const` is a JSON Schema keyword retained for validation and linting

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,9 +96,9 @@ When designing or modifying a Capability:
 - Keep the [Ikanos Specification](ikanos-spec/src/main/resources/schemas/ikanos-schema.json) and the [Ikanos Rules](ikanos-spec/src/main/resources/rules/ikanos-rules.yml) as first-class citizens — the schema enforces structure, the rules enforce cross-object consistency, quality, and security
 - Look at `ikanos-spec/src/main/resources/schemas/examples/` for patterns before writing new capabilities
 - When renaming a consumed field for a lookup `match`, also add a `ConsumedOutputParameter` on the consumed operation to map the raw field name to a kebab-case name — otherwise the lookup has nothing to match against
-- Use `aggregates` to define reusable domain functions when the same operation is exposed through multiple adapters (REST and MCP) — this follows the DDD Aggregate pattern: one definition, multiple projections
-- Declare `semantics` (safe, idempotent, cacheable) on aggregate functions to describe domain behavior — the engine derives MCP `hints` automatically
-- Override only adapter-specific fields when using `ref` (e.g., `method` for REST, `hints` for MCP) — let the rest be inherited from the function
+- Use `aggregates` to define reusable domain flows when the same operation is exposed through multiple adapters (REST and MCP) — this follows the DDD Aggregate pattern: one definition, multiple projections
+- Declare `semantics` (safe, idempotent, cacheable) on aggregate flows to describe domain behavior — the engine derives MCP `hints` automatically
+- Override only adapter-specific fields when using `ref` (e.g., `method` for REST, `hints` for MCP) — let the rest be inherited from the flow
 
 **Don't:**
 - Expose an `inputParameter` that is not used in any step
@@ -114,8 +114,8 @@ When designing or modifying a Capability:
 - Use `MappedOutputParameter` (with `mapping`, no `name`) when the tool/operation uses `steps` — use `OrchestratedOutputParameter` (with `name`, no `mapping`) instead
 - Use typed objects for lookup step `outputParameters` — they are plain string arrays of field names to extract (e.g. `- "fullName"`)
 - Put a `path` property on an `ExposedOperation` — extract multi-step operations with a different path into their own `ExposedResource`
-- Duplicate a full function definition inline on both MCP tools and REST operations — use `aggregates` + `ref` instead
-- Chain `ref` through multiple levels of aggregates — `ref` resolves to a function in a single aggregate, not transitively
+- Duplicate a full flow definition inline on both MCP tools and REST operations — use `aggregates` + `ref` instead
+- Chain `ref` through multiple levels of aggregates — `ref` resolves to a flow in a single aggregate, not transitively
 
 ## Contribution Workflow
 

--- a/ikanos-docs/tutorial/step-10-shipyard-rest-adapter.yml
+++ b/ikanos-docs/tutorial/step-10-shipyard-rest-adapter.yml
@@ -1,4 +1,4 @@
-﻿ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha3"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-10-shipyard-rest-adapter.yml
+++ b/ikanos-docs/tutorial/step-10-shipyard-rest-adapter.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+﻿ikanos: "1.0.0-alpha3"
 
 binds:
 - namespace: "registry-env"
@@ -25,7 +25,7 @@ capability:
     crew-resolver:
       display: "Crew Resolver"
       namespace: crew-resolver
-      functions:
+      flows:
         resolve-crew-for-ship:
           description: "Resolve crew member names and roles for a given ship"
           semantics:

--- a/ikanos-docs/tutorial/step-9-shipyard-aggregates.yml
+++ b/ikanos-docs/tutorial/step-9-shipyard-aggregates.yml
@@ -1,4 +1,4 @@
-﻿ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha3"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-9-shipyard-aggregates.yml
+++ b/ikanos-docs/tutorial/step-9-shipyard-aggregates.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+﻿ikanos: "1.0.0-alpha3"
 
 binds:
 - namespace: "registry-env"
@@ -25,7 +25,7 @@ capability:
     crew-resolver:
       display: "Crew Resolver"
       namespace: crew-resolver
-      functions:
+      flows:
         resolve-crew-for-ship:
           description: "Resolve crew member names and roles for a given ship"
           semantics:

--- a/ikanos-docs/wiki/FAQ.md
+++ b/ikanos-docs/wiki/FAQ.md
@@ -227,7 +227,7 @@ exposes:
 - `name` and `description` are optional when using `ref` — they default to the function's values.
 
 ### Q: How do semantics map to MCP tool hints?
-**A:** aggregate flows can declare transport-neutral **semantics** (`safe`, `idempotent`, `cacheable`). When exposed as MCP tools, the engine automatically derives [MCP tool hints](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#tool-annotations):
+**A:** Aggregate flows can declare transport-neutral **semantics** (`safe`, `idempotent`, `cacheable`). When exposed as MCP tools, the engine automatically derives [MCP tool hints](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#tool-annotations):
 
 | Semantics | MCP Hint | Rule |
 |-----------|----------|------|

--- a/ikanos-docs/wiki/FAQ.md
+++ b/ikanos-docs/wiki/FAQ.md
@@ -1,4 +1,4 @@
-﻿Welcome to the Ikanos FAQ! This guide answers common questions from developers who are learning, using, and contributing to Ikanos. For comprehensive technical details, see the [Specification - Schema](https://github.com/naftiko/ikanos/wiki/Specification-Schema) and [Specification - Rules](https://github.com/naftiko/ikanos/wiki/Specification-Rules).
+Welcome to the Ikanos FAQ! This guide answers common questions from developers who are learning, using, and contributing to Ikanos. For comprehensive technical details, see the [Specification - Schema](https://github.com/naftiko/ikanos/wiki/Specification-Schema) and [Specification - Rules](https://github.com/naftiko/ikanos/wiki/Specification-Rules).
 
 ---
 

--- a/ikanos-docs/wiki/FAQ.md
+++ b/ikanos-docs/wiki/FAQ.md
@@ -1,4 +1,4 @@
-Welcome to the Ikanos FAQ! This guide answers common questions from developers who are learning, using, and contributing to Ikanos. For comprehensive technical details, see the [Specification - Schema](https://github.com/naftiko/ikanos/wiki/Specification-Schema) and [Specification - Rules](https://github.com/naftiko/ikanos/wiki/Specification-Rules).
+﻿Welcome to the Ikanos FAQ! This guide answers common questions from developers who are learning, using, and contributing to Ikanos. For comprehensive technical details, see the [Specification - Schema](https://github.com/naftiko/ikanos/wiki/Specification-Schema) and [Specification - Rules](https://github.com/naftiko/ikanos/wiki/Specification-Rules).
 
 ---
 
@@ -186,7 +186,7 @@ capability:
   aggregates:
     - label: Weather Forecast
       namespace: forecast
-      functions:
+      flows:
         - name: get-forecast
           description: Retrieve weather forecast for a city
           semantics:
@@ -202,8 +202,8 @@ capability:
               mapping: $.forecast
 ```
 
-### Q: How does `ref` work to reference an aggregate function?
-**A:** MCP tools and REST operations can reference an aggregate function using `ref: {namespace}.{function-name}`. The engine merges inherited fields from the function — you only specify what's different at the adapter level.
+### Q: How does `ref` work to reference an aggregate flow?
+**A:** MCP tools and REST operations can reference an aggregate flow using `ref: {namespace}.{function-name}`. The engine merges inherited fields from the function — you only specify what's different at the adapter level.
 
 ```yaml
 exposes:
@@ -227,7 +227,7 @@ exposes:
 - `name` and `description` are optional when using `ref` — they default to the function's values.
 
 ### Q: How do semantics map to MCP tool hints?
-**A:** Aggregate functions can declare transport-neutral **semantics** (`safe`, `idempotent`, `cacheable`). When exposed as MCP tools, the engine automatically derives [MCP tool hints](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#tool-annotations):
+**A:** aggregate flows can declare transport-neutral **semantics** (`safe`, `idempotent`, `cacheable`). When exposed as MCP tools, the engine automatically derives [MCP tool hints](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#tool-annotations):
 
 | Semantics | MCP Hint | Rule |
 |-----------|----------|------|

--- a/ikanos-docs/wiki/Guide-‐-Linting.md
+++ b/ikanos-docs/wiki/Guide-‐-Linting.md
@@ -1,4 +1,4 @@
-# Guide - Linting
+﻿# Guide - Linting
 
 ## Table of Contents
 
@@ -280,7 +280,7 @@ rules:
 
 ### Adding Custom Functions
 
-For advanced validation logic (like the built-in `unique-namespaces` function), you can write custom JavaScript functions:
+For advanced validation logic (like the built-in `unique-namespaces` function), you can write custom JavaScript flows:
 
 1. Create a `functions/` directory next to your `.spectral.yaml`:
 
@@ -321,7 +321,7 @@ extends:
 
 functionsDir: ./functions
 
-functions:
+flows:
   - check-binds-location-scheme
 
 rules:
@@ -346,7 +346,7 @@ extends:
 
 functionsDir: ./functions
 
-functions:
+flows:
   - check-binds-location-scheme
 
 rules:

--- a/ikanos-docs/wiki/Guide-‐-Linting.md
+++ b/ikanos-docs/wiki/Guide-‐-Linting.md
@@ -1,4 +1,4 @@
-﻿# Guide - Linting
+# Guide - Linting
 
 ## Table of Contents
 

--- a/ikanos-docs/wiki/Guide-‐-Linting.md
+++ b/ikanos-docs/wiki/Guide-‐-Linting.md
@@ -280,7 +280,7 @@ rules:
 
 ### Adding Custom Functions
 
-For advanced validation logic (like the built-in `unique-namespaces` function), you can write custom JavaScript flows:
+For advanced validation logic (like the built-in `unique-namespaces` function), you can write custom JavaScript functions:
 
 1. Create a `functions/` directory next to your `.spectral.yaml`:
 
@@ -321,18 +321,8 @@ extends:
 
 functionsDir: ./functions
 
-flows:
+functions:
   - check-binds-location-scheme
-
-rules:
-  my-org-binds-location-scheme:
-    message: "Bind locations must use an approved URI scheme."
-    severity: error
-    given:
-      - "$.binds[*].location"
-      - "$.capability.binds[*].location"
-    then:
-      function: check-binds-location-scheme
 ```
 
 ### Full Example
@@ -346,7 +336,7 @@ extends:
 
 functionsDir: ./functions
 
-flows:
+functions:
   - check-binds-location-scheme
 
 rules:

--- a/ikanos-docs/wiki/Guide-‐-Use-Cases.md
+++ b/ikanos-docs/wiki/Guide-‐-Use-Cases.md
@@ -1,4 +1,4 @@
-﻿# Guide - Use Cases
+# Guide - Use Cases
 
 Here is an overview of typical use cases where Ikanos can help developers and supporting features available. Additional features are being added as described in the [roadmap](https://github.com/naftiko/ikanos/wiki/Roadmap).
 

--- a/ikanos-docs/wiki/Guide-‐-Use-Cases.md
+++ b/ikanos-docs/wiki/Guide-‐-Use-Cases.md
@@ -1,4 +1,4 @@
-# Guide - Use Cases
+﻿# Guide - Use Cases
 
 Here is an overview of typical use cases where Ikanos can help developers and supporting features available. Additional features are being added as described in the [roadmap](https://github.com/naftiko/ikanos/wiki/Roadmap).
 
@@ -56,7 +56,7 @@ Wrap a current API as a capability to make it easier to discover, reuse, and con
 How Ikanos achieves this technically:
 - Model the legacy/existing API once in `consumes.resources.operations` with explicit methods, paths, parameters, and body formats.
 - Add a stable capability namespace and expose curated resource paths/tools that are easier to consume than vendor-native endpoints.
-- Reshape not just data but also operation semantics: declare `semantics` (safe, idempotent, cacheable) on aggregate functions so the engine derives correct HTTP methods for REST adapters and `hints` for MCP tools automatically.
+- Reshape not just data but also operation semantics: declare `semantics` (safe, idempotent, cacheable) on aggregate flows so the engine derives correct HTTP methods for REST adapters and `hints` for MCP tools automatically.
 - Enforce schema-based validation (`capability-schema.json`) so the elevated contract remains consistent and machine-checkable.
 
 ![Elevate existing APIs](https://Ikanos.github.io/docs/images/technology/use_case_api_reusability_elevate_existing_apis.png)

--- a/ikanos-docs/wiki/Specification-‐-Schema.md
+++ b/ikanos-docs/wiki/Specification-‐-Schema.md
@@ -1,4 +1,4 @@
-# Ikanos Specification - Schema
+﻿# Ikanos Specification - Schema
 
 **Version:** {{RELEASE_TAG}}
 
@@ -320,7 +320,7 @@ Transport-neutral behavioral metadata for an invocable unit. These properties de
 
 #### 3.4.5.3 Semantics-to-Hints Derivation
 
-When an MCP tool references an aggregate function via `ref`, the function's `semantics` are automatically derived into MCP `hints` (`McpToolHints`). Explicit `hints` on the MCP tool override derived values field by field.
+When an MCP tool references an aggregate flow via `ref`, the function's `semantics` are automatically derived into MCP `hints` (`McpToolHints`). Explicit `hints` on the MCP tool override derived values field by field.
 
 **Mapping table:**
 
@@ -341,7 +341,7 @@ capability:
   aggregates:
     - display: "Forecast"
       namespace: "forecast"
-      functions:
+      flows:
         - name: "get-forecast"
           description: "Fetch current weather forecast for a location."
           semantics:
@@ -503,7 +503,7 @@ Capability groups not declared in the configuration are omitted from the `initia
 
 An MCP tool definition. Each tool maps to one or more consumed HTTP operations, similar to ExposedOperation but adapted for the MCP protocol (no HTTP method, tool-oriented input schema).
 
-> The McpTool supports the same two modes as ExposedOperation: **simple** (direct `call` + `with`) and **orchestrated** (multi-step with `steps` + `mappings`). Additionally, a tool can use **`ref`** to reference an aggregate function, inheriting its fields.
+> The McpTool supports the same two modes as ExposedOperation: **simple** (direct `call` + `with`) and **orchestrated** (multi-step with `steps` + `mappings`). Additionally, a tool can use **`ref`** to reference an aggregate flow, inheriting its fields.
 > 
 
 **Fixed Fields:**
@@ -514,7 +514,7 @@ An MCP tool definition. Each tool maps to one or more consumed HTTP operations, 
 | **display** | `string` | Human-readable display name for the tool. Mapped to MCP `title` in protocol responses. |
 | **tags** | `string[]` | Arbitrary string tags for filtering and discovery. |
 | **description** | `string` | A meaningful description of the tool. Essential for agent discovery. **REQUIRED** unless `ref` is used (inherited from function). |
-| **ref** | `string` | Reference to an aggregate function. Format: `{aggregate-namespace}.{function-name}`. Inherited fields are merged; explicit fields override. See [3.4.5 Aggregate Object](#345-aggregate-object). |
+| **ref** | `string` | Reference to an aggregate flow. Format: `{aggregate-namespace}.{function-name}`. Inherited fields are merged; explicit fields override. See [3.4.5 Aggregate Object](#345-aggregate-object). |
 | **hints** | `McpToolHints` | Optional behavioral hints for MCP clients. Mapped to `ToolAnnotations` in the MCP protocol. When `ref` is used, hints are automatically derived from the function's `semantics`; explicit values override derived ones. See [3.5.5.1 McpToolHints Object](#3551-mctoolhints-object). |
 | **inputParameters** | `McpToolInputParameter[]` | Tool input parameters. These become the MCP tool's input schema (JSON Schema). |
 | **call** | `string` | **Simple mode only**. Reference to a consumed operation. Format: `{namespace}.{operationId}`. MUST match pattern `^[a-zA-Z0-9-]+\.[a-zA-Z0-9-]+$`. |
@@ -540,7 +540,7 @@ An MCP tool definition. Each tool maps to one or more consumed HTTP operations, 
 - `outputParameters` are `OrchestratedOutputParameter[]`
 - `call` and `with` MUST NOT be present
 
-**Ref mode** — reference to an aggregate function:
+**Ref mode** — reference to an aggregate flow:
 
 - `ref` is **REQUIRED**
 - All other fields are optional — inherited from the referenced function
@@ -1334,7 +1334,7 @@ Describes an operation exposed on an exposed resource.
 
 > Update (schema v0.5): ExposesObject now supports two modes via `oneOf` — **simple** (direct call with mapped output) and **orchestrated** (multi-step with named operation). The `call` and `with` fields are new. The `name` and `steps` fields are only required in orchestrated mode.
 >
-> Update (schema v1.0.0-alpha1): A third **ref mode** allows referencing an aggregate function, inheriting its fields. See [3.4.5 Aggregate Object](#345-aggregate-object).
+> Update (schema v1.0.0-alpha1): A third **ref mode** allows referencing an aggregate flow, inheriting its fields. See [3.4.5 Aggregate Object](#345-aggregate-object).
 > 
 
 #### 3.9.1 Fixed Fields
@@ -1347,7 +1347,7 @@ All fields available on ExposesObject:
 | **name** | `string` | Technical name for the operation (pattern `^[a-zA-Z0-9-]+$`). **REQUIRED in orchestrated mode.** Optional when `ref` is used (inherited from function). |
 | **display** | `string` | Display name for the operation (likely used in UIs). |
 | **description** | `string` | A longer description of the operation. Useful for agent discovery and documentation. Optional when `ref` is used (inherited from function). |
-| **ref** | `string` | Reference to an aggregate function. Format: `{aggregate-namespace}.{function-name}`. Inherited fields are merged; explicit fields override. See [3.4.5 Aggregate Object](#345-aggregate-object). |
+| **ref** | `string` | Reference to an aggregate flow. Format: `{aggregate-namespace}.{function-name}`. Inherited fields are merged; explicit fields override. See [3.4.5 Aggregate Object](#345-aggregate-object). |
 | **inputParameters** | `ExposedInputParameter[]` | Input parameters attached to the operation. |
 | **call** | `string` | **Simple mode only**. Direct reference to a consumed operation. Format: `{namespace}.{operationId}`. MUST match pattern `^[a-zA-Z0-9-]+\.[a-zA-Z0-9-]+$`. |
 | **with** | `WithInjector` | **Simple mode only**. Parameter injection for the called operation. |
@@ -1374,7 +1374,7 @@ All fields available on ExposesObject:
 - `outputParameters` are `OrchestratedOutputParameter[]` (name + type)
 - `call` and `with` MUST NOT be present
 
-**Ref mode** — reference to an aggregate function:
+**Ref mode** — reference to an aggregate flow:
 
 - `ref` is **REQUIRED**
 - `method` is still **REQUIRED** (transport-specific)
@@ -1387,7 +1387,7 @@ All fields available on ExposesObject:
 - Exactly one of the three modes MUST be used (simple, orchestrated, or ref).
 - In simple mode, `call` MUST follow the format `{namespace}.{operationId}` and reference a valid consumed operation.
 - In orchestrated mode, the `steps` array MUST contain at least one entry. Each step references a consumed operation using `{namespace}.{operationName}`.
-- In ref mode, `ref` MUST resolve to an existing aggregate function at capability load time.
+- In ref mode, `ref` MUST resolve to an existing aggregate flow at capability load time.
 - The `method` field is always required regardless of mode.
 
 #### 3.9.4 ExposesObject Examples

--- a/ikanos-docs/wiki/Specification-‐-Schema.md
+++ b/ikanos-docs/wiki/Specification-‐-Schema.md
@@ -1,4 +1,4 @@
-﻿# Ikanos Specification - Schema
+# Ikanos Specification - Schema
 
 **Version:** {{RELEASE_TAG}}
 

--- a/ikanos-docs/wiki/Tutorial-‐-Part-2.md
+++ b/ikanos-docs/wiki/Tutorial-‐-Part-2.md
@@ -1,4 +1,4 @@
-# The Shipyard — Tutorial — Part 2
+﻿# The Shipyard — Tutorial — Part 2
 
 At the end of Part 1, your capability could list, inspect, plan, and enrich. Five tools, two APIs, one contract that survived the journey from mock to production. Good for an MCP client sitting next to the capability. But the Shipyard doesn't live alone: partner agents want a *catalog* they can discover, some logic keeps getting copy-pasted between tools, the operations dashboard speaks REST not MCP, and ops walks in one morning asking for *"one document that has everything."*
 
@@ -73,7 +73,7 @@ Something's starting to smell. Step 7 defined a three-step chain inside `get-shi
 ~~~yaml
 aggregates:
   - namespace: crew-resolver
-    functions:
+    flows:
       - name: resolve-crew-for-ship
         semantics:
           safe: true
@@ -133,7 +133,7 @@ The tool output is byte-for-byte identical to Step 7. The *spec* got dramaticall
 
 Not every consumer is an AI agent. The operations dashboard is a plain React app. The partner logistics company speaks OpenAPI. The mobile team doesn't care what MCP is — they want `GET /ships/{imo}` and they want it *now*.
 
-Same capability, different front door. `type: rest` exposes HTTP endpoints that map to the same consumed operations — or, better, the same aggregate functions we defined in Step 9. Write logic once, expose it three times.
+Same capability, different front door. `type: rest` exposes HTTP endpoints that map to the same consumed operations — or, better, the same aggregate flows we defined in Step 9. Write logic once, expose it three times.
 
 ~~~yaml
 - type: rest
@@ -192,12 +192,12 @@ Two things to notice. First, REST operations declare HTTP-level parameter placem
 
 The voyage is planned. The crew is confirmed. Oslo to Singapore, Northern Star, Captain Erik, Aiko in the galley. And now operations walks in with the final ask: *"I need one document. Voyage, ship, crew, cargo — all of it, resolved, in one payload. Before the ship leaves."*
 
-Three separate calls and client-side stitching would work. But we already have the pattern (Step 7) and the abstraction (Step 9). This is the same lookup mechanic, scaled up: **four `call` steps and three `lookup` steps**, defined once as an aggregate function, referenced from MCP, Skills, and REST simultaneously.
+Three separate calls and client-side stitching would work. But we already have the pattern (Step 7) and the abstraction (Step 9). This is the same lookup mechanic, scaled up: **four `call` steps and three `lookup` steps**, defined once as an aggregate flow, referenced from MCP, Skills, and REST simultaneously.
 
 ~~~yaml
 aggregates:
   - namespace: manifest
-    functions:
+    flows:
       - name: build-voyage-manifest
         semantics:
           safe: true

--- a/ikanos-docs/wiki/Tutorial-‐-Part-2.md
+++ b/ikanos-docs/wiki/Tutorial-‐-Part-2.md
@@ -1,4 +1,4 @@
-﻿# The Shipyard — Tutorial — Part 2
+# The Shipyard — Tutorial — Part 2
 
 At the end of Part 1, your capability could list, inspect, plan, and enrich. Five tools, two APIs, one contract that survived the journey from mock to production. Good for an MCP client sitting next to the capability. But the Shipyard doesn't live alone: partner agents want a *catalog* they can discover, some logic keeps getting copy-pasted between tools, the operations dashboard speaks REST not MCP, and ops walks in one morning asking for *"one document that has everything."*
 

--- a/ikanos-engine/src/main/java/io/ikanos/Capability.java
+++ b/ikanos-engine/src/main/java/io/ikanos/Capability.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.ikanos.engine.aggregates.Aggregate;
-import io.ikanos.engine.aggregates.AggregateFunction;
+import io.ikanos.engine.aggregates.AggregateFlow;
 import io.ikanos.engine.aggregates.AggregateRefResolver;
 import io.ikanos.engine.step.StepHandler;
 import io.ikanos.engine.step.StepHandlerRegistry;
@@ -206,32 +206,32 @@ public class Capability {
     }
 
     /**
-     * Look up an aggregate function by ref key ({@code "namespace.functionName"}).
+     * Look up an aggregate flow by ref key ({@code "namespace.flowName"}).
      *
      * @param ref the ref key, e.g. {@code "forecast.get-forecast"}
-     * @return the matching {@link AggregateFunction}
+     * @return the matching {@link AggregateFlow}
      * @throws IllegalArgumentException if the ref cannot be resolved
      */
-    public AggregateFunction lookupFunction(String ref) {
+    public AggregateFlow lookupFlow(String ref) {
         int dot = ref.indexOf('.');
         if (dot <= 0 || dot == ref.length() - 1) {
             throw new IllegalArgumentException(
-                    "Invalid aggregate function ref format: '" + ref
-                            + "'. Expected 'namespace.functionName'");
+                    "Invalid aggregate flow ref format: '" + ref
+                            + "'. Expected 'namespace.flowName'");
         }
         String namespace = ref.substring(0, dot);
-        String functionName = ref.substring(dot + 1);
+        String flowName = ref.substring(dot + 1);
 
         for (Aggregate agg : aggregates.get()) {
             if (agg.getNamespace().equals(namespace)) {
-                AggregateFunction fn = agg.findFunction(functionName);
-                if (fn != null) {
-                    return fn;
+                AggregateFlow flow = agg.findFlow(flowName);
+                if (flow != null) {
+                    return flow;
                 }
             }
         }
         throw new IllegalArgumentException(
-                "Unknown aggregate function ref: '" + ref + "'");
+                "Unknown aggregate flow ref: '" + ref + "'");
     }
 
     /**

--- a/ikanos-engine/src/main/java/io/ikanos/engine/aggregates/Aggregate.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/aggregates/Aggregate.java
@@ -16,25 +16,25 @@ package io.ikanos.engine.aggregates;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import io.ikanos.engine.util.OperationStepExecutor;
-import io.ikanos.spec.aggregates.AggregateFunctionSpec;
+import io.ikanos.spec.aggregates.AggregateFlowSpec;
 import io.ikanos.spec.aggregates.AggregateSpec;
 
 /**
  * Runtime representation of a domain aggregate.
  *
  * <p>Wraps an {@link AggregateSpec} (YAML data) and owns executable
- * {@link AggregateFunction} instances for each function defined in the spec.</p>
+ * {@link AggregateFlow} instances for each flow defined in the spec.</p>
  */
 public class Aggregate {
 
     private final String namespace;
-    private final List<AggregateFunction> functions;
+    private final List<AggregateFlow> flows;
 
     public Aggregate(AggregateSpec spec, OperationStepExecutor stepExecutor) {
         this.namespace = spec.getNamespace();
-        this.functions = new CopyOnWriteArrayList<>();
-        for (AggregateFunctionSpec fnSpec : spec.getFunctions().values()) {
-            this.functions.add(new AggregateFunction(fnSpec, stepExecutor, this.namespace));
+        this.flows = new CopyOnWriteArrayList<>();
+        for (AggregateFlowSpec flowSpec : spec.getFlows().values()) {
+            this.flows.add(new AggregateFlow(flowSpec, stepExecutor, this.namespace));
         }
     }
 
@@ -42,20 +42,20 @@ public class Aggregate {
         return namespace;
     }
 
-    public List<AggregateFunction> getFunctions() {
-        return functions;
+    public List<AggregateFlow> getFlows() {
+        return flows;
     }
 
     /**
-     * Find a function by name within this aggregate.
+     * Find a flow by name within this aggregate.
      *
-     * @param name the function name
-     * @return the function, or {@code null} if not found
+     * @param name the flow name
+     * @return the flow, or {@code null} if not found
      */
-    public AggregateFunction findFunction(String name) {
-        for (AggregateFunction fn : functions) {
-            if (fn.getName().equals(name)) {
-                return fn;
+    public AggregateFlow findFlow(String name) {
+        for (AggregateFlow flow : flows) {
+            if (flow.getName().equals(name)) {
+                return flow;
             }
         }
         return null;

--- a/ikanos-engine/src/main/java/io/ikanos/engine/aggregates/AggregateFlow.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/aggregates/AggregateFlow.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.ikanos.engine.observability.TelemetryBootstrap;
 import io.ikanos.engine.util.OperationStepExecutor;
 import io.ikanos.engine.util.Resolver;
-import io.ikanos.spec.aggregates.AggregateFunctionSpec;
+import io.ikanos.spec.aggregates.AggregateFlowSpec;
 import io.ikanos.spec.InputParameterSpec;
 import io.ikanos.spec.OutputParameterSpec;
 import io.ikanos.spec.aggregates.SemanticsSpec;
@@ -32,19 +32,19 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Scope;
 
 /**
- * Runtime-executable wrapper around an {@link AggregateFunctionSpec}.
+ * Runtime-executable wrapper around an {@link AggregateFlowSpec}.
  *
  * <p>Holds the spec data (from YAML) plus the {@link OperationStepExecutor} needed to actually
- * run the function. Adapters (MCP tools, REST operations) that reference an aggregate function
- * delegate execution here instead of duplicating the function's fields.</p>
+ * run the flow. Adapters (MCP tools, REST operations) that reference an aggregate flow
+ * delegate execution here instead of duplicating the flow's fields.</p>
  */
-public class AggregateFunction {
+public class AggregateFlow {
 
-    private final AggregateFunctionSpec spec;
+    private final AggregateFlowSpec spec;
     private final OperationStepExecutor stepExecutor;
     private final String namespace;
 
-    AggregateFunction(AggregateFunctionSpec spec, OperationStepExecutor stepExecutor,
+    AggregateFlow(AggregateFlowSpec spec, OperationStepExecutor stepExecutor,
             String namespace) {
         this.spec = spec;
         this.stepExecutor = stepExecutor;
@@ -89,7 +89,7 @@ public class AggregateFunction {
     }
 
     /**
-     * Execute this aggregate function with the given parameters.
+     * Execute this aggregate flow with the given parameters.
      *
      * <p>Supports three modes:
      * <ol>
@@ -99,11 +99,11 @@ public class AggregateFunction {
      * </ol>
      *
      * @param parameters resolved input parameters (merged with adapter-level 'with')
-     * @return a transport-neutral {@link FunctionResult}
+     * @return a transport-neutral {@link FlowResult}
      */
-    public FunctionResult execute(Map<String, Object> parameters) throws Exception {
+    public FlowResult execute(Map<String, Object> parameters) throws Exception {
         String ref = namespace + "." + spec.getName();
-        Span span = TelemetryBootstrap.get().startAggregateFunctionSpan(ref);
+        Span span = TelemetryBootstrap.get().startAggregateFlowSpan(ref);
         try (Scope scope = span.makeCurrent()) {
             return doExecute(parameters);
         } catch (Exception e) {
@@ -114,13 +114,13 @@ public class AggregateFunction {
         }
     }
 
-    FunctionResult doExecute(Map<String, Object> parameters) throws Exception {
+    FlowResult doExecute(Map<String, Object> parameters) throws Exception {
         Map<String, Object> merged = new HashMap<>();
         if (parameters != null) {
             merged.putAll(parameters);
         }
 
-        // Merge function-level 'with' parameters
+        // Merge flow-level 'with' parameters
         OperationStepExecutor.mergeWithParameters(spec.getWith(), merged, namespace);
 
         boolean hasCall = spec.getCall() != null;
@@ -130,7 +130,7 @@ public class AggregateFunction {
         if (!hasCall && !isOrchestrated) {
             ObjectMapper mapper = new ObjectMapper();
             JsonNode mockRoot = Resolver.buildMockData(spec.getOutputParameters(), mapper, merged);
-            return new FunctionResult(null, null, mockRoot);
+            return new FlowResult(null, null, mockRoot);
         }
 
         // Covers both orchestrated and simple-call paths
@@ -145,19 +145,19 @@ public class AggregateFunction {
                 String mapped = stepExecutor.resolveStepMappings(
                         spec.getMappings(), stepResult.stepContext);
                 if (mapped != null) {
-                    return new FunctionResult(stepResult.lastContext, mapped, null);
+                    return new FlowResult(stepResult.lastContext, mapped, null);
                 }
             }
 
-            return new FunctionResult(stepResult.lastContext, null, null);
+            return new FlowResult(stepResult.lastContext, null, null);
         }
 
         // Simple call mode
         OperationStepExecutor.HandlingContext found =
                 stepExecutor.execute(spec.getCall(), spec.getSteps(), merged,
-                        "Function '" + spec.getName() + "'");
+                        "Flow '" + spec.getName() + "'");
 
-        // Apply output parameter mappings if defined on the function
+        // Apply output parameter mappings if defined on the flow
         if (spec.getOutputParameters() != null && !spec.getOutputParameters().isEmpty()
                 && found != null && found.clientResponse != null
                 && found.clientResponse.getEntity() != null) {
@@ -169,11 +169,11 @@ public class AggregateFunction {
             String mapped = stepExecutor.applyOutputMappings(responseText,
                     spec.getOutputParameters(), outputRawFormat, outputSchema);
             if (mapped != null) {
-                return new FunctionResult(found, mapped, null);
+                return new FlowResult(found, mapped, null);
             }
         }
 
-        return new FunctionResult(found, null, null);
+        return new FlowResult(found, null, null);
     }
 
 }

--- a/ikanos-engine/src/main/java/io/ikanos/engine/aggregates/AggregateRefResolver.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/aggregates/AggregateRefResolver.java
@@ -17,7 +17,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import org.restlet.Context;
-import io.ikanos.spec.aggregates.AggregateFunctionSpec;
+import io.ikanos.spec.aggregates.AggregateFlowSpec;
 import io.ikanos.spec.aggregates.AggregateSpec;
 import io.ikanos.spec.CapabilitySpec;
 import io.ikanos.spec.IkanosSpec;
@@ -31,26 +31,26 @@ import io.ikanos.spec.exposes.rest.RestServerSpec;
 import io.ikanos.spec.exposes.ServerSpec;
 
 /**
- * Validates aggregate function references ({@code ref}) in adapter units (MCP tools, REST
+ * Validates aggregate flow references ({@code ref}) in adapter units (MCP tools, REST
  * operations) and derives MCP-specific metadata. Runs at capability load time, before server
  * startup.
  *
  * <p>
- * Validation ensures all refs point to known aggregate functions. For MCP tools, semantics are
+ * Validation ensures all refs point to known aggregate flows. For MCP tools, semantics are
  * automatically derived into hints (with field-level override). Adapter-specific metadata
  * (name, description) is inherited when not explicitly set on the adapter unit.
  *
  * <p>
  * Execution fields ({@code call}, {@code steps}, {@code with}, {@code inputParameters},
  * {@code outputParameters}, {@code mappings}) are <b>not</b> copied — at runtime, adapters
- * delegate to {@link AggregateFunction} instances held by the {@link io.ikanos.Capability}.
+ * delegate to {@link AggregateFlow} instances held by the {@link io.ikanos.Capability}.
  */
 public class AggregateRefResolver {
 
     /**
      * Validate all {@code ref} fields across adapter units in the given spec and derive
      * adapter-specific metadata.
-     * 
+     *
      * @param spec The root Naftiko spec to resolve
      * @throws IllegalArgumentException if a ref target is unknown
      */
@@ -60,22 +60,22 @@ public class AggregateRefResolver {
             return;
         }
 
-        // Build lookup map: "namespace.functionName" → AggregateFunctionSpec
-        Map<String, AggregateFunctionSpec> functionMap = buildFunctionMap(capability);
+        // Build lookup map: "namespace.flowName" → AggregateFlowSpec
+        Map<String, AggregateFlowSpec> flowMap = buildFlowMap(capability);
 
         // Validate refs and derive metadata in all adapter units
         for (ServerSpec serverSpec : capability.getExposes()) {
             if (serverSpec instanceof McpServerSpec mcpSpec) {
                 for (McpServerToolSpec tool : mcpSpec.getTools().values()) {
                     if (tool.getRef() != null) {
-                        resolveMcpToolRef(tool, functionMap);
+                        resolveMcpToolRef(tool, flowMap);
                     }
                 }
             } else if (serverSpec instanceof RestServerSpec restSpec) {
                 for (RestServerResourceSpec resource : restSpec.getResources().values()) {
                     for (RestServerOperationSpec op : resource.getOperations().values()) {
                         if (op.getRef() != null) {
-                            resolveRestOperationRef(op, functionMap);
+                            resolveRestOperationRef(op, flowMap);
                         }
                     }
                 }
@@ -84,49 +84,49 @@ public class AggregateRefResolver {
     }
 
     /**
-     * Build the lookup map of aggregate functions keyed by "namespace.functionName".
+     * Build the lookup map of aggregate flows keyed by "namespace.flowName".
      */
-    Map<String, AggregateFunctionSpec> buildFunctionMap(CapabilitySpec capability) {
-        Map<String, AggregateFunctionSpec> map = new HashMap<>();
+    Map<String, AggregateFlowSpec> buildFlowMap(CapabilitySpec capability) {
+        Map<String, AggregateFlowSpec> map = new HashMap<>();
 
         for (AggregateSpec aggregate : capability.getAggregates().values()) {
-            for (AggregateFunctionSpec function : aggregate.getFunctions().values()) {
-                String key = aggregate.getNamespace() + "." + function.getName();
+            for (AggregateFlowSpec flow : aggregate.getFlows().values()) {
+                String key = aggregate.getNamespace() + "." + flow.getName();
                 if (map.containsKey(key)) {
                     throw new IllegalArgumentException(
-                            "Duplicate aggregate function ref: '" + key + "'");
+                            "Duplicate aggregate flow ref: '" + key + "'");
                 }
-                map.put(key, function);
+                map.put(key, flow);
             }
         }
 
         Context.getCurrentLogger().log(Level.INFO,
-                "Built aggregate function map with {0} entries", map.size());
+                "Built aggregate flow map with {0} entries", map.size());
         return map;
     }
 
     /**
      * Validate a ref on an MCP tool, inherit adapter-specific metadata, and derive MCP hints
      * from semantics. Execution fields are not copied — they are resolved at runtime via
-     * {@link AggregateFunction}.
+     * {@link AggregateFlow}.
      */
     void resolveMcpToolRef(McpServerToolSpec tool,
-            Map<String, AggregateFunctionSpec> functionMap) {
-        AggregateFunctionSpec function = lookupFunction(tool.getRef(), functionMap);
+            Map<String, AggregateFlowSpec> flowMap) {
+        AggregateFlowSpec flow = lookupFlow(tool.getRef(), flowMap);
 
         // Inherit name (adapter-specific metadata)
         if (tool.getName() == null || tool.getName().isEmpty()) {
-            tool.setName(function.getName());
+            tool.setName(flow.getName());
         }
 
         // Inherit description (adapter-specific metadata)
         if (tool.getDescription() == null || tool.getDescription().isEmpty()) {
-            tool.setDescription(function.getDescription());
+            tool.setDescription(flow.getDescription());
         }
 
-        // Derive MCP hints from function semantics, with tool-level override
-        if (function.getSemantics() != null) {
-            McpToolHintsSpec derived = deriveHints(function.getSemantics());
+        // Derive MCP hints from flow semantics, with tool-level override
+        if (flow.getSemantics() != null) {
+            McpToolHintsSpec derived = deriveHints(flow.getSemantics());
             tool.setHints(mergeHints(derived, tool.getHints()));
         }
     }
@@ -134,35 +134,35 @@ public class AggregateRefResolver {
     /**
      * Validate a ref on a REST operation and inherit adapter-specific metadata.
      * Execution fields are not copied — they are resolved at runtime via
-     * {@link AggregateFunction}.
+     * {@link AggregateFlow}.
      */
     void resolveRestOperationRef(RestServerOperationSpec op,
-            Map<String, AggregateFunctionSpec> functionMap) {
-        AggregateFunctionSpec function = lookupFunction(op.getRef(), functionMap);
+            Map<String, AggregateFlowSpec> flowMap) {
+        AggregateFlowSpec flow = lookupFlow(op.getRef(), flowMap);
 
         // Inherit name
         if (op.getName() == null || op.getName().isEmpty()) {
-            op.setName(function.getName());
+            op.setName(flow.getName());
         }
 
         // Inherit description
         if (op.getDescription() == null || op.getDescription().isEmpty()) {
-            op.setDescription(function.getDescription());
+            op.setDescription(flow.getDescription());
         }
     }
 
     /**
-     * Look up a function by ref key. Fails fast on unknown refs.
+     * Look up a flow by ref key. Fails fast on unknown refs.
      */
-    AggregateFunctionSpec lookupFunction(String ref,
-            Map<String, AggregateFunctionSpec> functionMap) {
-        AggregateFunctionSpec function = functionMap.get(ref);
-        if (function == null) {
+    AggregateFlowSpec lookupFlow(String ref,
+            Map<String, AggregateFlowSpec> flowMap) {
+        AggregateFlowSpec flow = flowMap.get(ref);
+        if (flow == null) {
             throw new IllegalArgumentException(
-                    "Unknown aggregate function ref: '" + ref
-                            + "'. Available refs: " + functionMap.keySet());
+                    "Unknown aggregate flow ref: '" + ref
+                            + "'. Available refs: " + flowMap.keySet());
         }
-        return function;
+        return flow;
     }
 
     /**

--- a/ikanos-engine/src/main/java/io/ikanos/engine/aggregates/FlowResult.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/aggregates/FlowResult.java
@@ -17,11 +17,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.ikanos.engine.util.OperationStepExecutor;
 
 /**
- * Transport-neutral result of executing an aggregate function.
+ * Transport-neutral result of executing an aggregate flow.
  *
  * <p>Adapters (MCP, REST) convert this into their protocol-specific response format.</p>
  */
-public class FunctionResult {
+public class FlowResult {
 
     /** The last HTTP handling context (simple call or last orchestrated step). May be null in mock mode. */
     public final OperationStepExecutor.HandlingContext lastContext;
@@ -32,7 +32,7 @@ public class FunctionResult {
     /** Mock output built from outputParameter value fields. May be null. */
     public final JsonNode mockOutput;
 
-    FunctionResult(OperationStepExecutor.HandlingContext lastContext, String mappedOutput,
+    FlowResult(OperationStepExecutor.HandlingContext lastContext, String mappedOutput,
             JsonNode mockOutput) {
         this.lastContext = lastContext;
         this.mappedOutput = mappedOutput;

--- a/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/McpServerAdapter.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/McpServerAdapter.java
@@ -26,7 +26,7 @@ import org.restlet.Restlet;
 import org.restlet.routing.Router;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.ikanos.Capability;
-import io.ikanos.engine.aggregates.AggregateFunction;
+import io.ikanos.engine.aggregates.AggregateFlow;
 import io.ikanos.engine.exposes.ServerAdapter;
 import io.ikanos.spec.InputParameterSpec;
 import io.ikanos.spec.consumes.http.OAuth2AuthenticationSpec;
@@ -149,10 +149,10 @@ public class McpServerAdapter extends ServerAdapter {
         Map<String, Object> schemaProperties = new LinkedHashMap<>();
         List<String> required = new ArrayList<>();
 
-        // Resolve inputParameters: prefer tool-level, fall back to aggregate function
+        // Resolve inputParameters: prefer tool-level, fall back to aggregate flow
         List<InputParameterSpec> inputParams = toolSpec.getInputParameters();
         if ((inputParams == null || inputParams.isEmpty()) && toolSpec.getRef() != null) {
-            AggregateFunction fn = getCapability().lookupFunction(toolSpec.getRef());
+            AggregateFlow fn = getCapability().lookupFlow(toolSpec.getRef());
             inputParams = fn.getInputParameters();
         }
 

--- a/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/ToolHandler.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/ToolHandler.java
@@ -21,8 +21,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.restlet.Context;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.ikanos.Capability;
-import io.ikanos.engine.aggregates.AggregateFunction;
-import io.ikanos.engine.aggregates.FunctionResult;
+import io.ikanos.engine.aggregates.AggregateFlow;
+import io.ikanos.engine.aggregates.FlowResult;
 import io.ikanos.engine.observability.TelemetryBootstrap;
 import io.ikanos.engine.util.OperationStepExecutor;
 import io.ikanos.engine.util.Resolver;
@@ -185,13 +185,13 @@ public class ToolHandler {
     }
 
     /**
-     * Execute a tool call by delegating to its referenced aggregate function.
+     * Execute a tool call by delegating to its referenced aggregate flow.
      */
     private McpSchema.CallToolResult executeViaAggregate(McpServerToolSpec toolSpec,
             String toolName, Map<String, Object> parameters) throws Exception {
         try {
-            AggregateFunction fn = capability.lookupFunction(toolSpec.getRef());
-            FunctionResult result = fn.execute(parameters);
+            AggregateFlow fn = capability.lookupFlow(toolSpec.getRef());
+            FlowResult result = fn.execute(parameters);
 
             if (result.isMock()) {
                 ObjectMapper mapper = new ObjectMapper();

--- a/ikanos-engine/src/main/java/io/ikanos/engine/exposes/rest/ResourceRestlet.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/exposes/rest/ResourceRestlet.java
@@ -20,8 +20,8 @@ import org.restlet.Restlet;
 import org.restlet.data.MediaType;
 import org.restlet.data.Status;
 import io.ikanos.Capability;
-import io.ikanos.engine.aggregates.AggregateFunction;
-import io.ikanos.engine.aggregates.FunctionResult;
+import io.ikanos.engine.aggregates.AggregateFlow;
+import io.ikanos.engine.aggregates.FlowResult;
 import io.ikanos.engine.consumes.ClientAdapter;
 import io.ikanos.engine.consumes.http.HttpClientAdapter;
 import io.ikanos.engine.observability.OtelRestletBridge;
@@ -230,13 +230,13 @@ public class ResourceRestlet extends Restlet {
     }
 
     /**
-     * Execute an operation by delegating to its referenced aggregate function.
+     * Execute an operation by delegating to its referenced aggregate flow.
      */
     private boolean executeViaAggregate(RestServerOperationSpec serverOp, Request request,
             Response response, Map<String, Object> inputParameters) {
         try {
-            AggregateFunction fn = capability.lookupFunction(serverOp.getRef());
-            FunctionResult result = fn.execute(inputParameters);
+            AggregateFlow fn = capability.lookupFlow(serverOp.getRef());
+            FlowResult result = fn.execute(inputParameters);
 
             if (result.isMock()) {
                 ObjectMapper mapper = new ObjectMapper();

--- a/ikanos-engine/src/main/java/io/ikanos/engine/observability/TelemetryBootstrap.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/observability/TelemetryBootstrap.java
@@ -376,7 +376,7 @@ public class TelemetryBootstrap {
     /**
      * Start an INTERNAL span for an aggregate function execution.
      */
-    public Span startAggregateFunctionSpan(String ref) {
+    public Span startAggregateFlowSpan(String ref) {
         if (!enabled) return Span.getInvalid();
         SpanBuilder builder = tracer.spanBuilder("aggregate.function")
             .setSpanKind(SpanKind.INTERNAL);

--- a/ikanos-engine/src/main/java/io/ikanos/engine/observability/TelemetryBootstrap.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/observability/TelemetryBootstrap.java
@@ -378,7 +378,7 @@ public class TelemetryBootstrap {
      */
     public Span startAggregateFlowSpan(String ref) {
         if (!enabled) return Span.getInvalid();
-        SpanBuilder builder = tracer.spanBuilder("aggregate.function")
+        SpanBuilder builder = tracer.spanBuilder("aggregate.flow")
             .setSpanKind(SpanKind.INTERNAL);
         setStringAttribute(builder, ATTR_AGGREGATE_REF, ref != null ? ref : "unknown");
         return builder.startSpan();

--- a/ikanos-engine/src/main/java/io/ikanos/engine/util/OperationStepExecutor.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/util/OperationStepExecutor.java
@@ -93,9 +93,9 @@ public class OperationStepExecutor {
     /**
      * Override the expose namespace after construction.
      *
-     * <p>This setter exists for {@link io.ikanos.engine.aggregates.AggregateFunction}, which
-     * shares a single {@code OperationStepExecutor} across multiple aggregate functions that may
-     * belong to different namespaces. The function sets its own namespace before each execution.
+     * <p>This setter exists for {@link io.ikanos.engine.aggregates.AggregateFlow}, which
+     * shares a single {@code OperationStepExecutor} across multiple aggregate flows that may
+     * belong to different namespaces. The flow sets its own namespace before each execution.
      * Handlers whose namespace is known at construction time should use
      * {@link #OperationStepExecutor(Capability, String)} instead.</p>
      */

--- a/ikanos-engine/src/test/java/io/ikanos/engine/aggregates/AggregateFlowTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/aggregates/AggregateFlowTest.java
@@ -21,17 +21,17 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
-import io.ikanos.spec.aggregates.AggregateFunctionSpec;
+import io.ikanos.spec.aggregates.AggregateFlowSpec;
 import io.ikanos.spec.OutputParameterSpec;
 
 /**
- * Unit tests for {@link AggregateFunction} — namespace-qualified reference resolution
- * in function-level {@code with} blocks.
+ * Unit tests for {@link AggregateFlow} — namespace-qualified reference resolution
+ * in flow-level {@code with} blocks.
  */
-public class AggregateFunctionTest {
+public class AggregateFlowTest {
 
     /**
-     * When a mock-mode function has {@code with: {voyage-id: "shipyard.voyage-id"}} and the
+     * When a mock-mode flow has {@code with: {voyage-id: "shipyard.voyage-id"}} and the
      * aggregate namespace is "shipyard", calling execute should resolve the qualified reference
      * to the caller's argument and use it for mock data output.
      *
@@ -39,8 +39,8 @@ public class AggregateFunctionTest {
      * "shipyard.voyage-id" overwrote the caller's "VOY-2026-042" and appeared in the mock output.
      */
     @Test
-    void executeShouldResolveNamespaceQualifiedReferencesInFunctionWith() throws Exception {
-        AggregateFunctionSpec spec = new AggregateFunctionSpec();
+    void executeShouldResolveNamespaceQualifiedReferencesInFlowWith() throws Exception {
+        AggregateFlowSpec spec = new AggregateFlowSpec();
         spec.setName("get-voyage");
         spec.setDescription("Get a voyage manifest.");
         Map<String, Object> withBlock = new HashMap<>();
@@ -55,11 +55,11 @@ public class AggregateFunctionTest {
         spec.setOutputParameters(List.of(outParam));
 
         // No call, no steps -> mock mode
-        AggregateFunction fn = new AggregateFunction(spec, null, "shipyard");
+        AggregateFlow fn = new AggregateFlow(spec, null, "shipyard");
 
         Map<String, Object> callerParams = new HashMap<>();
         callerParams.put("voyage-id", "VOY-2026-042");
-        FunctionResult result = fn.execute(callerParams);
+        FlowResult result = fn.execute(callerParams);
 
         assertTrue(result.isMock(), "Should be mock mode");
         assertNotNull(result.mockOutput, "Mock output should not be null");

--- a/ikanos-engine/src/test/java/io/ikanos/engine/aggregates/AggregateRefResolverTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/aggregates/AggregateRefResolverTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
-import io.ikanos.spec.aggregates.AggregateFunctionSpec;
+import io.ikanos.spec.aggregates.AggregateFlowSpec;
 import io.ikanos.spec.aggregates.AggregateSpec;
 import io.ikanos.spec.CapabilitySpec;
 import io.ikanos.spec.IkanosSpec;
@@ -41,22 +41,22 @@ public class AggregateRefResolverTest {
         resolver = new AggregateRefResolver();
     }
 
-    // ── buildFunctionMap ──
+    // ── buildFlowMap ──
 
     @Test
-    void buildFunctionMapShouldIndexByNamespaceAndName() {
+    void buildFlowMapShouldIndexByNamespaceAndName() {
         CapabilitySpec cap = new CapabilitySpec();
         AggregateSpec agg = new AggregateSpec();
         agg.setNamespace("forecast");
         agg.setDisplay("Forecast");
 
-        AggregateFunctionSpec fn = new AggregateFunctionSpec();
+        AggregateFlowSpec fn = new AggregateFlowSpec();
         fn.setName("get-forecast");
         fn.setDescription("Get forecast");
-        agg.getFunctions().put(fn.getName(), fn);
+        agg.getFlows().put(fn.getName(), fn);
         cap.getAggregates().put(agg.getNamespace(), agg);
 
-        Map<String, AggregateFunctionSpec> map = resolver.buildFunctionMap(cap);
+        Map<String, AggregateFlowSpec> map = resolver.buildFlowMap(cap);
 
         assertEquals(1, map.size());
         assertTrue(map.containsKey("forecast.get-forecast"));
@@ -64,42 +64,42 @@ public class AggregateRefResolverTest {
     }
 
     @Test
-    void buildFunctionMapShouldFailOnDuplicateRef() {
+    void buildFlowMapShouldFailOnDuplicateRef() {
         // With named-object maps, two aggregates cannot share the same namespace key
         // (the second put overwrites the first). Duplicate detection now applies to
         // functions within different aggregates that share the same namespace.functionName
         // ref, which is architecturally impossible via the POJO model but can be simulated
         // by placing two functions with the same name in the same aggregate's function map.
-        // The duplicate-ref guard in buildFunctionMap protects against future injection;
+        // The duplicate-ref guard in buildFlowMap protects against future injection;
         // we verify it never fires when refs are distinct.
         CapabilitySpec cap = new CapabilitySpec();
 
         AggregateSpec agg = new AggregateSpec();
         agg.setNamespace("data");
         agg.setDisplay("Data");
-        AggregateFunctionSpec fn1 = new AggregateFunctionSpec();
+        AggregateFlowSpec fn1 = new AggregateFlowSpec();
         fn1.setName("read");
         fn1.setDescription("Read1");
-        agg.getFunctions().put(fn1.getName(), fn1);
+        agg.getFlows().put(fn1.getName(), fn1);
 
         cap.getAggregates().put(agg.getNamespace(), agg);
 
         // Single function → no duplicate → should not throw
-        Map<String, AggregateFunctionSpec> map = resolver.buildFunctionMap(cap);
+        Map<String, AggregateFlowSpec> map = resolver.buildFlowMap(cap);
         assertTrue(map.containsKey("data.read"));
     }
 
-    // ── lookupFunction ──
+    // ── lookupFlow ──
 
     @Test
-    void lookupFunctionShouldFailOnUnknownRef() {
-        Map<String, AggregateFunctionSpec> map = new HashMap<>();
-        AggregateFunctionSpec fn = new AggregateFunctionSpec();
+    void lookupFlowShouldFailOnUnknownRef() {
+        Map<String, AggregateFlowSpec> map = new HashMap<>();
+        AggregateFlowSpec fn = new AggregateFlowSpec();
         fn.setName("read");
         map.put("data.read", fn);
 
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                () -> resolver.lookupFunction("unknown.nonexistent", map));
+                () -> resolver.lookupFlow("unknown.nonexistent", map));
         assertTrue(ex.getMessage().contains("unknown.nonexistent"));
     }
 
@@ -107,11 +107,11 @@ public class AggregateRefResolverTest {
 
     @Test
     void resolveMcpToolRefShouldInheritNameFromFunction() {
-        AggregateFunctionSpec fn = new AggregateFunctionSpec();
+        AggregateFlowSpec fn = new AggregateFlowSpec();
         fn.setName("get-data");
         fn.setDescription("Get data");
 
-        Map<String, AggregateFunctionSpec> map = Map.of("data.get-data", fn);
+        Map<String, AggregateFlowSpec> map = Map.of("data.get-data", fn);
 
         McpServerToolSpec tool = new McpServerToolSpec(null, null, null);
         tool.setRef("data.get-data");
@@ -123,11 +123,11 @@ public class AggregateRefResolverTest {
 
     @Test
     void resolveMcpToolRefShouldNotOverrideExplicitName() {
-        AggregateFunctionSpec fn = new AggregateFunctionSpec();
+        AggregateFlowSpec fn = new AggregateFlowSpec();
         fn.setName("get-data");
         fn.setDescription("Get data");
 
-        Map<String, AggregateFunctionSpec> map = Map.of("data.get-data", fn);
+        Map<String, AggregateFlowSpec> map = Map.of("data.get-data", fn);
 
         McpServerToolSpec tool = new McpServerToolSpec("custom-name", null, null);
         tool.setRef("data.get-data");
@@ -139,24 +139,24 @@ public class AggregateRefResolverTest {
 
     @Test
     void resolveMcpToolRefShouldNotCopyCallFromFunction() {
-        AggregateFunctionSpec fn = new AggregateFunctionSpec();
+        AggregateFlowSpec fn = new AggregateFlowSpec();
         fn.setName("get-data");
         fn.setDescription("Get data");
         fn.setCall(new ServerCallSpec("mock-api.get-data"));
 
-        Map<String, AggregateFunctionSpec> map = Map.of("data.get-data", fn);
+        Map<String, AggregateFlowSpec> map = Map.of("data.get-data", fn);
 
         McpServerToolSpec tool = new McpServerToolSpec("get-data", null, "Get data");
         tool.setRef("data.get-data");
 
         resolver.resolveMcpToolRef(tool, map);
 
-        assertNull(tool.getCall(), "call should not be copied — resolved at runtime via AggregateFunction");
+        assertNull(tool.getCall(), "call should not be copied — resolved at runtime via aggregate flow");
     }
 
     @Test
     void resolveMcpToolRefShouldNotCopyInputParametersFromFunction() {
-        AggregateFunctionSpec fn = new AggregateFunctionSpec();
+        AggregateFlowSpec fn = new AggregateFlowSpec();
         fn.setName("get-data");
         fn.setDescription("Get data");
         io.ikanos.spec.InputParameterSpec param = new io.ikanos.spec.InputParameterSpec();
@@ -164,7 +164,7 @@ public class AggregateRefResolverTest {
         param.setType("string");
         fn.setInputParameters(Map.of("location", param));
 
-        Map<String, AggregateFunctionSpec> map = Map.of("data.get-data", fn);
+        Map<String, AggregateFlowSpec> map = Map.of("data.get-data", fn);
 
         McpServerToolSpec tool = new McpServerToolSpec("get-data", null, "Get data");
         tool.setRef("data.get-data");
@@ -172,16 +172,16 @@ public class AggregateRefResolverTest {
         resolver.resolveMcpToolRef(tool, map);
 
         assertTrue(tool.getInputParameters().isEmpty(),
-                "inputParameters should not be copied — resolved at runtime via AggregateFunction");
+                "inputParameters should not be copied — resolved at runtime via aggregate flow");
     }
 
     @Test
     void resolveMcpToolRefShouldInheritDescription() {
-        AggregateFunctionSpec fn = new AggregateFunctionSpec();
+        AggregateFlowSpec fn = new AggregateFlowSpec();
         fn.setName("get-data");
         fn.setDescription("Function description");
 
-        Map<String, AggregateFunctionSpec> map = Map.of("data.get-data", fn);
+        Map<String, AggregateFlowSpec> map = Map.of("data.get-data", fn);
 
         McpServerToolSpec tool = new McpServerToolSpec("get-data", null, null);
         tool.setRef("data.get-data");
@@ -193,11 +193,11 @@ public class AggregateRefResolverTest {
 
     @Test
     void resolveMcpToolRefShouldNotOverrideExplicitDescription() {
-        AggregateFunctionSpec fn = new AggregateFunctionSpec();
+        AggregateFlowSpec fn = new AggregateFlowSpec();
         fn.setName("get-data");
         fn.setDescription("Function description");
 
-        Map<String, AggregateFunctionSpec> map = Map.of("data.get-data", fn);
+        Map<String, AggregateFlowSpec> map = Map.of("data.get-data", fn);
 
         McpServerToolSpec tool = new McpServerToolSpec("get-data", null, "Tool description");
         tool.setRef("data.get-data");
@@ -211,11 +211,11 @@ public class AggregateRefResolverTest {
 
     @Test
     void resolveRestOperationRefShouldInheritNameFromFunction() {
-        AggregateFunctionSpec fn = new AggregateFunctionSpec();
+        AggregateFlowSpec fn = new AggregateFlowSpec();
         fn.setName("get-data");
         fn.setDescription("Get data");
 
-        Map<String, AggregateFunctionSpec> map = Map.of("data.get-data", fn);
+        Map<String, AggregateFlowSpec> map = Map.of("data.get-data", fn);
 
         RestServerOperationSpec op = new RestServerOperationSpec();
         op.setRef("data.get-data");
@@ -227,19 +227,19 @@ public class AggregateRefResolverTest {
 
     @Test
     void resolveRestOperationRefShouldNotCopyCallFromFunction() {
-        AggregateFunctionSpec fn = new AggregateFunctionSpec();
+        AggregateFlowSpec fn = new AggregateFlowSpec();
         fn.setName("get-data");
         fn.setDescription("Get data");
         fn.setCall(new ServerCallSpec("mock-api.get-data"));
 
-        Map<String, AggregateFunctionSpec> map = Map.of("data.get-data", fn);
+        Map<String, AggregateFlowSpec> map = Map.of("data.get-data", fn);
 
         RestServerOperationSpec op = new RestServerOperationSpec();
         op.setRef("data.get-data");
 
         resolver.resolveRestOperationRef(op, map);
 
-        assertNull(op.getCall(), "call should not be copied — resolved at runtime via AggregateFunction");
+        assertNull(op.getCall(), "call should not be copied — resolved at runtime via aggregate flow");
     }
 
     // ── deriveHints ──
@@ -401,12 +401,12 @@ public class AggregateRefResolverTest {
         AggregateSpec agg = new AggregateSpec();
         agg.setNamespace("data");
         agg.setDisplay("Data");
-        AggregateFunctionSpec fn = new AggregateFunctionSpec();
+        AggregateFlowSpec fn = new AggregateFlowSpec();
         fn.setName("read");
         fn.setDescription("Read data");
         fn.setSemantics(semantics);
         fn.setCall(new ServerCallSpec("mock.read"));
-        agg.getFunctions().put(fn.getName(), fn);
+        agg.getFlows().put(fn.getName(), fn);
         cap.getAggregates().put(agg.getNamespace(), agg);
 
         McpServerSpec mcpSpec = new McpServerSpec();

--- a/ikanos-engine/src/test/java/io/ikanos/engine/aggregates/AggregateStepNamespaceIntegrationTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/aggregates/AggregateStepNamespaceIntegrationTest.java
@@ -29,9 +29,9 @@ import io.ikanos.spec.aggregates.AggregateSpec;
 import io.ikanos.spec.IkanosSpec;
 
 /**
- * Integration test for issue #290: namespace-qualified references in aggregate function steps.
+ * Integration test for issue #290: namespace-qualified references in aggregate flow steps.
  *
- * Loads a capability YAML where an aggregate function has a step with
+ * Loads a capability YAML where an aggregate flow has a step with
  * {@code with: {voyage-id: shipyard.voyage-id}} and verifies that executing the function
  * resolves the namespace-qualified reference before building the HTTP request URL.
  *
@@ -59,18 +59,18 @@ public class AggregateStepNamespaceIntegrationTest {
     }
 
     /**
-     * Execute the aggregate function and verify the step-level namespace-qualified reference
+     * Execute the aggregate flow and verify the step-level namespace-qualified reference
      * resolves correctly. A CapturingStepExecutor captures the resolved parameters before the
      * HTTP call, so the assertion does not depend on error message contents.
      */
     @Test
-    void aggregateFunctionExecuteShouldResolveNamespaceQualifiedWithInSteps() {
+    void aggregateFlowExecuteShouldResolveNamespaceQualifiedWithInSteps() {
         CapturingStepExecutor executor = new CapturingStepExecutor(capability);
 
         AggregateSpec aggregateSpec = spec.getCapability().getAggregates().get("shipyard");
         Aggregate aggregate = new Aggregate(aggregateSpec, executor);
-        AggregateFunction fn = aggregate.findFunction("get-voyage-manifest");
-        assertNotNull(fn, "Aggregate function should be found");
+        AggregateFlow fn = aggregate.findFlow("get-voyage-manifest");
+        assertNotNull(fn, "aggregate flow should be found");
 
         Map<String, Object> params = new HashMap<>();
         params.put("voyage-id", "VOY-2026-042");

--- a/ikanos-engine/src/test/java/io/ikanos/engine/aggregates/AggregateStepNamespaceIntegrationTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/aggregates/AggregateStepNamespaceIntegrationTest.java
@@ -70,7 +70,7 @@ public class AggregateStepNamespaceIntegrationTest {
         AggregateSpec aggregateSpec = spec.getCapability().getAggregates().get("shipyard");
         Aggregate aggregate = new Aggregate(aggregateSpec, executor);
         AggregateFlow fn = aggregate.findFlow("get-voyage-manifest");
-        assertNotNull(fn, "aggregate flow should be found");
+        assertNotNull(fn, "Aggregate flow should be found");
 
         Map<String, Object> params = new HashMap<>();
         params.put("voyage-id", "VOY-2026-042");

--- a/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/AggregateIntegrationTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/AggregateIntegrationTest.java
@@ -20,14 +20,14 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.ikanos.Capability;
-import io.ikanos.engine.aggregates.AggregateFunction;
+import io.ikanos.engine.aggregates.AggregateFlow;
 import io.ikanos.spec.IkanosSpec;
 import io.ikanos.spec.exposes.mcp.McpServerSpec;
 import io.ikanos.spec.exposes.mcp.McpServerToolSpec;
 import java.io.File;
 
 /**
- * Integration tests for aggregate function ref resolution and semantics-to-hints derivation
+ * Integration tests for aggregate flow ref resolution and semantics-to-hints derivation
  * through the full capability loading pipeline.
  */
 public class AggregateIntegrationTest {
@@ -46,7 +46,7 @@ public class AggregateIntegrationTest {
     // ── Basic ref resolution ──
 
     @Test
-    void refShouldResolveCallFromAggregateFunction() throws Exception {
+    void refShouldResolveCallFromAggregateFlow() throws Exception {
         Capability capability = loadCapability("src/test/resources/aggregates/aggregate-basic.yaml");
         McpServerAdapter adapter = (McpServerAdapter) capability.getServerAdapters().get(0);
         McpServerSpec serverSpec = adapter.getMcpServerSpec();
@@ -56,9 +56,9 @@ public class AggregateIntegrationTest {
         // call is no longer copied to the tool spec — it is resolved at runtime
         assertNull(tool.getCall(), "call should not be on tool spec — delegated to aggregate");
 
-        // Verify call is available via the runtime aggregate function
-        AggregateFunction fn = capability.lookupFunction(tool.getRef());
-        assertNotNull(fn.getCall(), "call should be available on the aggregate function");
+        // Verify call is available via the runtime aggregate flow
+        AggregateFlow fn = capability.lookupFlow(tool.getRef());
+        assertNotNull(fn.getCall(), "call should be available on the aggregate flow");
         assertEquals("weather-api.get-forecast", fn.getCall().getOperation());
     }
 
@@ -73,8 +73,8 @@ public class AggregateIntegrationTest {
         assertTrue(tool.getInputParameters().isEmpty(),
                 "inputParameters should not be on tool spec — delegated to aggregate");
 
-        // Verify inputParameters are available via the runtime aggregate function
-        AggregateFunction fn = capability.lookupFunction(tool.getRef());
+        // Verify inputParameters are available via the runtime aggregate flow
+        AggregateFlow fn = capability.lookupFlow(tool.getRef());
         assertEquals(1, fn.getInputParameters().size());
         assertEquals("location", fn.getInputParameters().get(0).getName());
     }
@@ -101,7 +101,7 @@ public class AggregateIntegrationTest {
         io.ikanos.spec.exposes.rest.RestServerSpec restSpec =
                 (io.ikanos.spec.exposes.rest.RestServerSpec) restAdapter.getSpec();
 
-        // POST operation uses key "get-forecast" — name inherited from aggregate function key
+        // POST operation uses key "get-forecast" — name inherited from aggregate flow key
         io.ikanos.spec.exposes.rest.RestServerOperationSpec op =
                 restSpec.getResources().get("forecast").getOperations().get("get-forecast");
         assertEquals("POST", op.getMethod());

--- a/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ObservabilityMcpIntegrationTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ObservabilityMcpIntegrationTest.java
@@ -107,11 +107,11 @@ public class ObservabilityMcpIntegrationTest {
 
         List<SpanData> spans = exporter.getFinishedSpanItems();
 
-        // Find aggregate.function span
+        // Find aggregate.flow span
         SpanData aggregateSpan = spans.stream()
-                .filter(s -> s.getName().equals("aggregate.function"))
+                .filter(s -> s.getName().equals("aggregate.flow"))
                 .findFirst()
-                .orElseThrow(() -> new AssertionError("Missing aggregate.function span"));
+                .orElseThrow(() -> new AssertionError("Missing aggregate.flow span"));
 
         assertEquals(SpanKind.INTERNAL, aggregateSpan.getKind());
         assertEquals("forecast.get-forecast",
@@ -123,7 +123,7 @@ public class ObservabilityMcpIntegrationTest {
                 .findFirst().orElseThrow();
 
         assertEquals(toolSpan.getSpanId(), aggregateSpan.getParentSpanId(),
-                "aggregate.function should be a child of mcp.tool");
+                "aggregate.flow should be a child of mcp.tool");
         assertEquals(toolSpan.getTraceId(), aggregateSpan.getTraceId(),
                 "Both spans should share the same trace");
     }

--- a/ikanos-engine/src/test/java/io/ikanos/engine/exposes/rest/AggregateSharedMockIntegrationTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/exposes/rest/AggregateSharedMockIntegrationTest.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.ikanos.Capability;
-import io.ikanos.engine.aggregates.AggregateFunction;
+import io.ikanos.engine.aggregates.AggregateFlow;
 import io.ikanos.engine.exposes.mcp.McpServerAdapter;
 import io.ikanos.engine.exposes.mcp.ProtocolDispatcher;
 import io.ikanos.spec.IkanosSpec;
@@ -36,7 +36,7 @@ import io.ikanos.spec.exposes.rest.RestServerOperationSpec;
 import io.ikanos.spec.exposes.rest.RestServerSpec;
 
 /**
- * Integration test proving that a single aggregate function mock can be reused unchanged by
+ * Integration test proving that a single aggregate flow mock can be reused unchanged by
  * both MCP and REST adapters.
  */
 public class AggregateSharedMockIntegrationTest {
@@ -64,13 +64,13 @@ public class AggregateSharedMockIntegrationTest {
         RestServerSpec restSpec = (RestServerSpec) restAdapter.getSpec();
         RestServerOperationSpec restOperation = restSpec.getResources().values().iterator().next().getOperations().values().iterator().next();
 
-        // Output parameters are no longer copied — they live on the aggregate function
-        AggregateFunction fn = capability.lookupFunction(restOperation.getRef());
-        assertNotNull(fn, "Aggregate function should be resolvable from ref");
+        // Output parameters are no longer copied — they live on the aggregate flow
+        AggregateFlow fn = capability.lookupFlow(restOperation.getRef());
+        assertNotNull(fn, "aggregate flow should be resolvable from ref");
         assertEquals(2, fn.getOutputParameters().size(),
-                "Aggregate function should have two output parameters");
+                "aggregate flow should have two output parameters");
 
-        // Exercise REST path through the normal flow (delegating to aggregate function)
+        // Exercise REST path through the normal flow (delegating to aggregate flow)
         ResourceRestlet restlet = new ResourceRestlet(capability, restSpec,
                 restSpec.getResources().values().iterator().next());
         Request request = new Request(Method.GET, new Reference("http://localhost/hello?name=Nina"));

--- a/ikanos-engine/src/test/java/io/ikanos/engine/exposes/rest/AggregateSharedMockIntegrationTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/exposes/rest/AggregateSharedMockIntegrationTest.java
@@ -66,9 +66,9 @@ public class AggregateSharedMockIntegrationTest {
 
         // Output parameters are no longer copied — they live on the aggregate flow
         AggregateFlow fn = capability.lookupFlow(restOperation.getRef());
-        assertNotNull(fn, "aggregate flow should be resolvable from ref");
+        assertNotNull(fn, "Aggregate flow should be resolvable from ref");
         assertEquals(2, fn.getOutputParameters().size(),
-                "aggregate flow should have two output parameters");
+                "Aggregate flow should have two output parameters");
 
         // Exercise REST path through the normal flow (delegating to aggregate flow)
         ResourceRestlet restlet = new ResourceRestlet(capability, restSpec,

--- a/ikanos-engine/src/test/java/io/ikanos/engine/observability/TelemetryBootstrapTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/observability/TelemetryBootstrapTest.java
@@ -170,13 +170,13 @@ public class TelemetryBootstrapTest {
         assertEquals("vessel-name", stringAttribute(data.getAttributes(), TelemetryBootstrap.ATTR_STEP_MATCH));
     }
 
-    // ── Aggregate function span factory ──
+    // ── aggregate flow span factory ──
 
     @Test
-    void startAggregateFunctionSpanShouldCreateInternalSpanWithRef() {
+    void startAggregateFlowSpanShouldCreateInternalSpanWithRef() {
         initWithInMemoryExporter();
 
-        Span span = TelemetryBootstrap.get().startAggregateFunctionSpan("forecast.get-forecast");
+        Span span = TelemetryBootstrap.get().startAggregateFlowSpan("forecast.get-forecast");
         span.end();
 
         SpanData data = exporter.getFinishedSpanItems().get(0);
@@ -187,10 +187,10 @@ public class TelemetryBootstrapTest {
     }
 
     @Test
-    void startAggregateFunctionSpanShouldDefaultRefWhenNull() {
+    void startAggregateFlowSpanShouldDefaultRefWhenNull() {
         initWithInMemoryExporter();
 
-        Span span = TelemetryBootstrap.get().startAggregateFunctionSpan(null);
+        Span span = TelemetryBootstrap.get().startAggregateFlowSpan(null);
         span.end();
 
         SpanData data = exporter.getFinishedSpanItems().get(0);

--- a/ikanos-engine/src/test/java/io/ikanos/engine/observability/TelemetryBootstrapTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/observability/TelemetryBootstrapTest.java
@@ -180,7 +180,7 @@ public class TelemetryBootstrapTest {
         span.end();
 
         SpanData data = exporter.getFinishedSpanItems().get(0);
-        assertEquals("aggregate.function", data.getName());
+        assertEquals("aggregate.flow", data.getName());
         assertEquals(SpanKind.INTERNAL, data.getKind());
         assertEquals("forecast.get-forecast",
             stringAttribute(data.getAttributes(), TelemetryBootstrap.ATTR_AGGREGATE_REF));

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-basic.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-basic.yaml
@@ -1,4 +1,4 @@
-﻿ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha3
 info:
   display: Aggregate Basic Test
   description: Test capability for aggregate function ref resolution

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-basic.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-basic.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+﻿ikanos: 1.0.0-alpha3
 info:
   display: Aggregate Basic Test
   description: Test capability for aggregate function ref resolution
@@ -12,7 +12,7 @@ capability:
     forecast:
       display: Forecast
       namespace: forecast
-      functions:
+      flows:
         get-forecast:
           description: Fetch current weather forecast for a location.
           semantics:

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-hints-override.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-hints-override.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+﻿ikanos: 1.0.0-alpha3
 info:
   display: Aggregate Hints Override Test
   description: Test capability for semantics-to-hints derivation with override
@@ -12,7 +12,7 @@ capability:
     data:
       display: Data
       namespace: data
-      functions:
+      flows:
         read-items:
           description: Read items from the data store.
           semantics:

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-hints-override.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-hints-override.yaml
@@ -1,4 +1,4 @@
-﻿ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha3
 info:
   display: Aggregate Hints Override Test
   description: Test capability for semantics-to-hints derivation with override

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-invalid-ref.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-invalid-ref.yaml
@@ -1,4 +1,4 @@
-﻿ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha3"
 info:
   display: "Aggregate Invalid Ref Test"
   description: "Test capability with an unknown aggregate ref"

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-invalid-ref.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-invalid-ref.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+﻿ikanos: "1.0.0-alpha3"
 info:
   display: "Aggregate Invalid Ref Test"
   description: "Test capability with an unknown aggregate ref"
@@ -13,7 +13,7 @@ capability:
     "data":
       display: "Data"
       namespace: "data"
-      functions:
+      flows:
         "read-items":
           description: "Read items."
           call: "mock-api.get-items"

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-shared-mock.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-shared-mock.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+﻿ikanos: 1.0.0-alpha3
 info:
   display: Aggregate Shared Mock Test
   description: Shared aggregate mock function consumed by MCP and REST refs
@@ -12,7 +12,7 @@ capability:
     greeting:
       display: Greeting
       namespace: greeting
-      functions:
+      flows:
         hello:
           description: Builds a greeting payload from input parameters.
           inputParameters:

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-shared-mock.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-shared-mock.yaml
@@ -1,4 +1,4 @@
-﻿ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha3
 info:
   display: Aggregate Shared Mock Test
   description: Shared aggregate mock function consumed by MCP and REST refs

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-step-with-namespace.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-step-with-namespace.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+﻿ikanos: 1.0.0-alpha3
 info:
   display: Aggregate Step Namespace Test
   description: Test capability for namespace-qualified references in aggregate function
@@ -13,7 +13,7 @@ capability:
     shipyard:
       display: Shipyard
       namespace: shipyard
-      functions:
+      flows:
         get-voyage-manifest:
           description: Assemble a voyage manifest using an orchestrated step.
           inputParameters:

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-step-with-namespace.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-step-with-namespace.yaml
@@ -1,4 +1,4 @@
-﻿ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha3
 info:
   display: Aggregate Step Namespace Test
   description: Test capability for namespace-qualified references in aggregate function

--- a/ikanos-engine/src/test/resources/tutorial/step-10-shipyard-rest-adapter.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-10-shipyard-rest-adapter.yml
@@ -1,4 +1,4 @@
-﻿ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha3"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-10-shipyard-rest-adapter.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-10-shipyard-rest-adapter.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+﻿ikanos: "1.0.0-alpha3"
 
 binds:
 - namespace: "registry-env"
@@ -25,7 +25,7 @@ capability:
     crew-resolver:
       display: "Crew Resolver"
       namespace: crew-resolver
-      functions:
+      flows:
         resolve-crew-for-ship:
           description: "Resolve crew member names and roles for a given ship"
           semantics:

--- a/ikanos-engine/src/test/resources/tutorial/step-9-shipyard-aggregates.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-9-shipyard-aggregates.yml
@@ -1,4 +1,4 @@
-﻿ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha3"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-9-shipyard-aggregates.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-9-shipyard-aggregates.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+﻿ikanos: "1.0.0-alpha3"
 
 binds:
 - namespace: "registry-env"
@@ -25,7 +25,7 @@ capability:
     crew-resolver:
       display: "Crew Resolver"
       namespace: crew-resolver
-      functions:
+      flows:
         resolve-crew-for-ship:
           description: "Resolve crew member names and roles for a given ship"
           semantics:

--- a/ikanos-spec/src/main/java/io/ikanos/spec/aggregates/AggregateFlowMapDeserializer.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/aggregates/AggregateFlowMapDeserializer.java
@@ -16,13 +16,13 @@ package io.ikanos.spec.aggregates;
 import io.ikanos.spec.util.NamedMapDeserializer;
 
 /**
- * Jackson deserializer for {@code Aggregate.functions} named-object map.
- * Reads {@code { "fn-name": { ... }, ... }} and injects the key as
- * {@link AggregateFunctionSpec#setName(String)}.
+ * Jackson deserializer for {@code Aggregate.flows} named-object map.
+ * Reads {@code { "flow-name": { ... }, ... }} and injects the key as
+ * {@link AggregateFlowSpec#setName(String)}.
  */
-public class AggregateFunctionMapDeserializer extends NamedMapDeserializer<AggregateFunctionSpec> {
+public class AggregateFlowMapDeserializer extends NamedMapDeserializer<AggregateFlowSpec> {
 
-    public AggregateFunctionMapDeserializer() {
-        super(AggregateFunctionSpec.class, AggregateFunctionSpec::setName);
+    public AggregateFlowMapDeserializer() {
+        super(AggregateFlowSpec.class, AggregateFlowSpec::setName);
     }
 }

--- a/ikanos-spec/src/main/java/io/ikanos/spec/aggregates/AggregateFlowSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/aggregates/AggregateFlowSpec.java
@@ -31,10 +31,10 @@ import io.ikanos.spec.util.OperationStepSpec;
 import io.ikanos.spec.util.StepOutputMappingSpec;
 
 /**
- * Aggregate Function Specification Element.
+ * Aggregate Flow Specification Element.
  * 
- * <p>A reusable invocable unit within an aggregate. Adapter units reference it via
- * {@code ref: aggregate-namespace.function-name}.</p>
+ * <p>A reusable callable flow within an aggregate. Adapter units reference it via
+ * {@code ref: aggregate-namespace.flow-name}.</p>
  *
  * <h2>Thread safety</h2>
  * Each scalar field is held in an {@link AtomicReference}; the {@code with} parameter map is
@@ -43,7 +43,7 @@ import io.ikanos.spec.util.StepOutputMappingSpec;
  * is a synchronized {@link LinkedHashMap} in an {@link AtomicReference}. This satisfies
  * SonarQube rule {@code java:S3077}.
  */
-public class AggregateFunctionSpec {
+public class AggregateFlowSpec {
 
     private final AtomicReference<String> name = new AtomicReference<>();
     private final AtomicReference<String> description = new AtomicReference<>();
@@ -68,7 +68,7 @@ public class AggregateFunctionSpec {
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private final CopyOnWriteArrayList<OutputParameterSpec> outputParameters = new CopyOnWriteArrayList<>();
 
-    public AggregateFunctionSpec() {}
+    public AggregateFlowSpec() {}
 
     public String getName() { return name.get(); }
     public void setName(String name) { this.name.set(name); }

--- a/ikanos-spec/src/main/java/io/ikanos/spec/aggregates/AggregateSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/aggregates/AggregateSpec.java
@@ -23,12 +23,12 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 /**
  * Aggregate Specification Element.
  *
- * <p>A domain aggregate grouping reusable functions. Adapters reference these functions via ref.</p>
+ * <p>A domain aggregate grouping reusable flows. Adapters reference these flows via ref.</p>
  *
  * <h2>Thread safety</h2>
  * Each scalar field is held in an {@link AtomicReference} so that fluent builders and
  * Control-port runtime edits can replace values atomically while engine threads read them.
- * The {@code functions} map is stored as a synchronized {@link LinkedHashMap} to preserve
+ * The {@code flows} map is stored as a synchronized {@link LinkedHashMap} to preserve
  * YAML insertion order (critical for step orchestration semantics). This satisfies SonarQube
  * rule {@code java:S3077}.
  */
@@ -37,8 +37,8 @@ public class AggregateSpec {
     private final AtomicReference<String> display = new AtomicReference<>();
     private final AtomicReference<String> namespace = new AtomicReference<>();
 
-    @JsonDeserialize(using = AggregateFunctionMapDeserializer.class)
-    private final Map<String, AggregateFunctionSpec> functions =
+    @JsonDeserialize(using = AggregateFlowMapDeserializer.class)
+    private final Map<String, AggregateFlowSpec> flows =
             Collections.synchronizedMap(new LinkedHashMap<>());
 
     public String getDisplay() {
@@ -57,15 +57,15 @@ public class AggregateSpec {
         this.namespace.set(namespace);
     }
 
-    public Map<String, AggregateFunctionSpec> getFunctions() {
-        return functions;
+    public Map<String, AggregateFlowSpec> getFlows() {
+        return flows;
     }
 
-    public void setFunctions(Map<String, AggregateFunctionSpec> functions) {
-        if (functions == null) return;
-        synchronized (this.functions) {
-            this.functions.clear();
-            this.functions.putAll(functions);
+    public void setFlows(Map<String, AggregateFlowSpec> flows) {
+        if (flows == null) return;
+        synchronized (this.flows) {
+            this.flows.clear();
+            this.flows.putAll(flows);
         }
     }
 }

--- a/ikanos-spec/src/main/resources/rules/ikanos-rules.yml
+++ b/ikanos-spec/src/main/resources/rules/ikanos-rules.yml
@@ -116,24 +116,24 @@ rules:
       functionOptions:
         notMatch: "example\\.com$"
 
-  ikanos-aggregate-function-description:
-    message: "Each aggregate function should have a `description` field."
+  ikanos-aggregate-flow-description:
+    message: "Each aggregate flow should have a `description` field."
     description: >
-      Function descriptions are inherited by adapter units and improve agent
+      Flow descriptions are inherited by adapter units and improve agent
       discoverability.
     severity: warn
     recommended: true
-    given: "$.capability.aggregates[*].functions[*]"
+    given: "$.capability.aggregates[*].flows[*]"
     then:
       field: "description"
       function: truthy
 
   ikanos-aggregate-semantics-consistency:
-    message: "Aggregate function semantics must be consistent with MCP tool hints and REST operation methods."
+    message: "Aggregate flow semantics must be consistent with MCP tool hints and REST operation methods."
     description: >
-      When an MCP tool or REST operation references an aggregate function via `ref`,
-      any explicit hints or HTTP methods should not contradict the function's declared
-      semantics. For example, a safe function should not have destructive=true hints
+      When an MCP tool or REST operation references an aggregate flow via `ref`,
+      any explicit hints or HTTP methods should not contradict the flow's declared
+      semantics. For example, a safe flow should not have destructive=true hints
       or use a POST/DELETE method.
     severity: warn
     recommended: true

--- a/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
+++ b/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ikanos.io/schemas/v1.0.0-alpha3/ikanos.json",
   "name": "Ikanos Specification",

--- a/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
+++ b/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ikanos.io/schemas/v1.0.0-alpha3/ikanos.json",
   "name": "Ikanos Specification",
@@ -762,27 +762,27 @@
           "$ref": "#/$defs/IdentifierKebab",
           "description": "Machine-readable qualifier for this aggregate. Used as the first segment in ref values. Must match the map key."
         },
-        "functions": {
+        "flows": {
           "type": "object",
           "propertyNames": {
             "$ref": "#/$defs/IdentifierKebab"
           },
           "additionalProperties": {
-            "$ref": "#/$defs/AggregateFunction"
+            "$ref": "#/$defs/AggregateFlow"
           },
-          "description": "Reusable invocable units within this aggregate, keyed by function name.",
+          "description": "Reusable callable flows within this aggregate, keyed by flow name.",
           "minProperties": 1
         }
       },
       "required": [
         "display",
-        "functions"
+        "flows"
       ],
       "additionalProperties": false
     },
-    "AggregateFunction": {
+    "AggregateFlow": {
       "type": "object",
-      "description": "A reusable invocable unit within an aggregate. Adapter units reference it via ref: aggregate-namespace.function-name.",
+      "description": "A reusable callable flow within an aggregate. Adapter units reference it via ref: aggregate-namespace.flow-name.",
       "properties": {
         "description": {
           "type": "string",
@@ -1085,7 +1085,7 @@
         },
         "ref": {
           "type": "string",
-          "description": "Reference to an aggregate function. Format: {aggregate-namespace}.{function-name}. Inherited fields are merged; explicit fields override.",
+          "description": "Reference to an aggregate flow. Format: {aggregate-namespace}.{flow-name}. Inherited fields are merged; explicit fields override.",
           "pattern": "^[a-zA-Z0-9-]+\\.[a-zA-Z0-9-]+$"
         },
         "call": {
@@ -1576,7 +1576,7 @@
         },
         "ref": {
           "type": "string",
-          "description": "Reference to an aggregate function. Format: {aggregate-namespace}.{function-name}. Inherited fields are merged; explicit fields override.",
+          "description": "Reference to an aggregate flow. Format: {aggregate-namespace}.{flow-name}. Inherited fields are merged; explicit fields override.",
           "pattern": "^[a-zA-Z0-9-]+\\.[a-zA-Z0-9-]+$"
         },
         "call": {

--- a/ikanos-spec/src/test/java/io/ikanos/spec/SpecFieldThreadSafetyTest.java
+++ b/ikanos-spec/src/test/java/io/ikanos/spec/SpecFieldThreadSafetyTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import io.ikanos.spec.aggregates.AggregateFunctionSpec;
+import io.ikanos.spec.aggregates.AggregateFlowSpec;
 import io.ikanos.spec.aggregates.AggregateSpec;
 import io.ikanos.spec.consumes.http.HttpClientOperationSpec;
 import io.ikanos.spec.consumes.http.HttpClientResourceSpec;
@@ -78,7 +78,7 @@ class SpecFieldThreadSafetyTest {
         return Stream.of(
                 IkanosSpec.class,
                 OperationSpec.class,
-                AggregateFunctionSpec.class,
+                AggregateFlowSpec.class,
                 AggregateSpec.class,
                 HttpClientSpec.class,
                 HttpClientResourceSpec.class,
@@ -138,3 +138,4 @@ class SpecFieldThreadSafetyTest {
                 () -> "Default constructor of " + specClass.getSimpleName() + " did not return an instance");
     }
 }
+

--- a/ikanos-spec/src/test/java/io/ikanos/spec/aggregates/AggregateFlowDeserializationTest.java
+++ b/ikanos-spec/src/test/java/io/ikanos/spec/aggregates/AggregateFlowDeserializationTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.spec.aggregates;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.ikanos.spec.IkanosSpec;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Non-regression tests for the {@code flows:} rename (#463).
+ *
+ * <p>Verifies that a YAML capability document using {@code aggregates.<ns>.flows:} is correctly
+ * deserialized into {@link AggregateFlowSpec} objects, and that the injected key becomes the
+ * flow name.
+ */
+class AggregateFlowDeserializationTest {
+
+    private static final ObjectMapper MAPPER =
+            new ObjectMapper(new YAMLFactory()).findAndRegisterModules();
+
+    private static final String CAPABILITY_WITH_FLOWS = """
+            ikanos: "1.0.0-alpha3"
+            capability:
+              exposes: []
+              consumes: []
+              aggregates:
+                forecast:
+                  display: "Forecast"
+                  flows:
+                    get-forecast:
+                      description: "Retrieve forecast for a location"
+                      call: weather-api.get-forecast
+                    list-forecasts:
+                      description: "List recent forecasts"
+                      call: weather-api.list-forecasts
+            """;
+
+    @Test
+    void flowsKeyShouldDeserializeIntoAggregateFlowSpecMap() throws Exception {
+        IkanosSpec spec = MAPPER.readValue(CAPABILITY_WITH_FLOWS, IkanosSpec.class);
+
+        AggregateSpec aggregate = spec.getCapability().getAggregates().get("forecast");
+        assertNotNull(aggregate, "aggregate 'forecast' should be present");
+        assertNotNull(aggregate.getFlows(), "flows map should not be null");
+        assertEquals(2, aggregate.getFlows().size(), "should have 2 flows");
+    }
+
+    @Test
+    void flowKeysShouldBeInjectedAsFlowNames() throws Exception {
+        IkanosSpec spec = MAPPER.readValue(CAPABILITY_WITH_FLOWS, IkanosSpec.class);
+
+        AggregateSpec aggregate = spec.getCapability().getAggregates().get("forecast");
+        AggregateFlowSpec getForecast = aggregate.getFlows().get("get-forecast");
+        AggregateFlowSpec listForecasts = aggregate.getFlows().get("list-forecasts");
+
+        assertNotNull(getForecast, "flow 'get-forecast' should be present");
+        assertEquals("get-forecast", getForecast.getName(),
+                "YAML map key must be injected as the flow name");
+
+        assertNotNull(listForecasts, "flow 'list-forecasts' should be present");
+        assertEquals("list-forecasts", listForecasts.getName(),
+                "YAML map key must be injected as the flow name");
+    }
+
+    @Test
+    void flowDescriptionShouldBeDeserializedCorrectly() throws Exception {
+        IkanosSpec spec = MAPPER.readValue(CAPABILITY_WITH_FLOWS, IkanosSpec.class);
+
+        AggregateFlowSpec getForecast =
+                spec.getCapability().getAggregates().get("forecast").getFlows().get("get-forecast");
+
+        assertEquals("Retrieve forecast for a location", getForecast.getDescription());
+    }
+}

--- a/ikanos-spec/src/test/java/io/ikanos/spec/aggregates/AggregateFlowSpecTest.java
+++ b/ikanos-spec/src/test/java/io/ikanos/spec/aggregates/AggregateFlowSpecTest.java
@@ -1,11 +1,11 @@
 /**
  * Copyright 2025-2026 Naftiko
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -26,13 +26,13 @@ import io.ikanos.spec.exposes.ServerCallSpec;
 import io.ikanos.spec.util.OperationStepCallSpec;
 import io.ikanos.spec.util.StepOutputMappingSpec;
 
-class AggregateFunctionSpecTest {
+class AggregateFlowSpecTest {
 
-    private AggregateFunctionSpec spec;
+    private AggregateFlowSpec spec;
 
     @BeforeEach
     void setUp() {
-        spec = new AggregateFunctionSpec();
+        spec = new AggregateFlowSpec();
     }
 
     // ── Name ──

--- a/ikanos-spec/src/test/resources/rules/spectral-semantics-consistent.yaml
+++ b/ikanos-spec/src/test/resources/rules/spectral-semantics-consistent.yaml
@@ -1,10 +1,10 @@
-ikanos: 1.0.0-alpha3
+﻿ikanos: 1.0.0-alpha3
 capability:
   aggregates:
     weather:
       display: Weather Service
       namespace: weather
-      functions:
+      flows:
         get-forecast:
           description: Get weather forecast (safe, read-only)
           semantics:

--- a/ikanos-spec/src/test/resources/rules/spectral-semantics-consistent.yaml
+++ b/ikanos-spec/src/test/resources/rules/spectral-semantics-consistent.yaml
@@ -1,4 +1,4 @@
-﻿ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha3
 capability:
   aggregates:
     weather:

--- a/ikanos-spec/src/test/resources/rules/spectral-semantics-inconsistent.yaml
+++ b/ikanos-spec/src/test/resources/rules/spectral-semantics-inconsistent.yaml
@@ -1,10 +1,10 @@
-ikanos: 1.0.0-alpha3
+﻿ikanos: 1.0.0-alpha3
 capability:
   aggregates:
     weather:
       display: Weather Service
       namespace: weather
-      functions:
+      flows:
         get-forecast:
           description: Get weather forecast (safe, read-only)
           semantics:

--- a/ikanos-spec/src/test/resources/rules/spectral-semantics-inconsistent.yaml
+++ b/ikanos-spec/src/test/resources/rules/spectral-semantics-inconsistent.yaml
@@ -1,4 +1,4 @@
-﻿ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha3
 capability:
   aggregates:
     weather:

--- a/scripts/migrate_aggregate_flows.py
+++ b/scripts/migrate_aggregate_flows.py
@@ -14,6 +14,17 @@ This script targets the breaking rename introduced in story #463:
 
 It uses a regex-based approach rather than a full YAML parser so that
 comments and formatting are preserved verbatim.
+
+WARNING — Known false positive: Spectral configuration files (`.spectral.yaml`,
+`.spectral.yml`) use `functions:` as a built-in keyword to register custom
+JavaScript validation plugins. This pattern is NOT related to Ikanos aggregates
+and must NOT be migrated. Exclude Spectral configuration files when running this
+script, or review each match manually before accepting it. Example Spectral usage
+that must be preserved:
+
+    # .spectral.yaml
+    functions:
+      - check-binds-location-scheme
 """
 
 import re

--- a/scripts/migrate_aggregate_flows.py
+++ b/scripts/migrate_aggregate_flows.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+Migrate Ikanos capability YAML files from alpha3 `functions:` to `flows:`.
+
+Usage:
+    python scripts/migrate_aggregate_flows.py <path> [<path> ...]
+
+Where <path> is a file or a directory. Directories are searched recursively
+for *.yml and *.yaml files. The script is idempotent: files that already use
+`flows:` are left unchanged.
+
+This script targets the breaking rename introduced in story #463:
+    aggregates.<ns>.functions: → aggregates.<ns>.flows:
+
+It uses a regex-based approach rather than a full YAML parser so that
+comments and formatting are preserved verbatim.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+# Pattern: 'functions:' at any indentation level inside an 'aggregates' block.
+# We use a simple heuristic: replace every line that matches /^(\s+)functions:/
+# with the same indentation but 'flows:'.  This is intentionally conservative —
+# it only replaces lines where 'functions:' is the sole mapping key on that line,
+# which is the only valid form in an Ikanos capability document.
+PATTERN = re.compile(r'^(\s+)functions:', re.MULTILINE)
+REPLACEMENT = r'\1flows:'
+
+
+def migrate_file(path: Path) -> bool:
+    """Return True if the file was modified."""
+    original = path.read_text(encoding='utf-8')
+    updated = PATTERN.sub(REPLACEMENT, original)
+    if updated != original:
+        path.write_text(updated, encoding='utf-8')
+        return True
+    return False
+
+
+def migrate(paths: list[str]) -> None:
+    total = 0
+    modified = 0
+    for raw in paths:
+        p = Path(raw)
+        if p.is_dir():
+            candidates = list(p.rglob('*.yml')) + list(p.rglob('*.yaml'))
+        elif p.is_file():
+            candidates = [p]
+        else:
+            print(f'Warning: {raw} does not exist, skipping.', file=sys.stderr)
+            continue
+
+        for candidate in candidates:
+            total += 1
+            if migrate_file(candidate):
+                modified += 1
+                print(f'  migrated: {candidate}')
+
+    print(f'\nDone — {modified}/{total} file(s) updated.')
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print(f'Usage: {sys.argv[0]} <path> [<path> ...]', file=sys.stderr)
+        sys.exit(1)
+    migrate(sys.argv[1:])


### PR DESCRIPTION
## Related Issue

Closes #463

---

## What does this PR do?

Renames `aggregates.<ns>.functions:` → `aggregates.<ns>.flows:` across the entire codebase (schema, engine, spec, tests, docs, rules, SKILL.md, AGENTS.md).

**Why:** The `functions` name is ambiguous and blocks future extensibility. The new `flows:` container-per-type design (Option 1 from the #463 design exploration) reserves space for sibling sections (`harnesses:`, `retrievers:`, `tools:`, `skills:`) without introducing a polymorphic `type` discriminator — which would have been non-conformant to the JSON Structure convention used throughout the spec.

**Scope:**
- `ikanos-schema.json`: `AggregateFunction*` → `AggregateFlow*`, `functions:` → `flows:`, `$defs/AggregateFunction` → `$defs/AggregateFlow`
- Java spec: `AggregateFunctionSpec` → `AggregateFlowSpec`, `AggregateFunctionMapDeserializer` → `AggregateFlowMapDeserializer`, `AggregateSpec.getFlows()` / `setFlows()`
- Java engine: `AggregateFunction` → `AggregateFlow`, `FunctionResult` → `FlowResult`, `findFunction` → `findFlow`, `lookupFunction` → `lookupFlow`, `startAggregateFunctionSpan` → `startAggregateFlowSpan`
- YAML fixtures (test + tutorial): `functions:` → `flows:`
- Polychro ruleset: `ikanos-aggregate-function-description` rule renamed to `ikanos-aggregate-flow-description`, JSONPath updated
- Wiki, SKILL.md, AGENTS.md: terminology updated throughout
- Migration script: `scripts/migrate_aggregate_flows.py` (idempotent, preserves formatting)

**Breaking change:** Hard break on alpha3 (pre-GA). Any user-owned capability document with `aggregates.<ns>.functions:` must be migrated.

**Stacked on:** #496 (`feat/issue-495-display-and-tags`) → #471 (`feat/issue-328-named-object-rescope`)

---

## Tests

- All 6 renamed test classes updated (`AggregateFlowTest`, `AggregateFlowSpecTest`, `AggregateRefResolverTest`, `AggregateStepNamespaceIntegrationTest`, `AggregateIntegrationTest`, `TelemetryBootstrapTest`, ...)
- New non-regression test: `AggregateFlowDeserializationTest` — verifies that a YAML document using `flows:` deserializes correctly into `AggregateFlowSpec` objects and that the map key is injected as the flow name (3 focused tests)
- `mvn clean test` green: 493 tests, 0 failures, 0 errors (5 pre-existing skips)

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main` (stacked on #496 which is stacked on #471)
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Claude Sonnet 4.6
tool: VS Code Copilot Chat
confidence: high
source_event: issue #463
discovery_method: code_review
review_focus: AggregateFlowSpec.java, AggregateFlowMapDeserializer.java, AggregateSpec.java, AggregateFlow.java, ikanos-schema.json
```
