### PR TITLE
fix: adding missing module for successful build

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -7,6 +7,7 @@ COPY ikanos-spec ./ikanos-spec
 COPY ikanos-engine ./ikanos-engine
 COPY ikanos-cli ./ikanos-cli
 COPY ikanos-docs ./ikanos-docs
+COPY ikanos-coverage ./ikanos-coverage
 # Build the jar
 RUN mvn clean package -DskipTests
 


### PR DESCRIPTION
## Related Issue

no related issue

---

## What does this PR do?

adding missing module  (ikanos-coverage) for successful build of the ikanos image

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

