### PR TITLE
fix: bearer auth always returns 401 when token is resolved from file-based binding

### DIFF
--- a/ikanos-engine/src/main/java/io/ikanos/engine/exposes/ServerAdapter.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/exposes/ServerAdapter.java
@@ -140,7 +140,8 @@ public abstract class ServerAdapter extends Adapter {
         }
 
         Set<String> allowedVariables = extractAllowedVariables(getCapability().getSpec());
-        return new ServerAuthenticationRestlet(authentication, next, allowedVariables);
+        return new ServerAuthenticationRestlet(authentication, next, allowedVariables,
+                getCapability().getBindings());
     }
 
     /**
@@ -157,6 +158,7 @@ public abstract class ServerAdapter extends Adapter {
                 : ChallengeScheme.HTTP_BASIC;
 
         Set<String> allowedVariables = extractAllowedVariables(getCapability().getSpec());
+        Map<String, Object> bindings = getCapability().getBindings();
         ChallengeAuthenticator authenticator =
                 new ChallengeAuthenticator(next.getContext(), false, scheme, "ikanos");
         authenticator.setVerifier(new SecretVerifier() {
@@ -167,11 +169,11 @@ public abstract class ServerAdapter extends Adapter {
                 char[] expectedPassword = null;
 
                 if (authentication instanceof BasicAuthenticationSpec basic) {
-                    expectedUsername = resolveTemplate(basic.getUsername(), allowedVariables);
-                    expectedPassword = resolveTemplateChars(basic.getPassword(), allowedVariables);
+                    expectedUsername = resolveTemplate(basic.getUsername(), allowedVariables, bindings);
+                    expectedPassword = resolveTemplateChars(basic.getPassword(), allowedVariables, bindings);
                 } else if (authentication instanceof DigestAuthenticationSpec digest) {
-                    expectedUsername = resolveTemplate(digest.getUsername(), allowedVariables);
-                    expectedPassword = resolveTemplateChars(digest.getPassword(), allowedVariables);
+                    expectedUsername = resolveTemplate(digest.getUsername(), allowedVariables, bindings);
+                    expectedPassword = resolveTemplateChars(digest.getPassword(), allowedVariables, bindings);
                 }
 
                 if (expectedUsername == null || expectedPassword == null || identifier == null
@@ -190,13 +192,22 @@ public abstract class ServerAdapter extends Adapter {
         return authenticator;
     }
 
-    private static String resolveTemplate(String value, Set<String> allowedVariables) {
+    private static String resolveTemplate(String value, Set<String> allowedVariables,
+            Map<String, Object> bindings) {
         if (value == null) {
             return null;
         }
         Map<String, Object> env = new HashMap<>();
         if (value.contains("{{") && value.contains("}}")) {
             for (String varName : allowedVariables) {
+                // Prefer resolved bindings (file-based or injected) over env vars
+                if (bindings != null && bindings.containsKey(varName)) {
+                    Object bindingValue = bindings.get(varName);
+                    if (bindingValue != null) {
+                        env.put(varName, bindingValue);
+                        continue;
+                    }
+                }
                 String varValue = System.getenv(varName);
                 if (varValue != null) {
                     env.put(varName, varValue);
@@ -206,11 +217,12 @@ public abstract class ServerAdapter extends Adapter {
         return Resolver.resolveMustacheTemplate(value, env);
     }
 
-    private static char[] resolveTemplateChars(char[] value, Set<String> allowedVariables) {
+    private static char[] resolveTemplateChars(char[] value, Set<String> allowedVariables,
+            Map<String, Object> bindings) {
         if (value == null) {
             return null;
         }
-        String resolved = resolveTemplate(new String(value), allowedVariables);
+        String resolved = resolveTemplate(new String(value), allowedVariables, bindings);
         return resolved == null ? null : resolved.toCharArray();
     }
 

--- a/ikanos-engine/src/main/java/io/ikanos/engine/exposes/ServerAuthenticationRestlet.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/exposes/ServerAuthenticationRestlet.java
@@ -41,16 +41,23 @@ public class ServerAuthenticationRestlet extends Restlet {
     private final AuthenticationSpec authentication;
     private final Restlet next;
     private final Set<String> allowedVariables;
+    private final Map<String, Object> bindings;
 
     public ServerAuthenticationRestlet(AuthenticationSpec authentication, Restlet next) {
-        this(authentication, next, null);
+        this(authentication, next, null, null);
     }
 
     public ServerAuthenticationRestlet(AuthenticationSpec authentication, Restlet next,
             Set<String> allowedVariables) {
+        this(authentication, next, allowedVariables, null);
+    }
+
+    public ServerAuthenticationRestlet(AuthenticationSpec authentication, Restlet next,
+            Set<String> allowedVariables, Map<String, Object> bindings) {
         this.authentication = authentication;
         this.next = next;
         this.allowedVariables = allowedVariables != null ? allowedVariables : Set.of();
+        this.bindings = bindings != null ? bindings : Map.of();
     }
 
     @Override
@@ -153,12 +160,21 @@ public class ServerAuthenticationRestlet extends Restlet {
 
         while (matcher.find()) {
             String variableName = matcher.group(1);
-            
+
             // Only resolve variables that are explicitly declared in binds
             if (!allowedVariables.isEmpty() && !allowedVariables.contains(variableName)) {
                 continue;
             }
-            
+
+            // Prefer resolved bindings (file-based or injected) over env vars
+            if (bindings.containsKey(variableName)) {
+                Object bindingValue = bindings.get(variableName);
+                if (bindingValue != null) {
+                    variables.put(variableName, bindingValue);
+                    continue;
+                }
+            }
+
             String envValue = System.getenv(variableName);
 
             if (envValue != null) {

--- a/ikanos-engine/src/test/java/io/ikanos/engine/exposes/ServerAuthenticationRestletTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/exposes/ServerAuthenticationRestletTest.java
@@ -15,6 +15,7 @@ package io.ikanos.engine.exposes;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.Set;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.restlet.Request;
 import org.restlet.Response;
@@ -260,5 +261,114 @@ public class ServerAuthenticationRestletTest {
         secured.handle(request, response);
 
         assertEquals(Status.SUCCESS_OK, response.getStatus());
+    }
+
+    @Test
+    public void bearerShouldResolveTokenFromBindingsMap() {
+        BearerAuthenticationSpec auth = new BearerAuthenticationSpec();
+        auth.setToken("{{MCP_SERVER_TOKEN}}");
+
+        Restlet next = new Restlet() {
+            @Override
+            public void handle(Request request, Response response) {
+                response.setStatus(Status.SUCCESS_OK);
+                response.setEntity("ok", MediaType.TEXT_PLAIN);
+            }
+        };
+
+        // Simulate file-based binding resolution: bindings map has the resolved value
+        Map<String, Object> bindings = Map.of("MCP_SERVER_TOKEN", "sk-mcp-YYYYYYYYYYYY");
+        ServerAuthenticationRestlet secured = new ServerAuthenticationRestlet(
+                auth, next, Set.of("MCP_SERVER_TOKEN"), bindings);
+
+        Request request = new Request(Method.GET, "http://localhost/test");
+        request.getHeaders().set("Authorization", "Bearer sk-mcp-YYYYYYYYYYYY");
+        Response response = new Response(request);
+
+        secured.handle(request, response);
+
+        assertEquals(Status.SUCCESS_OK, response.getStatus(),
+                "Bearer token from bindings map should be accepted");
+    }
+
+    @Test
+    public void bearerShouldRejectWrongTokenWhenUsingBindingsMap() {
+        BearerAuthenticationSpec auth = new BearerAuthenticationSpec();
+        auth.setToken("{{MCP_SERVER_TOKEN}}");
+
+        Restlet next = new Restlet() {
+            @Override
+            public void handle(Request request, Response response) {
+                response.setStatus(Status.SUCCESS_OK);
+            }
+        };
+
+        Map<String, Object> bindings = Map.of("MCP_SERVER_TOKEN", "sk-mcp-YYYYYYYYYYYY");
+        ServerAuthenticationRestlet secured = new ServerAuthenticationRestlet(
+                auth, next, Set.of("MCP_SERVER_TOKEN"), bindings);
+
+        Request request = new Request(Method.GET, "http://localhost/test");
+        request.getHeaders().set("Authorization", "Bearer wrong-token");
+        Response response = new Response(request);
+
+        secured.handle(request, response);
+
+        assertEquals(Status.CLIENT_ERROR_UNAUTHORIZED, response.getStatus(),
+                "Wrong token should be rejected even when using bindings map");
+    }
+
+    @Test
+    public void bearerBindingsShouldTakePriorityOverUndeclaredEnvVar() {
+        BearerAuthenticationSpec auth = new BearerAuthenticationSpec();
+        auth.setToken("{{MY_TOKEN}}");
+
+        Restlet next = new Restlet() {
+            @Override
+            public void handle(Request request, Response response) {
+                response.setStatus(Status.SUCCESS_OK);
+            }
+        };
+
+        // Bindings have one value; env might have a different one
+        Map<String, Object> bindings = Map.of("MY_TOKEN", "token-from-bindings");
+        ServerAuthenticationRestlet secured = new ServerAuthenticationRestlet(
+                auth, next, Set.of("MY_TOKEN"), bindings);
+
+        Request request = new Request(Method.GET, "http://localhost/test");
+        request.getHeaders().set("Authorization", "Bearer token-from-bindings");
+        Response response = new Response(request);
+
+        secured.handle(request, response);
+
+        assertEquals(Status.SUCCESS_OK, response.getStatus(),
+                "Bindings-resolved token should authorize correctly");
+    }
+
+    @Test
+    public void apiKeyShouldResolveValueFromBindingsMap() {
+        ApiKeyAuthenticationSpec auth = new ApiKeyAuthenticationSpec();
+        auth.setKey("X-API-Key");
+        auth.setValue("{{API_KEY_VAR}}");
+        auth.setPlacement("header");
+
+        Restlet next = new Restlet() {
+            @Override
+            public void handle(Request request, Response response) {
+                response.setStatus(Status.SUCCESS_OK);
+            }
+        };
+
+        Map<String, Object> bindings = Map.of("API_KEY_VAR", "secret-api-key-from-file");
+        ServerAuthenticationRestlet secured = new ServerAuthenticationRestlet(
+                auth, next, Set.of("API_KEY_VAR"), bindings);
+
+        Request request = new Request(Method.GET, "http://localhost/test");
+        request.getHeaders().set("X-API-Key", "secret-api-key-from-file");
+        Response response = new Response(request);
+
+        secured.handle(request, response);
+
+        assertEquals(Status.SUCCESS_OK, response.getStatus(),
+                "API key from bindings map should be accepted");
     }
 }

--- a/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/McpAuthenticationIntegrationTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/McpAuthenticationIntegrationTest.java
@@ -21,6 +21,8 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -210,6 +212,51 @@ class McpAuthenticationIntegrationTest {
         }
     }
 
+    @Test
+    void bearerAuthFromFileBindingsShouldAcceptTokenFromSecretsFile() throws Exception {
+        // Write a temporary secrets file simulating file:///./shared/secrets.yaml
+        Path secretsFile = Files.createTempFile("ikanos-secrets-", ".yaml");
+        Files.writeString(secretsFile, "mcp-server-token: \"sk-mcp-from-file\"\n");
+        try {
+            McpServerAdapter adapter = startBearerProtectedServerWithBinding(
+                    secretsFile.toUri().toString());
+            HttpClient client = HttpClient.newHttpClient();
+            String baseUrl = baseUrlFor(adapter);
+
+            try {
+                // Correct token from the file should be accepted
+                HttpResponse<String> response = client.send(
+                        HttpRequest.newBuilder(URI.create(baseUrl))
+                                .POST(HttpRequest.BodyPublishers.ofString(
+                                        "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}"))
+                                .header("Content-Type", "application/json")
+                                .header("Authorization", "Bearer sk-mcp-from-file")
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
+
+                assertEquals(200, response.statusCode(),
+                        "Token resolved from file binding should be accepted");
+
+                // Wrong token should still be rejected
+                HttpResponse<String> rejectedResponse = client.send(
+                        HttpRequest.newBuilder(URI.create(baseUrl))
+                                .POST(HttpRequest.BodyPublishers.ofString(
+                                        "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}"))
+                                .header("Content-Type", "application/json")
+                                .header("Authorization", "Bearer wrong-token")
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
+
+                assertEquals(401, rejectedResponse.statusCode(),
+                        "Wrong token should still be rejected when using file binding");
+            } finally {
+                adapter.stop();
+            }
+        } finally {
+            Files.deleteIfExists(secretsFile);
+        }
+    }
+
     private McpServerAdapter startBearerProtectedServer() throws Exception {
         String schemaVersion = VersionHelper.getSchemaVersion();
         String yaml = """
@@ -313,5 +360,41 @@ class McpAuthenticationIntegrationTest {
         try (ServerSocket socket = new ServerSocket(0)) {
             return socket.getLocalPort();
         }
+    }
+
+    private McpServerAdapter startBearerProtectedServerWithBinding(String secretsFileUri)
+            throws Exception {
+        String schemaVersion = VersionHelper.getSchemaVersion();
+        String yaml = """
+                ikanos: "%s"
+                info:
+                  label: "MCP Auth Binding Test"
+                  description: "Bearer auth from file bindings integration test"
+                binds:
+                  - namespace: "mcp-secrets"
+                    description: "MCP server credentials"
+                    location: "%s"
+                    keys:
+                      MCP_SERVER_TOKEN: "mcp-server-token"
+                capability:
+                  exposes:
+                    - type: "mcp"
+                      address: "127.0.0.1"
+                      port: %d
+                      namespace: "auth-test-mcp"
+                      description: "Test MCP server with bearer auth from bindings"
+                      authentication:
+                        type: "bearer"
+                        token: "{{MCP_SERVER_TOKEN}}"
+                      tools:
+                        - name: "test-tool"
+                          description: "A test tool"
+                          outputParameters:
+                            - type: "string"
+                              value: "ok"
+                  consumes: []
+                """.formatted(schemaVersion, secretsFileUri, findFreePort());
+
+        return startAdapter(yaml);
     }
 }

--- a/ikanos-engine/src/test/java/io/ikanos/tutorial/AbstractShipyardMcpClientIntegrationTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/tutorial/AbstractShipyardMcpClientIntegrationTest.java
@@ -117,6 +117,23 @@ abstract class AbstractShipyardMcpClientIntegrationTest {
         serverUrl = "http://localhost:" + port + "/";
     }
 
+    /**
+     * Like {@link #startServerFromSpec(IkanosSpec)} but keeps MCP authentication enabled.
+     * Use this when the test explicitly exercises the authentication pipeline.
+     */
+    protected void startServerFromSpecWithAuth(IkanosSpec spec) throws Exception {
+        int port = findFreePort();
+        ServerSpec exposesSpec = spec.getCapability().getExposes().get(0);
+        exposesSpec.setAddress("localhost");
+        exposesSpec.setPort(port);
+
+        Capability capability = new Capability(spec);
+        adapter = (McpServerAdapter) capability.getServerAdapters().get(0);
+        adapter.start();
+
+        serverUrl = "http://localhost:" + port + "/";
+    }
+
     protected void disableMcpAuthentication(IkanosSpec spec) {
         spec.getCapability().getExposes().stream()
                 .filter(McpServerSpec.class::isInstance)

--- a/ikanos-engine/src/test/java/io/ikanos/tutorial/Step3ShipyardMcpClientIntegrationTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/tutorial/Step3ShipyardMcpClientIntegrationTest.java
@@ -18,7 +18,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.net.URI;
 import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -70,7 +73,6 @@ public class Step3ShipyardMcpClientIntegrationTest
     public void startServer() throws Exception {
         IkanosSpec spec = loadSpec(CAPABILITY_FILE);
         useMcpServerToken(SECRETS_FILE);
-
 
         startServerFromSpec(spec);
     }
@@ -194,6 +196,70 @@ public class Step3ShipyardMcpClientIntegrationTest
         assertTrue(ship.has("status"), "Must have 'status'");
         assertEquals("IMO-9321483", ship.path("imo").asText(),
                 "Returned imo must match the requested IMO number");
+    }
+
+    // ── authentication pipeline — validates fix for issue #482 ───────────────
+
+    /**
+     * Regression test for GitHub issue #482: bearer auth must work when the token is
+     * resolved from a file-based binding ({{MCP_SERVER_TOKEN}} → secrets.yaml).
+     *
+     * <p>Starts the server with authentication ENABLED and verifies that requests
+     * carrying the correct token (loaded from the secrets file) are accepted, while
+     * requests with wrong or missing tokens are rejected with HTTP 401.</p>
+     */
+    @Test
+    public void bearerAuthFromFileBindingShouldAcceptCorrectTokenAndRejectWrong() throws Exception {
+        // Start a fresh server with auth ENABLED (not disabled)
+        if (adapter != null) {
+            adapter.stop();
+        }
+        IkanosSpec spec = loadSpec(CAPABILITY_FILE);
+        useMcpServerToken(SECRETS_FILE);
+        startServerFromSpecWithAuth(spec);
+
+        HttpClient http = HttpClient.newHttpClient();
+        String initBody = """
+                {"jsonrpc":"2.0","id":1,"method":"initialize",
+                 "params":{"protocolVersion":"2025-11-25",
+                           "clientInfo":{"name":"test-client","version":"1.0"},
+                           "capabilities":{}}}
+                """;
+
+        // Correct token from secrets.yaml should be accepted (issue #482 fix)
+        HttpResponse<String> accepted = http.send(
+                HttpRequest.newBuilder(URI.create(serverUrl))
+                        .POST(HttpRequest.BodyPublishers.ofString(initBody.strip()))
+                        .header("Content-Type", "application/json")
+                        .header("Authorization", "Bearer " + mcpServerToken)
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, accepted.statusCode(),
+                "Correct token resolved from file binding must be accepted (issue #482)");
+
+        // Wrong token must be rejected
+        HttpResponse<String> rejected = http.send(
+                HttpRequest.newBuilder(URI.create(serverUrl))
+                        .POST(HttpRequest.BodyPublishers.ofString(initBody.strip()))
+                        .header("Content-Type", "application/json")
+                        .header("Authorization", "Bearer wrong-token")
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(401, rejected.statusCode(),
+                "Wrong token must be rejected");
+
+        // Missing token must be rejected
+        HttpResponse<String> noToken = http.send(
+                HttpRequest.newBuilder(URI.create(serverUrl))
+                        .POST(HttpRequest.BodyPublishers.ofString(initBody.strip()))
+                        .header("Content-Type", "application/json")
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(401, noToken.statusCode(),
+                "Request without token must be rejected");
     }
 
 }


### PR DESCRIPTION
Fixes #482

## Root Cause

`ServerAuthenticationRestlet.resolveSecretTemplate()` called `System.getenv()` exclusively. Tokens expressed as Mustache templates (e.g. `{{MCP_SERVER_TOKEN}}`) could never resolve when the value came from a file-based `binds` entry. The `Capability` constructor already resolved those binds into a `Map<String, Object>` via `BindingResolver`, but that map was never passed down to the authentication layer — making bearer auth always return `null` for the expected token, producing HTTP 401 for every request.

## Changes

**Production code**
- `ServerAuthenticationRestlet`: new 4-arg constructor accepting resolved `bindings`; `resolveSecretTemplate()` checks bindings first, falls back to `System.getenv()`.
- `ServerAdapter.buildServerChain()`: passes `capability.getBindings()` to `ServerAuthenticationRestlet`.
- `ServerAdapter.buildChallengeAuthenticator()` + `resolveTemplate()`: same bindings-first fix for basic/digest auth.

**Tests**
- 4 new unit tests in `ServerAuthenticationRestletTest`
- 1 new integration test in `McpAuthenticationIntegrationTest` (writes temp secrets YAML, wires via binds block)
- Regression test in `Step3ShipyardMcpClientIntegrationTest` that runs with auth ENABLED against the tutorial secrets file
