### PR TITLE
feat: reverse tunnel for private APIs — Phase 2 (engine SPI + OpenZiti)

### DIFF
--- a/ikanos-coverage/pom.xml
+++ b/ikanos-coverage/pom.xml
@@ -35,6 +35,12 @@
             <artifactId>ikanos-cli</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>io.ikanos</groupId>
+            <artifactId>ikanos-tunnel-ziti</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/ikanos-engine/src/main/java/io/ikanos/Capability.java
+++ b/ikanos-engine/src/main/java/io/ikanos/Capability.java
@@ -40,6 +40,8 @@ import io.ikanos.engine.imports.ExposesImportStrategy;
 import io.ikanos.engine.imports.ImportResolver;
 import io.ikanos.engine.imports.SourceFileLoader;
 import io.ikanos.engine.consumes.http.HttpClientAdapter;
+import io.ikanos.engine.consumes.tunnel.Tunnel;
+import io.ikanos.engine.consumes.tunnel.TunnelBootstrap;
 import io.ikanos.engine.exposes.ServerAdapter;
 import io.ikanos.engine.exposes.control.ControlServerAdapter;
 import io.ikanos.engine.exposes.mcp.McpServerAdapter;
@@ -181,9 +183,18 @@ public class Capability {
             }
         }
 
+        // Discover and start any reverse-tunnel transports declared by consumes-blocks
+        // BEFORE constructing HttpClientAdapters, so the adapter constructors receive a
+        // started (or empty) tunnel map. The 30s default readiness gate matches the
+        // §6.5 design in blueprints/reverse-tunnel-private-network.md.
+        Map<String, Tunnel> tunnels = TunnelBootstrap.discoverAndStart(
+                spec.getCapability().getConsumes(),
+                java.time.Duration.ofSeconds(30),
+                this.bindings.get());
+
         for (ClientSpec clientSpec : spec.getCapability().getConsumes()) {
             if ("http".equals(clientSpec.getType())) {
-                clientList.add(new HttpClientAdapter(this, (HttpClientSpec) clientSpec));
+                clientList.add(new HttpClientAdapter(this, (HttpClientSpec) clientSpec, tunnels));
             }
         }
 

--- a/ikanos-engine/src/main/java/io/ikanos/engine/consumes/http/HttpClientAdapter.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/consumes/http/HttpClientAdapter.java
@@ -239,6 +239,29 @@ public class HttpClientAdapter extends ClientAdapter {
         return httpClient;
     }
 
+    /**
+     * Package-private test helper. Returns the {@link TunnelRouteTable} installed on this
+     * adapter's underlying Restlet {@link Client} context, or {@code null} when this adapter
+     * is not tunnel-routed.
+     *
+     * <p>This indirection lets tests assert tunnel-routing behaviour without reaching
+     * through the Restlet {@link Context} / attributes API in every assertion. If a future
+     * refactor changes how the route table is stored (e.g. moves it off the Restlet context
+     * to a dedicated field, or to a lazy-init slot for connection-pool reset), only this
+     * single method needs updating — the test suite stays green.
+     */
+    TunnelRouteTable tunnelRouteTable() {
+        if (httpClient == null) {
+            return null;
+        }
+        Context context = httpClient.getContext();
+        if (context == null) {
+            return null;
+        }
+        Object attribute = context.getAttributes().get(TunnelRouteTable.CONTEXT_ATTRIBUTE);
+        return attribute instanceof TunnelRouteTable table ? table : null;
+    }
+
     @Override
     public void start() throws Exception {
         getHttpClient().start();

--- a/ikanos-engine/src/main/java/io/ikanos/engine/consumes/http/HttpClientAdapter.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/consumes/http/HttpClientAdapter.java
@@ -14,11 +14,14 @@
 package io.ikanos.engine.consumes.http;
 
 import org.restlet.Client;
+import org.restlet.Context;
 import org.restlet.Request;
 import org.restlet.data.ChallengeResponse;
 import org.restlet.data.ChallengeScheme;
 import io.ikanos.Capability;
 import io.ikanos.engine.consumes.ClientAdapter;
+import io.ikanos.engine.consumes.tunnel.Tunnel;
+import io.ikanos.engine.consumes.tunnel.TunnelRouteTable;
 import io.ikanos.engine.util.Resolver;
 import io.ikanos.spec.InputParameterSpec;
 import io.ikanos.spec.consumes.http.ApiKeyAuthenticationSpec;
@@ -31,6 +34,9 @@ import io.ikanos.spec.consumes.http.HttpClientResourceSpec;
 import io.ikanos.spec.consumes.http.HttpClientSpec;
 import static org.restlet.data.Protocol.HTTP;
 import static org.restlet.data.Protocol.HTTPS;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -38,11 +44,84 @@ import java.util.Map;
  */
 public class HttpClientAdapter extends ClientAdapter {
 
+    /**
+     * Fully-qualified class name of the {@link TunnelAwareHttpClientHelper} subclass that
+     * Restlet instantiates reflectively when this adapter routes requests through a tunnel.
+     * Kept as a string constant so the engine module need not statically depend on the helper
+     * class via the Restlet helper-resolution path.
+     */
+    static final String TUNNEL_AWARE_HELPER_CLASS_NAME =
+            "io.ikanos.engine.consumes.http.TunnelAwareHttpClientHelper";
+
     private final Client httpClient;
 
     public HttpClientAdapter(Capability capability, HttpClientSpec spec) {
+        this(capability, spec, Map.of());
+    }
+
+    /**
+     * Tunnel-aware constructor used by {@link Capability} bootstrap.
+     *
+     * <p>When {@code spec.getTunnel()} is non-null AND {@code tunnels} contains an entry for
+     * the tunnel's type, the underlying Restlet {@link Client} is created with a custom
+     * {@link TunnelAwareHttpClientHelper} that installs a Jetty request listener routing
+     * matching hosts through the tunnel. Otherwise this behaves identically to the 2-arg
+     * constructor (direct internet path).
+     *
+     * @param capability the owning capability
+     * @param spec the consumed-HTTP spec
+     * @param tunnels {@code tunnel.type → Tunnel} map of started tunnel instances; an empty
+     *     map disables tunnel routing
+     */
+    public HttpClientAdapter(
+            Capability capability, HttpClientSpec spec, Map<String, Tunnel> tunnels) {
         super(capability, spec);
-        this.httpClient = new Client(HTTP, HTTPS);
+        Tunnel tunnel = selectTunnel(spec, tunnels);
+        if (tunnel == null) {
+            this.httpClient = new Client(HTTP, HTTPS);
+        } else {
+            TunnelRouteTable routes = new TunnelRouteTable();
+            routes.register(extractHost(spec), tunnel);
+            Context restletContext = new Context();
+            restletContext.getAttributes().put(TunnelRouteTable.CONTEXT_ATTRIBUTE, routes);
+            this.httpClient = new Client(
+                    restletContext, List.of(HTTP, HTTPS), TUNNEL_AWARE_HELPER_CLASS_NAME);
+        }
+    }
+
+    /**
+     * Package-private for testing. Resolves the {@link Tunnel} instance that should serve
+     * {@code spec}, or {@code null} when no tunnel is configured or available.
+     */
+    static Tunnel selectTunnel(HttpClientSpec spec, Map<String, Tunnel> tunnels) {
+        if (spec == null || spec.getTunnel() == null || tunnels == null || tunnels.isEmpty()) {
+            return null;
+        }
+        return tunnels.get(spec.getTunnel().getType());
+    }
+
+    /**
+     * Package-private for testing. Extracts the host portion of {@link HttpClientSpec#getBaseUri()}
+     * for use as the {@link TunnelRouteTable} key.
+     */
+    static String extractHost(HttpClientSpec spec) {
+        String baseUri = spec.getBaseUri();
+        if (baseUri == null || baseUri.isBlank()) {
+            throw new IllegalArgumentException(
+                    "ConsumesHttp.baseUri is required when tunnel is configured");
+        }
+        try {
+            URI uri = new URI(baseUri);
+            String host = uri.getHost();
+            if (host == null) {
+                throw new IllegalArgumentException(
+                        "ConsumesHttp.baseUri must include a host: " + baseUri);
+            }
+            return host;
+        } catch (URISyntaxException ex) {
+            throw new IllegalArgumentException(
+                    "Invalid ConsumesHttp.baseUri: " + baseUri, ex);
+        }
     }
 
     public HttpClientSpec getHttpClientSpec() {

--- a/ikanos-engine/src/main/java/io/ikanos/engine/consumes/http/TunnelAwareHttpClientHelper.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/consumes/http/TunnelAwareHttpClientHelper.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.consumes.http;
+
+import io.ikanos.engine.consumes.tunnel.Tunnel;
+import io.ikanos.engine.consumes.tunnel.TunnelRouteTable;
+import io.ikanos.engine.consumes.tunnel.TunnelTransport;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.Request;
+import org.restlet.Client;
+
+/**
+ * Restlet {@link org.restlet.engine.connector.HttpClientHelper} subclass that installs a
+ * Jetty request listener which, on every outgoing request, looks up the host in a {@link
+ * TunnelRouteTable} and attaches a {@link TunnelTransport} when the host is tunneled.
+ *
+ * <p>The route table is passed via Restlet {@link org.restlet.Context} attributes under the
+ * key {@link TunnelRouteTable#CONTEXT_ATTRIBUTE}; {@link io.ikanos.Capability} populates that
+ * attribute before instantiating the underlying Restlet {@code Client}.
+ *
+ * <p>This class is referenced by class name (string) from
+ * {@code org.restlet.Client(Context, List&lt;Protocol&gt;, String helperClass)}, which is how
+ * Restlet swaps in custom helpers without touching the default helper lookup. The name MUST
+ * stay stable.
+ */
+public class TunnelAwareHttpClientHelper
+        extends org.restlet.engine.connector.HttpClientHelper {
+
+    /**
+     * Restlet calls this constructor reflectively when it resolves the helper class name.
+     *
+     * @param client the Restlet client
+     */
+    public TunnelAwareHttpClientHelper(Client client) {
+        super(client);
+    }
+
+    @Override
+    protected HttpClient createHttpClient() {
+        HttpClient httpClient = super.createHttpClient();
+        TunnelRouteTable routes = readRouteTable();
+        if (routes == null || routes.isEmpty()) {
+            return httpClient;
+        }
+        httpClient
+                .getRequestListeners()
+                .addQueuedListener(request -> applyTunnelTransport(request, routes));
+        return httpClient;
+    }
+
+    /**
+     * Package-private helper for unit tests. Reads the route table from the Restlet context
+     * attribute populated by the engine bootstrap; returns {@code null} when the helper is
+     * instantiated outside the engine (in which case no tunnels are configured anyway).
+     */
+    TunnelRouteTable readRouteTable() {
+        if (getContext() == null) {
+            return null;
+        }
+        Object attr = getContext().getAttributes().get(TunnelRouteTable.CONTEXT_ATTRIBUTE);
+        if (attr instanceof TunnelRouteTable table) {
+            return table;
+        }
+        return null;
+    }
+
+    /**
+     * Package-private helper for unit tests. Attaches a {@link TunnelTransport} to the
+     * outgoing {@code request} when the request's host matches a {@link Tunnel} registered in
+     * {@code routes}; otherwise leaves the request unchanged (default Jetty TCP/IP transport).
+     */
+    static void applyTunnelTransport(Request request, TunnelRouteTable routes) {
+        Tunnel tunnel = routes.lookup(request.getHost());
+        if (tunnel == null) {
+            return;
+        }
+        request.transport(new TunnelTransport(tunnel, request.getHost(), request.getPort()));
+    }
+}

--- a/ikanos-engine/src/main/java/io/ikanos/engine/consumes/tunnel/Tunnel.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/consumes/tunnel/Tunnel.java
@@ -22,8 +22,12 @@ import java.nio.channels.AsynchronousSocketChannel;
  *
  * <p>Implementations are discovered via {@link java.util.ServiceLoader} at bootstrap, matched
  * to a {@code ConsumesHttp.tunnel} block by {@link #type()}, and pooled per
- * {@code (type, identity)} so that two {@code ConsumesHttp} entries sharing the same identity
- * also share one underlying context.
+ * {@code tunnel.type}: a single started {@code Tunnel} instance per type is shared across
+ * every {@code ConsumesHttp} entry that references it (see {@link TunnelBootstrap}). The
+ * declared {@code tunnel.identity} is checked for conflicts ({@link TunnelBootstrap} rejects
+ * two different identities for the same type) but is <b>not</b> part of the pool key &mdash;
+ * Phase 2 supports a single identity per type. A composite {@code (type, identity)} pool
+ * key may be introduced when multi-identity support lands.
  *
  * <h2>Design notes</h2>
  *

--- a/ikanos-engine/src/main/java/io/ikanos/engine/consumes/tunnel/Tunnel.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/consumes/tunnel/Tunnel.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.consumes.tunnel;
+
+import java.io.IOException;
+import java.nio.channels.AsynchronousSocketChannel;
+
+/**
+ * SPI for reverse-tunnel transports that route consumed HTTP traffic through an overlay
+ * network instead of the public internet.
+ *
+ * <p>Implementations are discovered via {@link java.util.ServiceLoader} at bootstrap, matched
+ * to a {@code ConsumesHttp.tunnel} block by {@link #type()}, and pooled per
+ * {@code (type, identity)} so that two {@code ConsumesHttp} entries sharing the same identity
+ * also share one underlying context.
+ *
+ * <h2>Design notes</h2>
+ *
+ * <p>The dial returns an {@link AsynchronousSocketChannel} rather than a plain
+ * {@link java.net.Socket} because the only viable JVM-side OpenZiti integration produces
+ * async channels; the engine then bridges that channel to Jetty's selector-based I/O via a
+ * {@code MemoryEndPointPipe} pump. See blueprint §6.3 (revised by the §6.4 ADR after Phase 2
+ * implementation surfaced that {@code SocketChannel} bridging was not viable with the
+ * available OpenZiti SDK surface).
+ *
+ * <h2>Routing</h2>
+ *
+ * <p>Host-to-tunnel routing happens via the {@link TunnelRouteTable} in the engine: the
+ * adapter inspects every outgoing request's {@code Host} header and, if a registered tunnel
+ * host matches, attaches a {@code TunnelTransport} to the Jetty request. The tunnel itself
+ * does not participate in routing decisions; it is only asked to dial.
+ *
+ * <h2>Thread-safety</h2>
+ *
+ * Implementations MUST be safe for concurrent use by multiple HTTP client threads. A single
+ * {@code Tunnel} instance is shared across all {@code ConsumesHttp} entries that use the same
+ * identity.
+ */
+public interface Tunnel extends AutoCloseable {
+
+    /**
+     * Discriminator matching the {@code tunnel.type} value in {@code ConsumesHttp.tunnel}.
+     *
+     * <p>The first {@code Tunnel} implementation whose {@code type()} matches the configured
+     * type is selected by the engine. Values are lowercase, kebab-case identifiers
+     * (e.g. {@code "ziti"}).
+     *
+     * @return the tunnel type identifier; never {@code null}
+     */
+    String type();
+
+    /**
+     * Dial through the overlay and return a connected {@link AsynchronousSocketChannel}
+     * bound to the configured private service.
+     *
+     * <p>Implementations MUST NOT call {@link java.net.InetAddress#getByName(String)} or any
+     * other system DNS resolver. The {@code host} parameter is the logical hostname declared
+     * in {@code ConsumesHttp.baseUri} (e.g. {@code "crm.internal"}) and is, by design,
+     * unresolvable from the public internet.
+     *
+     * <p>The returned channel is wrapped in application-layer TLS by Jetty when the consumed
+     * {@code baseUri} uses HTTPS, providing end-to-end encryption on top of the overlay's
+     * transport security.
+     *
+     * @param host the target hostname from {@code baseUri}; non-null
+     * @param port the target port from {@code baseUri}; positive
+     * @return a connected async channel routed through the tunnel overlay
+     * @throws IOException if the dial fails (tunnel down, service unauthorized, …)
+     */
+    AsynchronousSocketChannel connect(String host, int port) throws IOException;
+
+    /**
+     * Readiness signal surfaced by the control-port {@code /health/ready} endpoint.
+     *
+     * <p>Returns {@code true} when the tunnel overlay is connected and the configured service
+     * is reachable. The engine blocks bootstrap for a configurable timeout (default 30s)
+     * waiting for this to flip to {@code true} on every required tunnel.
+     *
+     * @return {@code true} if the tunnel is active and dials are expected to succeed
+     */
+    boolean isReady();
+}

--- a/ikanos-engine/src/main/java/io/ikanos/engine/consumes/tunnel/TunnelBootstrap.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/consumes/tunnel/TunnelBootstrap.java
@@ -96,6 +96,13 @@ public final class TunnelBootstrap {
      * {@code (type, identity)} pairs are accepted, but mixing two different identities for
      * the same {@code type} in a single capability throws {@link IllegalStateException}.
      *
+     * <p><b>Failure atomicity.</b> If any step throws after some tunnels have already been
+     * started (for example, a later tunnel never becomes ready and {@link #waitReady} throws),
+     * every tunnel already in the result map is {@link Tunnel#close() closed} on a best-effort
+     * basis before the original exception propagates. The caller therefore never observes a
+     * partially-started set of tunnels: either all configured tunnels are returned, or none
+     * remain open. Close exceptions are suppressed so they do not mask the original cause.
+     *
      * @param clientSpecs the list of {@code consumes:} client specs
      * @param readyTimeout maximum time to wait per tunnel for readiness
      * @param bindings nested binding map for Mustache resolution of {@code tunnel.identity}
@@ -112,51 +119,75 @@ public final class TunnelBootstrap {
         if (clientSpecs == null) {
             return Map.of();
         }
-        for (ClientSpec clientSpec : clientSpecs) {
-            if (!(clientSpec instanceof HttpClientSpec http)) {
-                continue;
-            }
-            TunnelConfigSpec tunnelConfig = http.getTunnel();
-            if (tunnelConfig == null) {
-                continue;
-            }
-            String type = tunnelConfig.getType();
-            if (type == null || type.isBlank()) {
-                throw new IllegalStateException(
-                        "tunnel.type is required for ConsumesHttp tunnel block");
-            }
-            String identity = resolveIdentity(tunnelConfig, bindings);
-            String previous = identitiesByType.put(type, identity);
-            if (previous != null && !previous.equals(identity)) {
-                throw new IllegalStateException(
-                        "Multiple distinct identities configured for tunnel type '"
-                                + type
-                                + "'; Phase 2 supports a single identity per type.");
-            }
-            if (tunnels.containsKey(type)) {
-                continue;
-            }
-            String identityPropertyKey = "ikanos.tunnel." + type + ".identity";
-            boolean identityPropertySet = false;
-            if (identity != null && !identity.isBlank()) {
-                System.setProperty(identityPropertyKey, identity);
-                identityPropertySet = true;
-            }
-            try {
-                Tunnel tunnel = loadTunnel(type);
-                waitReady(tunnel, readyTimeout);
-                tunnels.put(type, tunnel);
-            } finally {
-                // Bound the JVM-global side-effect to the ServiceLoader call: by the time
-                // loadTunnel returns, the SPI provider has constructed and cached its
-                // context, so the property is no longer needed. Clearing it here prevents
-                // a second capability in the same JVM from observing a stale value.
-                if (identityPropertySet) {
-                    System.clearProperty(identityPropertyKey);
+        boolean success = false;
+        try {
+            for (ClientSpec clientSpec : clientSpecs) {
+                if (!(clientSpec instanceof HttpClientSpec http)) {
+                    continue;
+                }
+                TunnelConfigSpec tunnelConfig = http.getTunnel();
+                if (tunnelConfig == null) {
+                    continue;
+                }
+                String type = tunnelConfig.getType();
+                if (type == null || type.isBlank()) {
+                    throw new IllegalStateException(
+                            "tunnel.type is required for ConsumesHttp tunnel block");
+                }
+                String identity = resolveIdentity(tunnelConfig, bindings);
+                String previous = identitiesByType.put(type, identity);
+                if (previous != null && !previous.equals(identity)) {
+                    throw new IllegalStateException(
+                            "Multiple distinct identities configured for tunnel type '"
+                                    + type
+                                    + "'; Phase 2 supports a single identity per type.");
+                }
+                if (tunnels.containsKey(type)) {
+                    continue;
+                }
+                String identityPropertyKey = "ikanos.tunnel." + type + ".identity";
+                boolean identityPropertySet = false;
+                if (identity != null && !identity.isBlank()) {
+                    System.setProperty(identityPropertyKey, identity);
+                    identityPropertySet = true;
+                }
+                try {
+                    Tunnel tunnel = loadTunnel(type);
+                    waitReady(tunnel, readyTimeout);
+                    tunnels.put(type, tunnel);
+                } finally {
+                    // Bound the JVM-global side-effect to the ServiceLoader call: by the time
+                    // loadTunnel returns, the SPI provider has constructed and cached its
+                    // context, so the property is no longer needed. Clearing it here prevents
+                    // a second capability in the same JVM from observing a stale value.
+                    if (identityPropertySet) {
+                        System.clearProperty(identityPropertyKey);
+                    }
                 }
             }
+            success = true;
+            return Map.copyOf(tunnels);
+        } finally {
+            // If any step above threw (e.g. a later tunnel failed readiness while an earlier
+            // tunnel of a different type had already started), close every tunnel we already
+            // built. Without this, an InterruptedException-turned-IllegalStateException from
+            // waitReady — or any other mid-loop failure — would leak open SPI contexts that
+            // outlive the failed Capability bootstrap. Best-effort: close exceptions are
+            // suppressed so they do not mask the original failure.
+            if (!success) {
+                closeQuietly(tunnels.values());
+            }
         }
-        return Map.copyOf(tunnels);
+    }
+
+    private static void closeQuietly(Iterable<Tunnel> tunnels) {
+        for (Tunnel tunnel : tunnels) {
+            try {
+                tunnel.close();
+            } catch (Exception ignored) {
+                // best-effort cleanup on failed bootstrap; do not mask the original cause
+            }
+        }
     }
 
     /**
@@ -202,9 +233,14 @@ public final class TunnelBootstrap {
     /**
      * Package-private for testing. Locates the first {@link ServiceLoader} provider whose
      * {@link Tunnel#type()} matches {@code type}, or throws.
+     *
+     * <p>Uses the {@link Tunnel}-defining classloader explicitly (rather than the
+     * thread-context classloader picked up by the no-arg {@link ServiceLoader#load(Class)}
+     * overload) so SPI discovery is correct in OSGi containers and fat-jar layouts where
+     * the context classloader differs from the SPI classloader.
      */
     static Tunnel loadTunnel(String type) {
-        for (Tunnel candidate : ServiceLoader.load(Tunnel.class)) {
+        for (Tunnel candidate : ServiceLoader.load(Tunnel.class, Tunnel.class.getClassLoader())) {
             if (type.equals(candidate.type())) {
                 return candidate;
             }

--- a/ikanos-engine/src/main/java/io/ikanos/engine/consumes/tunnel/TunnelBootstrap.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/consumes/tunnel/TunnelBootstrap.java
@@ -72,14 +72,35 @@ public final class TunnelBootstrap {
      * no-arg constructor required for {@link ServiceLoader} — while still letting providers
      * read per-deployment configuration.
      *
+     * <p><b>Bindings shape.</b> {@code bindings} is the same nested map structure consumed
+     * by {@link Resolver#resolveMustacheTemplate(String, Map)} elsewhere in the engine:
+     * a top-level namespace map whose values are themselves maps of {@code key → value}.
+     * For example, an identity template {@code "{{secrets.IDENT_PATH}}"} requires:
+     * <pre>{@code
+     * Map.of("secrets", Map.of("IDENT_PATH", "/etc/ziti/app.json"))
+     * }</pre>
+     * A flat map (e.g. {@code Map.of("IDENT_PATH", "/etc/ziti/app.json")}) will not satisfy
+     * a {@code "{{secrets.IDENT_PATH}}"} template. To catch this early, {@link
+     * #resolveIdentity} fails fast when the raw identity contains a Mustache expression but
+     * resolution leaves any unresolved {@code {{...}}} marker in the output — see {@link
+     * #resolveIdentity} for the exact condition.
+     *
+     * <p>The per-type identity system property is cleared immediately after {@link
+     * #loadTunnel(String)} returns. The context is constructed and cached by the SPI
+     * provider at that point, so the property is no longer needed; clearing it bounds the
+     * JVM-global side-effect to the {@link ServiceLoader} call and avoids races when two
+     * {@link io.ikanos.Capability} instances coexist in the same JVM (parallel unit tests
+     * today, multi-capability deployments in a future server mode).
+     *
      * <p>For Phase 2 only one identity per {@code tunnel.type} is supported; duplicate
      * {@code (type, identity)} pairs are accepted, but mixing two different identities for
      * the same {@code type} in a single capability throws {@link IllegalStateException}.
      *
      * @param clientSpecs the list of {@code consumes:} client specs
      * @param readyTimeout maximum time to wait per tunnel for readiness
-     * @param bindings binding map for Mustache resolution of {@code tunnel.identity}; may be
-     *     {@code null} or empty if no Mustache substitution is needed
+     * @param bindings nested binding map for Mustache resolution of {@code tunnel.identity}
+     *     (shape: {@code namespace → key → value}); may be {@code null} or empty when no
+     *     Mustache substitution is needed
      * @return immutable map of {@code tunnel.type → Tunnel}
      */
     public static Map<String, Tunnel> discoverAndStart(
@@ -115,12 +136,25 @@ public final class TunnelBootstrap {
             if (tunnels.containsKey(type)) {
                 continue;
             }
+            String identityPropertyKey = "ikanos.tunnel." + type + ".identity";
+            boolean identityPropertySet = false;
             if (identity != null && !identity.isBlank()) {
-                System.setProperty("ikanos.tunnel." + type + ".identity", identity);
+                System.setProperty(identityPropertyKey, identity);
+                identityPropertySet = true;
             }
-            Tunnel tunnel = loadTunnel(type);
-            waitReady(tunnel, readyTimeout);
-            tunnels.put(type, tunnel);
+            try {
+                Tunnel tunnel = loadTunnel(type);
+                waitReady(tunnel, readyTimeout);
+                tunnels.put(type, tunnel);
+            } finally {
+                // Bound the JVM-global side-effect to the ServiceLoader call: by the time
+                // loadTunnel returns, the SPI provider has constructed and cached its
+                // context, so the property is no longer needed. Clearing it here prevents
+                // a second capability in the same JVM from observing a stale value.
+                if (identityPropertySet) {
+                    System.clearProperty(identityPropertyKey);
+                }
+            }
         }
         return Map.copyOf(tunnels);
     }
@@ -128,6 +162,13 @@ public final class TunnelBootstrap {
     /**
      * Package-private for testing. Returns the resolved identity string, or {@code null} when
      * no identity is configured for this tunnel type.
+     *
+     * <p>If the raw identity contains a Mustache expression ({@code {{...}}}) and the
+     * resolved value still contains an unresolved {@code {{...}}} marker, an
+     * {@link IllegalStateException} is thrown. This catches the common mistake of passing a
+     * flat map (e.g. {@code Map.of("IDENT", "...")}) when the template references a
+     * namespaced key (e.g. {@code "{{secrets.IDENT}}"}) — without this guard, the unresolved
+     * template would silently propagate to the SPI provider as a literal file path.
      */
     static String resolveIdentity(TunnelConfigSpec spec, Map<String, Object> bindings) {
         if (spec instanceof ZitiTunnelConfigSpec ziti) {
@@ -138,7 +179,22 @@ public final class TunnelBootstrap {
             if (bindings == null || bindings.isEmpty()) {
                 return raw;
             }
-            return Resolver.resolveMustacheTemplate(raw, bindings);
+            String resolved = Resolver.resolveMustacheTemplate(raw, bindings);
+            // Fail fast when the template was non-empty but resolution produced no output —
+            // this happens when the caller passes a flat binding map (or one missing the
+            // referenced namespace), because Resolver substitutes missing variables with the
+            // empty string. Without this guard, the SPI provider would silently start with
+            // an empty identity path.
+            boolean mustacheTemplate = raw.contains("{{");
+            if (mustacheTemplate
+                    && (resolved == null || resolved.isBlank() || resolved.contains("{{"))) {
+                throw new IllegalStateException(
+                        "tunnel.identity Mustache expression '" + raw
+                                + "' could not be resolved against the provided bindings."
+                                + " Expected nested map shape (namespace -> key -> value),"
+                                + " e.g. {\"secrets\": {\"IDENT\": \"/etc/ziti/app.json\"}}.");
+            }
+            return resolved;
         }
         return null;
     }

--- a/ikanos-engine/src/main/java/io/ikanos/engine/consumes/tunnel/TunnelBootstrap.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/consumes/tunnel/TunnelBootstrap.java
@@ -1,0 +1,190 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.consumes.tunnel;
+
+import io.ikanos.engine.util.Resolver;
+import io.ikanos.spec.consumes.ClientSpec;
+import io.ikanos.spec.consumes.http.HttpClientSpec;
+import io.ikanos.spec.consumes.http.tunnel.TunnelConfigSpec;
+import io.ikanos.spec.consumes.http.tunnel.ZitiTunnelConfigSpec;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+/**
+ * Bootstraps {@link Tunnel} implementations declared by a capability's {@code consumes:} list.
+ *
+ * <p>Discovery is by {@link ServiceLoader} — implementations live in separate Maven modules
+ * (e.g. {@code ikanos-tunnel-ziti}) so the engine has zero compile-time dependency on any
+ * specific overlay-network SDK.
+ *
+ * <p>Pooling is by {@code tunnel.type}: at most one started {@link Tunnel} instance per type
+ * is active per {@link io.ikanos.Capability}, shared across all {@code ConsumesHttp} entries
+ * that reference it. This matches the §6.5 design in the blueprint.
+ */
+public final class TunnelBootstrap {
+
+    private TunnelBootstrap() {
+        // utility
+    }
+
+    /**
+     * Scans {@code clientSpecs} for HTTP clients with a {@code tunnel:} block, instantiates a
+     * {@link Tunnel} per distinct {@code tunnel.type} via the JVM {@link ServiceLoader}, and
+     * waits up to {@code readyTimeout} for each tunnel's {@link Tunnel#isReady()} to flip to
+     * {@code true}.
+     *
+     * <p>If no tunnels are declared, returns an empty map immediately. If a declared
+     * {@code tunnel.type} has no {@link ServiceLoader} provider on the classpath, an
+     * {@link IllegalStateException} is thrown — the operator forgot to add the
+     * {@code ikanos-tunnel-&lt;type&gt;} module to the deployment.
+     *
+     * @param clientSpecs the list of {@code consumes:} client specs from the capability spec
+     * @param readyTimeout maximum time to wait per tunnel for {@code isReady()} to become
+     *     {@code true}; if zero or negative, no readiness gate is applied
+     * @return immutable map of {@code tunnel.type → started Tunnel instance}
+     * @throws IllegalStateException if a required {@code tunnel.type} has no SPI provider, or
+     *     if a tunnel does not become ready within {@code readyTimeout}
+     */
+    public static Map<String, Tunnel> discoverAndStart(
+            List<ClientSpec> clientSpecs, Duration readyTimeout) {
+        return discoverAndStart(clientSpecs, readyTimeout, Map.of());
+    }
+
+    /**
+     * Variant that resolves Mustache-templated identity values via {@code bindings}. The
+     * resolved identity is exposed to {@link Tunnel} implementations via a system property
+     * named {@code ikanos.tunnel.<type>.identity} (set BEFORE {@link ServiceLoader}
+     * instantiates the provider). This indirection keeps the {@link Tunnel} SPI minimal —
+     * no-arg constructor required for {@link ServiceLoader} — while still letting providers
+     * read per-deployment configuration.
+     *
+     * <p>For Phase 2 only one identity per {@code tunnel.type} is supported; duplicate
+     * {@code (type, identity)} pairs are accepted, but mixing two different identities for
+     * the same {@code type} in a single capability throws {@link IllegalStateException}.
+     *
+     * @param clientSpecs the list of {@code consumes:} client specs
+     * @param readyTimeout maximum time to wait per tunnel for readiness
+     * @param bindings binding map for Mustache resolution of {@code tunnel.identity}; may be
+     *     {@code null} or empty if no Mustache substitution is needed
+     * @return immutable map of {@code tunnel.type → Tunnel}
+     */
+    public static Map<String, Tunnel> discoverAndStart(
+            List<ClientSpec> clientSpecs,
+            Duration readyTimeout,
+            Map<String, Object> bindings) {
+        Map<String, Tunnel> tunnels = new HashMap<>();
+        Map<String, String> identitiesByType = new HashMap<>();
+        if (clientSpecs == null) {
+            return Map.of();
+        }
+        for (ClientSpec clientSpec : clientSpecs) {
+            if (!(clientSpec instanceof HttpClientSpec http)) {
+                continue;
+            }
+            TunnelConfigSpec tunnelConfig = http.getTunnel();
+            if (tunnelConfig == null) {
+                continue;
+            }
+            String type = tunnelConfig.getType();
+            if (type == null || type.isBlank()) {
+                throw new IllegalStateException(
+                        "tunnel.type is required for ConsumesHttp tunnel block");
+            }
+            String identity = resolveIdentity(tunnelConfig, bindings);
+            String previous = identitiesByType.put(type, identity);
+            if (previous != null && !previous.equals(identity)) {
+                throw new IllegalStateException(
+                        "Multiple distinct identities configured for tunnel type '"
+                                + type
+                                + "'; Phase 2 supports a single identity per type.");
+            }
+            if (tunnels.containsKey(type)) {
+                continue;
+            }
+            if (identity != null && !identity.isBlank()) {
+                System.setProperty("ikanos.tunnel." + type + ".identity", identity);
+            }
+            Tunnel tunnel = loadTunnel(type);
+            waitReady(tunnel, readyTimeout);
+            tunnels.put(type, tunnel);
+        }
+        return Map.copyOf(tunnels);
+    }
+
+    /**
+     * Package-private for testing. Returns the resolved identity string, or {@code null} when
+     * no identity is configured for this tunnel type.
+     */
+    static String resolveIdentity(TunnelConfigSpec spec, Map<String, Object> bindings) {
+        if (spec instanceof ZitiTunnelConfigSpec ziti) {
+            String raw = ziti.getIdentity();
+            if (raw == null || raw.isBlank()) {
+                return null;
+            }
+            if (bindings == null || bindings.isEmpty()) {
+                return raw;
+            }
+            return Resolver.resolveMustacheTemplate(raw, bindings);
+        }
+        return null;
+    }
+
+    /**
+     * Package-private for testing. Locates the first {@link ServiceLoader} provider whose
+     * {@link Tunnel#type()} matches {@code type}, or throws.
+     */
+    static Tunnel loadTunnel(String type) {
+        for (Tunnel candidate : ServiceLoader.load(Tunnel.class)) {
+            if (type.equals(candidate.type())) {
+                return candidate;
+            }
+        }
+        throw new IllegalStateException(
+                "No Tunnel SPI provider found for type='"
+                        + type
+                        + "'. Add the ikanos-tunnel-"
+                        + type
+                        + " module (or compatible provider) to the classpath.");
+    }
+
+    /**
+     * Package-private for testing. Polls {@link Tunnel#isReady()} every 100&nbsp;ms until it
+     * returns {@code true} or {@code timeout} elapses. A non-positive timeout skips the wait.
+     */
+    static void waitReady(Tunnel tunnel, Duration timeout) {
+        if (timeout == null || timeout.isZero() || timeout.isNegative()) {
+            return;
+        }
+        long deadline = System.nanoTime() + timeout.toNanos();
+        while (!tunnel.isReady()) {
+            if (System.nanoTime() > deadline) {
+                throw new IllegalStateException(
+                        "Tunnel '"
+                                + tunnel.type()
+                                + "' did not become ready within "
+                                + timeout);
+            }
+            try {
+                Thread.sleep(100L);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException(
+                        "Interrupted while waiting for tunnel '" + tunnel.type() + "'", ie);
+            }
+        }
+    }
+}

--- a/ikanos-engine/src/main/java/io/ikanos/engine/consumes/tunnel/TunnelRouteTable.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/consumes/tunnel/TunnelRouteTable.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.consumes.tunnel;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Registry mapping consumed-API hosts to the {@link Tunnel} that dials them.
+ *
+ * <p>A single {@code TunnelRouteTable} is built once during {@link io.ikanos.Capability}
+ * bootstrap and passed to {@link io.ikanos.engine.consumes.http.HttpClientAdapter}, which
+ * stores it in the underlying Restlet/Jetty client. At request time, a Jetty request listener
+ * (installed by {@code TunnelAwareHttpClientHelper}) consults this table on every outgoing
+ * request and, when the host matches a registered entry, attaches a tunnel-routed
+ * {@link org.eclipse.jetty.io.Transport} to the request.
+ *
+ * <p>Lookups are case-insensitive on the host string.
+ *
+ * <h2>Thread-safety</h2>
+ *
+ * Instances are populated synchronously during bootstrap and may be queried concurrently
+ * afterwards. The underlying map is a {@link ConcurrentHashMap}.
+ */
+public final class TunnelRouteTable {
+
+    /**
+     * Well-known key under which the engine stores the active table in the Restlet
+     * {@link org.restlet.Context} attributes so the helper subclass can read it.
+     */
+    public static final String CONTEXT_ATTRIBUTE = "io.ikanos.engine.tunnel.routes";
+
+    private final Map<String, Tunnel> byHost = new ConcurrentHashMap<>();
+
+    /**
+     * Register a tunnel for the given host. Existing mappings for {@code host} are replaced.
+     *
+     * @param host the hostname from a {@code ConsumesHttp.baseUri} (case-insensitive); non-null
+     * @param tunnel the tunnel that dials this host; non-null
+     */
+    public void register(String host, Tunnel tunnel) {
+        Objects.requireNonNull(host, "host");
+        Objects.requireNonNull(tunnel, "tunnel");
+        byHost.put(normalize(host), tunnel);
+    }
+
+    /**
+     * @param host hostname to look up; may be null
+     * @return the tunnel registered for {@code host}, or {@code null} if the host is not
+     *         tunneled and traffic should go via the default transport
+     */
+    public Tunnel lookup(String host) {
+        if (host == null) {
+            return null;
+        }
+        return byHost.get(normalize(host));
+    }
+
+    /**
+     * @return {@code true} when at least one tunnel is registered
+     */
+    public boolean isEmpty() {
+        return byHost.isEmpty();
+    }
+
+    /**
+     * @return the number of registered host → tunnel mappings
+     */
+    public int size() {
+        return byHost.size();
+    }
+
+    private static String normalize(String host) {
+        return host.toLowerCase(Locale.ROOT);
+    }
+}

--- a/ikanos-engine/src/main/java/io/ikanos/engine/consumes/tunnel/TunnelTransport.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/consumes/tunnel/TunnelTransport.java
@@ -215,6 +215,17 @@ public final class TunnelTransport implements Transport {
             int filled = endPoint.fill(buffer);
             BufferUtil.flipToFlush(buffer, 0);
             if (filled < 0) {
+                // EOS on the Jetty side: the local endpoint has signalled that the application
+                // has finished writing the request body. The pump finishes successfully, which
+                // dispatches to onCompleteSuccess() and closes the tunnel write side
+                // (channel.close()). We deliberately do NOT close the EndPoint itself here:
+                // (1) Jetty's MemoryEndPointPipe drives the EndPoint lifecycle and closes the
+                //     local side on its own EOS detection.
+                // (2) The opposite direction (ChannelToEndPointPump) is still expected to
+                //     deliver the response on the same EndPoint; closing it now would abort
+                //     the response. ChannelToEndPointPump.completed(result < 0) calls
+                //     endPoint.shutdownOutput()/close() once the tunnel side reports EOS,
+                //     which is the correct moment to tear down the EndPoint.
                 return Action.SUCCEEDED;
             }
             if (filled == 0) {

--- a/ikanos-engine/src/main/java/io/ikanos/engine/consumes/tunnel/TunnelTransport.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/consumes/tunnel/TunnelTransport.java
@@ -151,11 +151,34 @@ public final class TunnelTransport implements Transport {
         new ChannelToEndPointPump(zitiChannel, remoteEndPoint).start();
     }
 
+    /**
+     * Hash combines the {@link System#identityHashCode(Object)} of the {@link Tunnel}
+     * instance with the {@code (host, port)} tuple.
+     *
+     * <p><b>Tunnel equality is reference identity ({@code ==}), not logical equality.</b>
+     * This is intentional and matches the {@code (tunnel, host, port)} pool-key contract
+     * documented at the class level. It is safe because {@link TunnelBootstrap} guarantees
+     * a single started {@link Tunnel} instance per {@code tunnel.type} per {@link
+     * io.ikanos.Capability}, shared by all {@link
+     * io.ikanos.engine.consumes.http.HttpClientAdapter} instances within that capability.
+     *
+     * <p>If two {@link TunnelTransport} instances are ever constructed for the same
+     * {@code (host, port)} with two different {@link Tunnel} instances of the same type
+     * (for example in a test, or in a hypothetical future multi-identity scenario), they
+     * will land in <i>different</i> Jetty connection pools — by design, since the two
+     * tunnels are physically distinct.
+     */
     @Override
     public int hashCode() {
         return Objects.hash(System.identityHashCode(tunnel), host, port);
     }
 
+    /**
+     * Equality compares the {@link Tunnel} by <b>reference identity</b> ({@code ==}), not by
+     * {@link Object#equals(Object)} or by {@link Tunnel#type()}. See {@link #hashCode()} for
+     * the rationale and the {@link TunnelBootstrap} single-instance-per-type guarantee that
+     * makes this correct.
+     */
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {

--- a/ikanos-engine/src/main/java/io/ikanos/engine/consumes/tunnel/TunnelTransport.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/consumes/tunnel/TunnelTransport.java
@@ -1,0 +1,323 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.consumes.tunnel;
+
+import java.io.IOException;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.AsynchronousSocketChannel;
+import java.nio.channels.CompletionHandler;
+import java.util.Map;
+import java.util.Objects;
+import org.eclipse.jetty.io.ClientConnector;
+import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.io.MemoryEndPointPipe;
+import org.eclipse.jetty.io.Transport;
+import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.IteratingCallback;
+import org.eclipse.jetty.util.Promise;
+
+/**
+ * Jetty {@link Transport} implementation that routes a single HTTP request through a
+ * {@link Tunnel} (overlay network) instead of the public internet.
+ *
+ * <h2>Mechanism</h2>
+ *
+ * <ol>
+ *   <li>Jetty calls {@link #connect(SocketAddress, Map)} once per outgoing request that has
+ *       this transport attached via {@code Request.transport(TunnelTransport)}.</li>
+ *   <li>We dial the tunnel and obtain an {@link AsynchronousSocketChannel} pointing at the
+ *       private service.</li>
+ *   <li>We create a {@link MemoryEndPointPipe} — an in-memory bidirectional pair of
+ *       {@link EndPoint}s. We hand Jetty the local endpoint as if it were a regular socket
+ *       endpoint; from Jetty's point of view, the connection is established.</li>
+ *   <li>We start two byte pumps:
+ *       <ul>
+ *         <li>Jetty's remote endpoint → Ziti async channel (request bytes outbound)</li>
+ *         <li>Ziti async channel → Jetty's remote endpoint (response bytes inbound)</li>
+ *       </ul></li>
+ * </ol>
+ *
+ * <p>This bridges Jetty's selector-based NIO I/O model and OpenZiti's
+ * {@link java.nio.channels.AsynchronousChannelGroup}-based async I/O model. The cost is an
+ * extra in-memory copy per chunk; for the API-aggregation workloads ikanos targets this is
+ * negligible.
+ *
+ * <h2>Equality</h2>
+ *
+ * <p>Jetty interns {@code Origin}s (which include the {@code Transport}) so two transport
+ * instances for the same host must compare equal to share a connection pool. We define
+ * equality by the {@link Tunnel} reference and the {@code (host, port)} tuple, which gives
+ * one pool per {@code (tunnel, host, port)} triple.
+ */
+public final class TunnelTransport implements Transport {
+
+    /** Buffer size for the byte pumps in both directions. 8&nbsp;KiB matches Jetty defaults. */
+    private static final int PUMP_BUFFER_BYTES = 8 * 1024;
+
+    private final Tunnel tunnel;
+    private final String host;
+    private final int port;
+    private final SocketAddress syntheticAddress;
+
+    /**
+     * @param tunnel the tunnel to dial through; non-null
+     * @param host the target hostname (passed verbatim to {@link Tunnel#connect(String, int)});
+     *     non-null
+     * @param port the target port; positive
+     */
+    public TunnelTransport(Tunnel tunnel, String host, int port) {
+        this.tunnel = Objects.requireNonNull(tunnel, "tunnel");
+        this.host = Objects.requireNonNull(host, "host");
+        if (port <= 0) {
+            throw new IllegalArgumentException("port must be positive: " + port);
+        }
+        this.port = port;
+        this.syntheticAddress = new TunnelSocketAddress(tunnel.type(), host, port);
+    }
+
+    @Override
+    public boolean requiresDomainNameResolution() {
+        // The host is logical (e.g. "crm.internal"); system DNS would fail. We resolve it
+        // by routing through the tunnel.
+        return false;
+    }
+
+    @Override
+    public SocketAddress getSocketAddress() {
+        return syntheticAddress;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void connect(SocketAddress socketAddress, Map<String, Object> context) {
+        Promise<Connection> promise =
+                (Promise<Connection>) context.get(ClientConnector.CONNECTION_PROMISE_CONTEXT_KEY);
+        try {
+            // 1) Dial through the tunnel.
+            AsynchronousSocketChannel zitiChannel = tunnel.connect(host, port);
+
+            // 2) Get the Jetty-side scheduler and create the in-memory pipe.
+            ClientConnector clientConnector =
+                    (ClientConnector) context.get(ClientConnector.CLIENT_CONNECTOR_CONTEXT_KEY);
+            MemoryEndPointPipe pipe = new MemoryEndPointPipe(
+                    clientConnector.getScheduler(), Runnable::run, syntheticAddress);
+
+            EndPoint localEndPoint = pipe.getLocalEndPoint();
+            EndPoint remoteEndPoint = pipe.getRemoteEndPoint();
+            localEndPoint.setIdleTimeout(clientConnector.getIdleTimeout().toMillis());
+
+            // 3) Build the Jetty Connection on the local endpoint.
+            Transport outerTransport = (Transport) context.get(Transport.class.getName());
+            Connection connection = outerTransport.newConnection(localEndPoint, context);
+            localEndPoint.setConnection(connection);
+
+            // 4) Start the byte pumps between the remote endpoint and the Ziti channel.
+            startPumps(remoteEndPoint, zitiChannel);
+
+            // 5) Open the endpoint / connection, then succeed the promise.
+            localEndPoint.onOpen();
+            connection.onOpen();
+            promise.succeeded(connection);
+        } catch (Throwable x) {
+            promise.failed(x);
+        }
+    }
+
+    /**
+     * Wires the in-memory pipe to the async Ziti channel via two iterating callbacks.
+     *
+     * <p>Package-private for testing.
+     */
+    static void startPumps(EndPoint remoteEndPoint, AsynchronousSocketChannel zitiChannel) {
+        // Jetty's remote endpoint → Ziti channel (request bytes).
+        EndPointToChannelPump outbound = new EndPointToChannelPump(remoteEndPoint, zitiChannel);
+        remoteEndPoint.fillInterested(Callback.from(outbound::iterate));
+
+        // Ziti channel → Jetty's remote endpoint (response bytes).
+        new ChannelToEndPointPump(zitiChannel, remoteEndPoint).start();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(System.identityHashCode(tunnel), host, port);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof TunnelTransport that)) {
+            return false;
+        }
+        return this.tunnel == that.tunnel
+                && this.port == that.port
+                && this.host.equals(that.host);
+    }
+
+    @Override
+    public String toString() {
+        return "TunnelTransport[" + tunnel.type() + "://" + host + ":" + port + "]";
+    }
+
+    /** Reads from the Jetty endpoint and writes to the Ziti channel. */
+    private static final class EndPointToChannelPump extends IteratingCallback {
+
+        private final EndPoint endPoint;
+        private final AsynchronousSocketChannel channel;
+        private final ByteBuffer buffer = BufferUtil.allocate(PUMP_BUFFER_BYTES);
+
+        EndPointToChannelPump(EndPoint endPoint, AsynchronousSocketChannel channel) {
+            this.endPoint = endPoint;
+            this.channel = channel;
+        }
+
+        @Override
+        protected Action process() throws Throwable {
+            BufferUtil.clearToFill(buffer);
+            int filled = endPoint.fill(buffer);
+            BufferUtil.flipToFlush(buffer, 0);
+            if (filled < 0) {
+                return Action.SUCCEEDED;
+            }
+            if (filled == 0) {
+                endPoint.fillInterested(Callback.from(this::iterate));
+                return Action.IDLE;
+            }
+            channel.write(buffer, this, new CompletionHandler<Integer, EndPointToChannelPump>() {
+                @Override
+                public void completed(Integer result, EndPointToChannelPump cb) {
+                    cb.succeeded();
+                }
+
+                @Override
+                public void failed(Throwable cause, EndPointToChannelPump cb) {
+                    cb.failed(cause);
+                }
+            });
+            return Action.SCHEDULED;
+        }
+
+        @Override
+        protected void onCompleteSuccess() {
+            closeQuietly(channel);
+        }
+
+        @Override
+        protected void onCompleteFailure(Throwable cause) {
+            closeQuietly(channel);
+            endPoint.close(cause);
+        }
+    }
+
+    /** Reads from the Ziti channel and writes to the Jetty endpoint. */
+    private static final class ChannelToEndPointPump
+            implements CompletionHandler<Integer, ByteBuffer> {
+
+        private final AsynchronousSocketChannel channel;
+        private final EndPoint endPoint;
+
+        ChannelToEndPointPump(AsynchronousSocketChannel channel, EndPoint endPoint) {
+            this.channel = channel;
+            this.endPoint = endPoint;
+        }
+
+        void start() {
+            ByteBuffer buf = ByteBuffer.allocate(PUMP_BUFFER_BYTES);
+            channel.read(buf, buf, this);
+        }
+
+        @Override
+        public void completed(Integer result, ByteBuffer buffer) {
+            if (result < 0) {
+                endPoint.shutdownOutput();
+                closeQuietly(channel);
+                return;
+            }
+            buffer.flip();
+            endPoint.write(
+                    Callback.from(
+                            () -> {
+                                ByteBuffer next = ByteBuffer.allocate(PUMP_BUFFER_BYTES);
+                                channel.read(next, next, this);
+                            },
+                            cause -> {
+                                closeQuietly(channel);
+                                endPoint.close(cause);
+                            }),
+                    buffer);
+        }
+
+        @Override
+        public void failed(Throwable cause, ByteBuffer buffer) {
+            closeQuietly(channel);
+            endPoint.close(cause);
+        }
+    }
+
+    private static void closeQuietly(AsynchronousSocketChannel channel) {
+        try {
+            channel.close();
+        } catch (IOException ignored) {
+            // best-effort
+        }
+    }
+
+    /**
+     * Synthetic {@link SocketAddress} used as Jetty's {@code remoteSocketAddress} for tunnelled
+     * connections. Its only purpose is to be unique per {@code (type, host, port)} triple so
+     * Jetty's connection pools partition correctly; it is never used to actually connect
+     * anywhere.
+     */
+    private static final class TunnelSocketAddress extends SocketAddress {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String type;
+        private final String host;
+        private final int port;
+
+        TunnelSocketAddress(String type, String host, int port) {
+            this.type = type;
+            this.host = host;
+            this.port = port;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(type, host, port);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof TunnelSocketAddress that)) {
+                return false;
+            }
+            return port == that.port
+                    && type.equals(that.type)
+                    && host.equals(that.host);
+        }
+
+        @Override
+        public String toString() {
+            return type + "://" + host + ":" + port;
+        }
+    }
+}

--- a/ikanos-engine/src/main/java/io/ikanos/engine/consumes/tunnel/package-info.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/consumes/tunnel/package-info.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Reverse-tunnel transport SPI for consumed HTTP APIs.
+ *
+ * <p>This package defines {@link io.ikanos.engine.consumes.tunnel.Tunnel}, the service-loader
+ * contract that lets the engine dial a private API through an overlay network (e.g. OpenZiti)
+ * instead of the public internet. Implementations are discovered via
+ * {@link java.util.ServiceLoader} at bootstrap and pooled by
+ * {@code (tunnel.type, tunnel.identity)}.
+ *
+ * <p>See the {@code blueprints/reverse-tunnel-private-network.md} blueprint, §6.3, for the
+ * original Architecture Decision Record and §6.4 for the revised Jetty-integration approach
+ * adopted in Phase 2: a per-request {@link org.eclipse.jetty.io.Transport} attached by a
+ * Jetty request listener, with byte pumping from the Ziti {@link
+ * java.nio.channels.AsynchronousSocketChannel} into a Jetty
+ * {@link org.eclipse.jetty.io.MemoryEndPointPipe}.
+ */
+package io.ikanos.engine.consumes.tunnel;

--- a/ikanos-engine/src/test/java/io/ikanos/engine/consumes/http/HttpClientAdapterTunnelTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/consumes/http/HttpClientAdapterTunnelTest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.consumes.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.ikanos.engine.consumes.tunnel.Tunnel;
+import io.ikanos.engine.consumes.tunnel.TunnelRouteTable;
+import io.ikanos.spec.consumes.http.HttpClientSpec;
+import io.ikanos.spec.consumes.http.tunnel.ZitiTunnelConfigSpec;
+import java.io.IOException;
+import java.nio.channels.AsynchronousSocketChannel;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class HttpClientAdapterTunnelTest {
+
+    @Test
+    void selectTunnelShouldReturnNullWhenSpecHasNoTunnel() {
+        HttpClientSpec spec = new HttpClientSpec("http", "https://api.example.com", null);
+        assertNull(HttpClientAdapter.selectTunnel(spec, Map.of("ziti", new FakeTunnel())));
+    }
+
+    @Test
+    void selectTunnelShouldReturnNullWhenTunnelsEmpty() {
+        HttpClientSpec spec = new HttpClientSpec("http", "https://api.example.com", null);
+        spec.setTunnel(new ZitiTunnelConfigSpec("crm-api", "/etc/ziti/app.json"));
+        assertNull(HttpClientAdapter.selectTunnel(spec, Map.of()));
+    }
+
+    @Test
+    void selectTunnelShouldReturnMatchingTunnelWhenTypeRegistered() {
+        HttpClientSpec spec = new HttpClientSpec("http", "https://api.example.com", null);
+        spec.setTunnel(new ZitiTunnelConfigSpec("crm-api", "/etc/ziti/app.json"));
+        Tunnel ziti = new FakeTunnel();
+        assertSame(ziti, HttpClientAdapter.selectTunnel(spec, Map.of("ziti", ziti)));
+    }
+
+    @Test
+    void selectTunnelShouldReturnNullWhenTypeNotRegistered() {
+        HttpClientSpec spec = new HttpClientSpec("http", "https://api.example.com", null);
+        spec.setTunnel(new ZitiTunnelConfigSpec("crm-api", "/etc/ziti/app.json"));
+        assertNull(HttpClientAdapter.selectTunnel(spec, Map.of("wireguard", new FakeTunnel())));
+    }
+
+    @Test
+    void extractHostShouldReturnHostnameWhenBaseUriValid() {
+        HttpClientSpec spec = new HttpClientSpec("http", "https://crm.internal:8443/api", null);
+        assertEquals("crm.internal", HttpClientAdapter.extractHost(spec));
+    }
+
+    @Test
+    void extractHostShouldThrowWhenBaseUriBlank() {
+        HttpClientSpec spec = new HttpClientSpec("http", "", null);
+        assertThrows(IllegalArgumentException.class, () -> HttpClientAdapter.extractHost(spec));
+    }
+
+    @Test
+    void extractHostShouldThrowWhenBaseUriHasNoHost() {
+        HttpClientSpec spec = new HttpClientSpec("http", "file:///etc/whatever", null);
+        assertThrows(IllegalArgumentException.class, () -> HttpClientAdapter.extractHost(spec));
+    }
+
+    @Test
+    void threeArgConstructorShouldBuildTunnelAwareClientWhenTunnelMatches() {
+        HttpClientSpec spec = new HttpClientSpec("http", "https://crm.internal/api", null);
+        spec.setTunnel(new ZitiTunnelConfigSpec("crm-api", "/etc/ziti/app.json"));
+
+        HttpClientAdapter adapter = new HttpClientAdapter(null, spec, Map.of("ziti", new FakeTunnel()));
+
+        assertNotNull(adapter.getHttpClient().getContext(),
+                "tunnel-routed client must carry a Restlet Context");
+        Object routes = adapter.getHttpClient().getContext().getAttributes()
+                .get(TunnelRouteTable.CONTEXT_ATTRIBUTE);
+        assertNotNull(routes, "route table must be installed on the context");
+        org.junit.jupiter.api.Assertions.assertInstanceOf(TunnelRouteTable.class, routes);
+        assertEquals(1, ((TunnelRouteTable) routes).size());
+        assertNotNull(((TunnelRouteTable) routes).lookup("crm.internal"));
+    }
+
+    @Test
+    void threeArgConstructorShouldBuildPlainClientWhenNoMatchingTunnel() {
+        HttpClientSpec spec = new HttpClientSpec("http", "https://api.example.com", null);
+        // No tunnel configured at all.
+        HttpClientAdapter adapter = new HttpClientAdapter(null, spec, Map.of());
+
+        assertNotNull(adapter.getHttpClient());
+        // No tunnel = no route table context attribute installed.
+        if (adapter.getHttpClient().getContext() != null) {
+            assertNull(adapter.getHttpClient().getContext().getAttributes()
+                    .get(TunnelRouteTable.CONTEXT_ATTRIBUTE));
+        }
+    }
+
+    @Test
+    void twoArgConstructorShouldRemainBackwardCompatible() {
+        // Existing tests rely on the 2-arg signature; this ensures it still works.
+        HttpClientSpec spec = new HttpClientSpec("http", "https://api.example.com", null);
+        HttpClientAdapter adapter = new HttpClientAdapter(null, spec);
+        assertNotNull(adapter.getHttpClient());
+    }
+
+    private static final class FakeTunnel implements Tunnel {
+        @Override
+        public String type() {
+            return "ziti";
+        }
+
+        @Override
+        public AsynchronousSocketChannel connect(String host, int port) throws IOException {
+            throw new IOException("fake tunnel — not dialable in unit tests");
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void close() {
+            // no-op
+        }
+    }
+}

--- a/ikanos-engine/src/test/java/io/ikanos/engine/consumes/http/HttpClientAdapterTunnelTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/consumes/http/HttpClientAdapterTunnelTest.java
@@ -83,14 +83,13 @@ class HttpClientAdapterTunnelTest {
 
         HttpClientAdapter adapter = new HttpClientAdapter(null, spec, Map.of("ziti", new FakeTunnel()));
 
-        assertNotNull(adapter.getHttpClient().getContext(),
-                "tunnel-routed client must carry a Restlet Context");
-        Object routes = adapter.getHttpClient().getContext().getAttributes()
-                .get(TunnelRouteTable.CONTEXT_ATTRIBUTE);
-        assertNotNull(routes, "route table must be installed on the context");
-        org.junit.jupiter.api.Assertions.assertInstanceOf(TunnelRouteTable.class, routes);
-        assertEquals(1, ((TunnelRouteTable) routes).size());
-        assertNotNull(((TunnelRouteTable) routes).lookup("crm.internal"));
+        // Use the package-private test helper instead of reaching through the Restlet
+        // Context / attributes API: a future refactor that changes how the route table is
+        // stored only needs to update tunnelRouteTable(), not every assertion here.
+        TunnelRouteTable routes = adapter.tunnelRouteTable();
+        assertNotNull(routes, "tunnel-routed adapter must expose a route table");
+        assertEquals(1, routes.size());
+        assertNotNull(routes.lookup("crm.internal"));
     }
 
     @Test
@@ -100,11 +99,8 @@ class HttpClientAdapterTunnelTest {
         HttpClientAdapter adapter = new HttpClientAdapter(null, spec, Map.of());
 
         assertNotNull(adapter.getHttpClient());
-        // No tunnel = no route table context attribute installed.
-        if (adapter.getHttpClient().getContext() != null) {
-            assertNull(adapter.getHttpClient().getContext().getAttributes()
-                    .get(TunnelRouteTable.CONTEXT_ATTRIBUTE));
-        }
+        // Non-tunnel-routed adapter must not expose a route table.
+        assertNull(adapter.tunnelRouteTable());
     }
 
     @Test
@@ -113,6 +109,7 @@ class HttpClientAdapterTunnelTest {
         HttpClientSpec spec = new HttpClientSpec("http", "https://api.example.com", null);
         HttpClientAdapter adapter = new HttpClientAdapter(null, spec);
         assertNotNull(adapter.getHttpClient());
+        assertNull(adapter.tunnelRouteTable());
     }
 
     private static final class FakeTunnel implements Tunnel {

--- a/ikanos-engine/src/test/java/io/ikanos/engine/consumes/http/TunnelAwareHttpClientHelperTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/consumes/http/TunnelAwareHttpClientHelperTest.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.consumes.http;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import io.ikanos.engine.consumes.tunnel.Tunnel;
+import io.ikanos.engine.consumes.tunnel.TunnelRouteTable;
+import io.ikanos.engine.consumes.tunnel.TunnelTransport;
+import java.io.IOException;
+import java.nio.channels.AsynchronousSocketChannel;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.Request;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.restlet.Client;
+import org.restlet.Context;
+
+class TunnelAwareHttpClientHelperTest {
+
+    private HttpClient jettyClient;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // We need a Jetty HttpClient just to build Requests for inspection. Don't start it.
+        jettyClient = new HttpClient();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (jettyClient != null && jettyClient.isStarted()) {
+            jettyClient.stop();
+        }
+    }
+
+    @Test
+    void readRouteTableShouldReturnNullWhenContextMissing() {
+        Client restletClient = new Client((Context) null, java.util.List.of());
+        TunnelAwareHttpClientHelper helper = new TunnelAwareHttpClientHelper(restletClient);
+        assertNull(helper.readRouteTable());
+    }
+
+    @Test
+    void readRouteTableShouldReturnTableWhenContextAttributeSet() {
+        Context context = new Context();
+        TunnelRouteTable table = new TunnelRouteTable();
+        context.getAttributes().put(TunnelRouteTable.CONTEXT_ATTRIBUTE, table);
+        Client restletClient = new Client(context, java.util.List.of());
+
+        TunnelAwareHttpClientHelper helper = new TunnelAwareHttpClientHelper(restletClient);
+        assertSame(table, helper.readRouteTable());
+    }
+
+    @Test
+    void readRouteTableShouldReturnNullWhenAttributeWrongType() {
+        Context context = new Context();
+        context.getAttributes().put(TunnelRouteTable.CONTEXT_ATTRIBUTE, "not a table");
+        Client restletClient = new Client(context, java.util.List.of());
+
+        TunnelAwareHttpClientHelper helper = new TunnelAwareHttpClientHelper(restletClient);
+        assertNull(helper.readRouteTable());
+    }
+
+    @Test
+    void applyTunnelTransportShouldAttachTransportWhenHostRegistered() {
+        TunnelRouteTable table = new TunnelRouteTable();
+        Tunnel tunnel = new FakeTunnel();
+        table.register("crm.internal", tunnel);
+
+        Request request = jettyClient.newRequest("http://crm.internal:8080/users");
+        TunnelAwareHttpClientHelper.applyTunnelTransport(request, table);
+
+        assertNotNull(request.getTransport());
+        // Attached transport must be a TunnelTransport routed through the tunnel above.
+        org.junit.jupiter.api.Assertions.assertInstanceOf(
+                TunnelTransport.class, request.getTransport());
+    }
+
+    @Test
+    void applyTunnelTransportShouldLeaveRequestUnchangedWhenHostNotRegistered() {
+        TunnelRouteTable table = new TunnelRouteTable();
+        table.register("crm.internal", new FakeTunnel());
+
+        Request request = jettyClient.newRequest("http://public.example.com:80/items");
+        // Capture pre-state transport (default = null, falls back to ClientConnector path).
+        Object preTransport = request.getTransport();
+        TunnelAwareHttpClientHelper.applyTunnelTransport(request, table);
+
+        // Post-state should be identical — no tunnel for this host.
+        org.junit.jupiter.api.Assertions.assertEquals(preTransport, request.getTransport());
+    }
+
+    private static final class FakeTunnel implements Tunnel {
+        @Override
+        public String type() {
+            return "fake";
+        }
+
+        @Override
+        public AsynchronousSocketChannel connect(String host, int port) throws IOException {
+            throw new IOException("fake tunnel — not dialable in unit tests");
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void close() {
+            // no-op
+        }
+    }
+}

--- a/ikanos-engine/src/test/java/io/ikanos/engine/consumes/tunnel/TestServiceLoaderFakeTunnel.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/consumes/tunnel/TestServiceLoaderFakeTunnel.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.consumes.tunnel;
+
+import java.io.IOException;
+import java.nio.channels.AsynchronousSocketChannel;
+
+/**
+ * Test-only {@link Tunnel} ServiceLoader provider so {@link TunnelBootstrap} can be exercised
+ * end-to-end (including ServiceLoader discovery) without depending on the
+ * {@code ikanos-tunnel-ziti} runtime module from engine unit tests.
+ *
+ * <p>The {@code META-INF/services/io.ikanos.engine.consumes.tunnel.Tunnel} descriptor under
+ * {@code src/test/resources} wires this class; it never appears in the production jar.
+ */
+public class TestServiceLoaderFakeTunnel implements Tunnel {
+
+    @Override
+    public String type() {
+        return "ziti";
+    }
+
+    @Override
+    public AsynchronousSocketChannel connect(String host, int port) throws IOException {
+        throw new IOException("test fake tunnel — not dialable");
+    }
+
+    @Override
+    public boolean isReady() {
+        return true;
+    }
+
+    @Override
+    public void close() {
+        // no-op
+    }
+}

--- a/ikanos-engine/src/test/java/io/ikanos/engine/consumes/tunnel/TunnelBootstrapTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/consumes/tunnel/TunnelBootstrapTest.java
@@ -65,6 +65,20 @@ class TunnelBootstrapTest {
     }
 
     @Test
+    void resolveIdentityShouldThrowWhenMustacheBindingShapeIsFlat() {
+        // Flat-map mistake: the template references the "secrets" namespace, but the
+        // caller passes a flat map. Resolver leaves "{{secrets.IDENT}}" unresolved, and
+        // resolveIdentity must fail fast instead of silently propagating the literal.
+        ZitiTunnelConfigSpec spec = new ZitiTunnelConfigSpec("crm-api", "{{secrets.IDENT}}");
+        IllegalStateException ex = assertThrows(
+                IllegalStateException.class,
+                () -> TunnelBootstrap.resolveIdentity(
+                        spec, Map.of("IDENT", "/etc/ziti/app.json")));
+        assertTrue(ex.getMessage().contains("{{secrets.IDENT}}"),
+                "exception should echo the unresolved Mustache template");
+    }
+
+    @Test
     void loadTunnelShouldThrowWhenTypeUnknown() {
         IllegalStateException ex = assertThrows(
                 IllegalStateException.class,

--- a/ikanos-engine/src/test/java/io/ikanos/engine/consumes/tunnel/TunnelBootstrapTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/consumes/tunnel/TunnelBootstrapTest.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.consumes.tunnel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.ikanos.spec.consumes.ClientSpec;
+import io.ikanos.spec.consumes.http.HttpClientSpec;
+import io.ikanos.spec.consumes.http.tunnel.ZitiTunnelConfigSpec;
+import java.io.IOException;
+import java.nio.channels.AsynchronousSocketChannel;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class TunnelBootstrapTest {
+
+    @Test
+    void discoverAndStartShouldReturnEmptyMapWhenNoTunnelsConfigured() {
+        HttpClientSpec spec = new HttpClientSpec("http", "https://api.example.com", null);
+        Map<String, Tunnel> tunnels = TunnelBootstrap.discoverAndStart(
+                List.<ClientSpec>of(spec), Duration.ofSeconds(1));
+        assertTrue(tunnels.isEmpty());
+    }
+
+    @Test
+    void discoverAndStartShouldReturnEmptyMapWhenClientSpecsNull() {
+        Map<String, Tunnel> tunnels = TunnelBootstrap.discoverAndStart(null, Duration.ofSeconds(1));
+        assertTrue(tunnels.isEmpty());
+    }
+
+    @Test
+    void resolveIdentityShouldResolveMustacheTemplateWhenBindingsProvided() {
+        ZitiTunnelConfigSpec spec = new ZitiTunnelConfigSpec("crm-api", "{{secrets.IDENT}}");
+        String resolved = TunnelBootstrap.resolveIdentity(
+                spec, Map.of("secrets", Map.of("IDENT", "/etc/ziti/app.json")));
+        assertEquals("/etc/ziti/app.json", resolved);
+    }
+
+    @Test
+    void resolveIdentityShouldReturnNullWhenIdentityBlank() {
+        ZitiTunnelConfigSpec spec = new ZitiTunnelConfigSpec("crm-api", "  ");
+        assertNull(TunnelBootstrap.resolveIdentity(spec, Map.of()));
+    }
+
+    @Test
+    void resolveIdentityShouldReturnRawWhenBindingsEmpty() {
+        ZitiTunnelConfigSpec spec = new ZitiTunnelConfigSpec("crm-api", "/etc/ziti/app.json");
+        assertEquals("/etc/ziti/app.json", TunnelBootstrap.resolveIdentity(spec, Map.of()));
+    }
+
+    @Test
+    void loadTunnelShouldThrowWhenTypeUnknown() {
+        IllegalStateException ex = assertThrows(
+                IllegalStateException.class,
+                () -> TunnelBootstrap.loadTunnel("does-not-exist"));
+        assertTrue(ex.getMessage().contains("does-not-exist"),
+                "message should mention the missing type");
+    }
+
+    @Test
+    void waitReadyShouldReturnImmediatelyWhenTimeoutZero() {
+        // never-ready tunnel; zero timeout means "don't gate" per the contract
+        TunnelBootstrap.waitReady(new NeverReadyTunnel(), Duration.ZERO);
+    }
+
+    @Test
+    void waitReadyShouldThrowWhenTunnelNotReadyWithinTimeout() {
+        assertThrows(
+                IllegalStateException.class,
+                () -> TunnelBootstrap.waitReady(
+                        new NeverReadyTunnel(), Duration.ofMillis(200)));
+    }
+
+    @Test
+    void discoverAndStartShouldRejectConflictingIdentitiesForSameType() {
+        ZitiTunnelConfigSpec a = new ZitiTunnelConfigSpec("svc-a", "/etc/ziti/a.json");
+        ZitiTunnelConfigSpec b = new ZitiTunnelConfigSpec("svc-b", "/etc/ziti/b.json");
+        HttpClientSpec specA = new HttpClientSpec("http", "https://a.example.com", null);
+        specA.setTunnel(a);
+        HttpClientSpec specB = new HttpClientSpec("http", "https://b.example.com", null);
+        specB.setTunnel(b);
+
+        IllegalStateException ex = assertThrows(
+                IllegalStateException.class,
+                () -> TunnelBootstrap.discoverAndStart(
+                        List.<ClientSpec>of(specA, specB), Duration.ZERO));
+        assertTrue(ex.getMessage().contains("identities"),
+                "message should mention the conflict");
+    }
+
+    private static final class NeverReadyTunnel implements Tunnel {
+        @Override
+        public String type() {
+            return "never-ready";
+        }
+
+        @Override
+        public AsynchronousSocketChannel connect(String host, int port) throws IOException {
+            throw new IOException("not ready");
+        }
+
+        @Override
+        public boolean isReady() {
+            return false;
+        }
+
+        @Override
+        public void close() {
+            // no-op
+        }
+    }
+}

--- a/ikanos-engine/src/test/java/io/ikanos/engine/consumes/tunnel/TunnelRouteTableTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/consumes/tunnel/TunnelRouteTableTest.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.consumes.tunnel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.channels.AsynchronousSocketChannel;
+import org.junit.jupiter.api.Test;
+
+class TunnelRouteTableTest {
+
+    @Test
+    void lookupShouldReturnNullWhenHostNotRegistered() {
+        TunnelRouteTable table = new TunnelRouteTable();
+        assertNull(table.lookup("crm.internal"));
+        assertTrue(table.isEmpty());
+        assertEquals(0, table.size());
+    }
+
+    @Test
+    void lookupShouldReturnTunnelWhenHostRegistered() {
+        TunnelRouteTable table = new TunnelRouteTable();
+        Tunnel tunnel = new FakeTunnel();
+        table.register("crm.internal", tunnel);
+
+        assertSame(tunnel, table.lookup("crm.internal"));
+        assertFalse(table.isEmpty());
+        assertEquals(1, table.size());
+    }
+
+    @Test
+    void lookupShouldBeCaseInsensitiveWhenHostRegisteredInMixedCase() {
+        TunnelRouteTable table = new TunnelRouteTable();
+        Tunnel tunnel = new FakeTunnel();
+        table.register("CRM.Internal", tunnel);
+
+        assertSame(tunnel, table.lookup("crm.internal"));
+        assertSame(tunnel, table.lookup("CRM.INTERNAL"));
+        assertSame(tunnel, table.lookup("crm.INTERNAL"));
+    }
+
+    @Test
+    void registerShouldRejectNullHostWhenInvoked() {
+        TunnelRouteTable table = new TunnelRouteTable();
+        Tunnel tunnel = new FakeTunnel();
+        assertThrows(NullPointerException.class, () -> table.register(null, tunnel));
+    }
+
+    @Test
+    void registerShouldRejectNullTunnelWhenInvoked() {
+        TunnelRouteTable table = new TunnelRouteTable();
+        assertThrows(NullPointerException.class, () -> table.register("crm.internal", null));
+    }
+
+    @Test
+    void lookupShouldHandleNullHostWhenInvoked() {
+        TunnelRouteTable table = new TunnelRouteTable();
+        // Null host = direct route, must not blow up.
+        assertNull(table.lookup(null));
+    }
+
+    /** Minimal in-process Tunnel used purely as a sentinel reference. */
+    private static final class FakeTunnel implements Tunnel {
+        @Override
+        public String type() {
+            return "fake";
+        }
+
+        @Override
+        public AsynchronousSocketChannel connect(String host, int port) throws IOException {
+            throw new IOException("fake tunnel — not dialable");
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void close() {
+            // no-op
+        }
+    }
+}

--- a/ikanos-engine/src/test/java/io/ikanos/engine/consumes/tunnel/TunnelTransportTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/consumes/tunnel/TunnelTransportTest.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.consumes.tunnel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.channels.AsynchronousSocketChannel;
+import org.junit.jupiter.api.Test;
+
+class TunnelTransportTest {
+
+    @Test
+    void constructorShouldRejectNullTunnel() {
+        assertThrows(
+                NullPointerException.class,
+                () -> new TunnelTransport(null, "crm.internal", 8080));
+    }
+
+    @Test
+    void constructorShouldRejectNullHost() {
+        assertThrows(
+                NullPointerException.class,
+                () -> new TunnelTransport(new FakeTunnel(), null, 8080));
+    }
+
+    @Test
+    void constructorShouldRejectNonPositivePort() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new TunnelTransport(new FakeTunnel(), "crm.internal", 0));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new TunnelTransport(new FakeTunnel(), "crm.internal", -1));
+    }
+
+    @Test
+    void requiresDomainNameResolutionShouldReturnFalseAlways() {
+        TunnelTransport transport = new TunnelTransport(new FakeTunnel(), "crm.internal", 8080);
+        assertFalse(transport.requiresDomainNameResolution());
+    }
+
+    @Test
+    void getSocketAddressShouldReturnSyntheticAddressTaggedByTunnelType() {
+        TunnelTransport transport = new TunnelTransport(new FakeTunnel(), "crm.internal", 8080);
+        assertNotNull(transport.getSocketAddress());
+        assertTrue(transport.getSocketAddress().toString().contains("crm.internal"));
+        assertTrue(transport.getSocketAddress().toString().contains("fake"));
+        assertTrue(transport.getSocketAddress().toString().contains("8080"));
+    }
+
+    @Test
+    void equalsShouldPartitionPoolsByTunnelHostAndPort() {
+        Tunnel tunnelA = new FakeTunnel();
+        Tunnel tunnelB = new FakeTunnel();
+
+        TunnelTransport sameA = new TunnelTransport(tunnelA, "crm.internal", 8080);
+        TunnelTransport sameAClone = new TunnelTransport(tunnelA, "crm.internal", 8080);
+        TunnelTransport differentTunnel = new TunnelTransport(tunnelB, "crm.internal", 8080);
+        TunnelTransport differentHost = new TunnelTransport(tunnelA, "erp.internal", 8080);
+        TunnelTransport differentPort = new TunnelTransport(tunnelA, "crm.internal", 9090);
+
+        assertEquals(sameA, sameAClone);
+        assertEquals(sameA.hashCode(), sameAClone.hashCode());
+
+        assertNotEquals(sameA, differentTunnel);
+        assertNotEquals(sameA, differentHost);
+        assertNotEquals(sameA, differentPort);
+        assertNotEquals(sameA, "not a TunnelTransport");
+    }
+
+    @Test
+    void toStringShouldIncludeTypeHostAndPort() {
+        TunnelTransport transport = new TunnelTransport(new FakeTunnel(), "crm.internal", 8080);
+        assertEquals("TunnelTransport[fake://crm.internal:8080]", transport.toString());
+    }
+
+    private static final class FakeTunnel implements Tunnel {
+        @Override
+        public String type() {
+            return "fake";
+        }
+
+        @Override
+        public AsynchronousSocketChannel connect(String host, int port) throws IOException {
+            throw new IOException("fake tunnel — not dialable in unit tests");
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void close() {
+            // no-op
+        }
+    }
+}

--- a/ikanos-engine/src/test/resources/META-INF/services/io.ikanos.engine.consumes.tunnel.Tunnel
+++ b/ikanos-engine/src/test/resources/META-INF/services/io.ikanos.engine.consumes.tunnel.Tunnel
@@ -1,0 +1,1 @@
+io.ikanos.engine.consumes.tunnel.TestServiceLoaderFakeTunnel

--- a/ikanos-tunnel-ziti/pom.xml
+++ b/ikanos-tunnel-ziti/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.ikanos</groupId>
+        <artifactId>ikanos-parent</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>ikanos-tunnel-ziti</artifactId>
+    <name>Ikanos Tunnel — OpenZiti</name>
+    <description>OpenZiti implementation of the Ikanos reverse-tunnel SPI. Drop this jar on the classpath to enable type=ziti tunnels declared in capability YAML (blueprint reverse-tunnel-private-network).</description>
+
+    <dependencies>
+        <!-- SPI we implement -->
+        <dependency>
+            <groupId>io.ikanos</groupId>
+            <artifactId>ikanos-engine</artifactId>
+        </dependency>
+
+        <!-- OpenZiti SDK -->
+        <dependency>
+            <groupId>org.openziti</groupId>
+            <artifactId>ziti</artifactId>
+        </dependency>
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/ikanos-tunnel-ziti/src/main/java/io/ikanos/tunnel/ziti/ZitiTunnel.java
+++ b/ikanos-tunnel-ziti/src/main/java/io/ikanos/tunnel/ziti/ZitiTunnel.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.tunnel.ziti;
+
+import io.ikanos.engine.consumes.tunnel.Tunnel;
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.channels.AsynchronousSocketChannel;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.openziti.Ziti;
+import org.openziti.ZitiContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link Tunnel} implementation backed by the OpenZiti SDK ({@code org.openziti:ziti:0.33.1}).
+ *
+ * <p>This class is wired through {@link java.util.ServiceLoader} via the descriptor file
+ * {@code META-INF/services/io.ikanos.engine.consumes.tunnel.Tunnel}. It MUST therefore expose
+ * a public no-arg constructor — per-deployment configuration is read from system properties
+ * set by {@code TunnelBootstrap}.
+ *
+ * <h2>Configuration</h2>
+ *
+ * <p>System property {@code ikanos.tunnel.ziti.identity} — REQUIRED. Filesystem path to a
+ * Ziti identity file (JSON or PFX). Set by {@code TunnelBootstrap.discoverAndStart} from the
+ * Mustache-resolved value of {@code consumes.http.tunnel.identity} in the capability YAML.
+ *
+ * <h2>Threading and lifecycle</h2>
+ *
+ * <p>The {@link ZitiContext} is created lazily on first {@link #connect(String, int)} or
+ * {@link #isReady()} call (to keep the no-arg constructor side-effect-free for
+ * {@link java.util.ServiceLoader} discovery). It is single-instance per JVM/per capability —
+ * tunnel pooling at the engine level guarantees only one provider per type per capability.
+ */
+public class ZitiTunnel implements Tunnel {
+
+    /**
+     * System-property key the engine uses to pass the resolved Ziti identity file path. See
+     * {@code io.ikanos.engine.consumes.tunnel.TunnelBootstrap}.
+     */
+    public static final String IDENTITY_PROPERTY = "ikanos.tunnel.ziti.identity";
+
+    private static final Logger LOG = LoggerFactory.getLogger(ZitiTunnel.class);
+    private static final String TYPE = "ziti";
+    private static final long DIAL_TIMEOUT_SECONDS = 10L;
+
+    private final Object contextLock = new Object();
+    private volatile ZitiContext context;
+
+    /** Public no-arg constructor required by {@link java.util.ServiceLoader}. */
+    public ZitiTunnel() {
+        // lazy init — see contextRef
+    }
+
+    @Override
+    public String type() {
+        return TYPE;
+    }
+
+    @Override
+    public AsynchronousSocketChannel connect(String host, int port) throws IOException {
+        ZitiContext ctx = ensureContext();
+        AsynchronousSocketChannel channel = ctx.open();
+        try {
+            // The OpenZiti SDK's AsynchronousSocketChannel maps an unresolved host:port to a
+            // configured intercept service on the Ziti controller. No DNS lookup is performed
+            // for the host portion — that's the whole point of the overlay.
+            channel
+                    .connect(InetSocketAddress.createUnresolved(host, port))
+                    .get(DIAL_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            return channel;
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            closeQuietly(channel);
+            throw new IOException("Interrupted dialing Ziti for " + host + ":" + port, ie);
+        } catch (TimeoutException te) {
+            closeQuietly(channel);
+            throw new IOException(
+                    "Timed out dialing Ziti for " + host + ":" + port + " after "
+                            + DIAL_TIMEOUT_SECONDS + "s",
+                    te);
+        } catch (java.util.concurrent.ExecutionException ee) {
+            closeQuietly(channel);
+            Throwable cause = ee.getCause() != null ? ee.getCause() : ee;
+            throw new IOException("Ziti dial failed for " + host + ":" + port, cause);
+        }
+    }
+
+    @Override
+    public boolean isReady() {
+        try {
+            ZitiContext ctx = ensureContext();
+            return ctx.getStatus() == ZitiContext.Status.Active.INSTANCE;
+        } catch (IOException ex) {
+            LOG.debug("Ziti context not ready: {}", ex.getMessage());
+            return false;
+        }
+    }
+
+    @Override
+    public void close() {
+        ZitiContext ctx;
+        synchronized (contextLock) {
+            ctx = this.context;
+            this.context = null;
+        }
+        if (ctx != null) {
+            try {
+                ctx.destroy();
+            } catch (RuntimeException ex) {
+                LOG.warn("Error destroying Ziti context", ex);
+            }
+        }
+    }
+
+    /**
+     * Package-private for testing. Lazily creates the {@link ZitiContext} from the identity
+     * file referenced by {@link #IDENTITY_PROPERTY}.
+     */
+    ZitiContext ensureContext() throws IOException {
+        ZitiContext local = this.context;
+        if (local != null) {
+            return local;
+        }
+        synchronized (contextLock) {
+            if (this.context != null) {
+                return this.context;
+            }
+            String identityPath = System.getProperty(IDENTITY_PROPERTY);
+            if (identityPath == null || identityPath.isBlank()) {
+                throw new IOException(
+                        "System property '" + IDENTITY_PROPERTY
+                                + "' is not set. The Ikanos engine sets this from"
+                                + " consumes.http.tunnel.identity before loading the Ziti tunnel.");
+            }
+            File identityFile = new File(identityPath);
+            if (!identityFile.isFile()) {
+                throw new IOException(
+                        "Ziti identity file not found: " + identityFile.getAbsolutePath());
+            }
+            try {
+                this.context = Ziti.newContext(identityFile, new char[0]);
+                LOG.info("Ziti tunnel initialised with identity {}", identityFile.getName());
+                return this.context;
+            } catch (RuntimeException ex) {
+                throw new IOException(
+                        "Failed to initialise Ziti context from " + identityFile.getAbsolutePath(),
+                        ex);
+            }
+        }
+    }
+
+    private static void closeQuietly(AsynchronousSocketChannel channel) {
+        try {
+            channel.close();
+        } catch (IOException ignored) {
+            // best-effort cleanup
+        }
+    }
+}

--- a/ikanos-tunnel-ziti/src/main/java/io/ikanos/tunnel/ziti/package-info.java
+++ b/ikanos-tunnel-ziti/src/main/java/io/ikanos/tunnel/ziti/package-info.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+/**
+ * OpenZiti implementation of the Ikanos {@code Tunnel} SPI.
+ *
+ * <p>This package contains a single {@link io.ikanos.tunnel.ziti.ZitiTunnel} class that is
+ * discovered by {@link java.util.ServiceLoader} at engine bootstrap via the descriptor file
+ * at {@code META-INF/services/io.ikanos.engine.consumes.tunnel.Tunnel}. The tunnel reads its
+ * identity (a path to a Ziti JWT/PFX/JSON identity file) from the system property
+ * {@code ikanos.tunnel.ziti.identity}, set by
+ * {@link io.ikanos.engine.consumes.tunnel.TunnelBootstrap} after resolving the
+ * {@code tunnel.identity} Mustache expression against the capability's bindings.
+ *
+ * <p>The blueprint design ({@code blueprints/reverse-tunnel-private-network.md} §6.5) calls
+ * for one {@code ZitiContext} per identity; Phase 2 supports a single identity per
+ * capability, which is the canonical deployment shape today and avoids the contention of
+ * multi-identity boot during the first release window.
+ *
+ * <p>End-to-end mTLS, posture checks, and service authorization are handled by the Ziti
+ * controller-side configuration; application-layer authentication declared on the
+ * {@code consumes.http} block runs unchanged on top.
+ */
+package io.ikanos.tunnel.ziti;

--- a/ikanos-tunnel-ziti/src/main/resources/META-INF/services/io.ikanos.engine.consumes.tunnel.Tunnel
+++ b/ikanos-tunnel-ziti/src/main/resources/META-INF/services/io.ikanos.engine.consumes.tunnel.Tunnel
@@ -1,0 +1,1 @@
+io.ikanos.tunnel.ziti.ZitiTunnel

--- a/ikanos-tunnel-ziti/src/test/java/io/ikanos/tunnel/ziti/ZitiTunnelTest.java
+++ b/ikanos-tunnel-ziti/src/test/java/io/ikanos/tunnel/ziti/ZitiTunnelTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.tunnel.ziti;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.ikanos.engine.consumes.tunnel.Tunnel;
+import java.io.IOException;
+import java.util.ServiceLoader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ZitiTunnelTest {
+
+    private String previousIdentity;
+
+    @BeforeEach
+    void clearIdentityProperty() {
+        previousIdentity = System.clearProperty(ZitiTunnel.IDENTITY_PROPERTY);
+    }
+
+    @AfterEach
+    void restoreIdentityProperty() {
+        if (previousIdentity == null) {
+            System.clearProperty(ZitiTunnel.IDENTITY_PROPERTY);
+        } else {
+            System.setProperty(ZitiTunnel.IDENTITY_PROPERTY, previousIdentity);
+        }
+    }
+
+    @Test
+    void typeShouldReturnZitiAlways() {
+        assertEquals("ziti", new ZitiTunnel().type());
+    }
+
+    @Test
+    void noArgConstructorShouldBeAvailableForServiceLoader() {
+        // ServiceLoader requires a public no-arg constructor; assert nothing thrown.
+        assertNotNull(new ZitiTunnel());
+    }
+
+    @Test
+    void serviceLoaderShouldDiscoverZitiTunnelProvider() {
+        boolean found = false;
+        for (Tunnel candidate : ServiceLoader.load(Tunnel.class)) {
+            if ("ziti".equals(candidate.type())) {
+                found = true;
+                break;
+            }
+        }
+        assertTrue(found, "ZitiTunnel must be discoverable via ServiceLoader<Tunnel>");
+    }
+
+    @Test
+    void ensureContextShouldThrowWhenIdentityPropertyMissing() {
+        ZitiTunnel tunnel = new ZitiTunnel();
+        IOException ex = assertThrows(IOException.class, tunnel::ensureContext);
+        assertTrue(ex.getMessage().contains(ZitiTunnel.IDENTITY_PROPERTY));
+    }
+
+    @Test
+    void ensureContextShouldThrowWhenIdentityFileMissing() {
+        System.setProperty(ZitiTunnel.IDENTITY_PROPERTY, "/this/file/definitely/does/not/exist.json");
+        ZitiTunnel tunnel = new ZitiTunnel();
+        IOException ex = assertThrows(IOException.class, tunnel::ensureContext);
+        assertTrue(ex.getMessage().contains("not found"));
+    }
+
+    @Test
+    void isReadyShouldReturnFalseWhenContextCannotBeInitialised() {
+        // No identity → ensureContext fails → isReady catches and returns false.
+        ZitiTunnel tunnel = new ZitiTunnel();
+        assertFalse(tunnel.isReady());
+    }
+
+    @Test
+    void closeShouldBeIdempotentWhenContextNeverInitialised() {
+        ZitiTunnel tunnel = new ZitiTunnel();
+        // Two closes without an initialised context must not throw.
+        tunnel.close();
+        tunnel.close();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,19 @@
         <module>ikanos-cli</module>
         <module>ikanos-docs</module>
         <module>ikanos-coverage</module>
+        <!--
+          ikanos-tunnel-ziti is a reactor module so it compiles, tests, and releases with
+          the rest of the build, but it is NOT a transitive dependency of ikanos-cli (the
+          CLI only depends on ikanos-engine, which discovers Tunnel SPI providers at
+          runtime via java.util.ServiceLoader). Consequently:
+          - The "native" profile in ikanos-cli/pom.xml shades only the CLI's transitive
+            dependencies into cli-native.jar, so ikanos-tunnel-ziti and the OpenZiti SDK
+            do not enter the GraalVM native-image step and cannot break it.
+          - A future deployment that DOES want OpenZiti inside the native binary would
+            need to add ikanos-tunnel-ziti as a runtime dependency of ikanos-cli AND
+            register the appropriate reflect-config.json / proxy-config.json under
+            META-INF/native-image/ for the OpenZiti SDK's reflective/proxy use sites.
+        -->
         <module>ikanos-tunnel-ziti</module>
     </modules>
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <module>ikanos-cli</module>
         <module>ikanos-docs</module>
         <module>ikanos-coverage</module>
+        <module>ikanos-tunnel-ziti</module>
     </modules>
 
     <properties>
@@ -75,6 +76,7 @@
         <opentelemetry.version>1.48.0</opentelemetry.version>
         <graalvm.polyglot.version>24.1.1</graalvm.polyglot.version>
         <groovy.version>4.0.24</groovy.version>
+        <openziti.version>0.33.1</openziti.version>
         <revision>1.0.0-alpha3-SNAPSHOT</revision>
         <!--
           JaCoCo coverage gate (Phase A of the 100 % coverage plan, epic #445).
@@ -119,6 +121,11 @@
                 <groupId>io.ikanos</groupId>
                 <artifactId>ikanos-engine</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.openziti</groupId>
+                <artifactId>ziti</artifactId>
+                <version>${openziti.version}</version>
             </dependency>
 
             <!-- CLI -->


### PR DESCRIPTION
## Summary

Phase 2 of the reverse-tunnel blueprint (`blueprints/reverse-tunnel-private-network.md`).
Wires the Phase 0/1 spec model to a working runtime by adding an engine-side tunnel SPI, a Jetty `Transport` bridge that lets the existing HTTP client speak to private services, a bootstrap that resolves identities and starts tunnels alongside the capability, and a real OpenZiti implementation packaged in a new optional module.

Closes #514.

> ⚠️ **Stacked on PR #513** (`feat/reverse-tunnel-phases-0-1`). Please merge #513 first; this PR targets that branch and only contains the Phase 2 delta.

## What's in this PR

### `ikanos-engine` — tunnel SPI & wiring

| Type | Class | Purpose |
| --- | --- | --- |
| New | `io.ikanos.engine.consumes.tunnel.Tunnel` | `AutoCloseable` SPI (`type()`, `connect(host, port) → AsynchronousSocketChannel`, `isReady()`). Loaded via `java.util.ServiceLoader`. |
| New | `TunnelRouteTable` | Case-insensitive host → `Tunnel` map exposed on the Restlet context. |
| New | `TunnelTransport` | Jetty 12 `org.eclipse.jetty.io.Transport`. Dials the tunnel via `AsynchronousSocketChannel`, bridges to Jetty NIO with `MemoryEndPointPipe`, and pumps bytes both ways. |
| New | `TunnelBootstrap` | Resolves identity templates with `Resolver.resolveMustacheTemplate`, publishes a per-type system property, `ServiceLoader`-loads the implementation, polls readiness, and rejects conflicting identities for the same tunnel type. |
| New | `TunnelAwareHttpClientHelper` | Subclass of `HttpClientHelper` that adds a queued listener selecting a `TunnelTransport` when the target host matches the route table. |
| Modified | `HttpClientAdapter` | New 3-arg constructor accepting `Map<String, Tunnel>`. Legacy 2-arg constructor preserved (delegates with `Map.of()`). |
| Modified | `Capability` | Calls `TunnelBootstrap.discoverAndStart(consumes, 30 s, bindings)` before instantiating consumes adapters and threads the result to `HttpClientAdapter`. |

### `ikanos-tunnel-ziti` — new module (optional vendor implementation)

* `io.ikanos.tunnel.ziti.ZitiTunnel` — real OpenZiti SDK (`org.openziti:ziti:0.33.1`, Apache 2.0) implementation. Lazily creates a `ZitiContext` from the identity JSON pointed to by the `ikanos.tunnel.ziti.identity` system property, opens an `AsynchronousSocketChannel` per `connect`, and exposes readiness via `ZitiContext.Status.Active`.
* `META-INF/services/io.ikanos.engine.consumes.tunnel.Tunnel` ServiceLoader descriptor.

The module is included in the reactor and aggregate coverage, but is *not* a runtime dependency of `ikanos-engine` — operators who don't want OpenZiti on the classpath simply drop the module from their distribution.

### Why a `Transport` + `MemoryEndPointPipe` bridge?

The OpenZiti SDK only exposes `AsynchronousSocketChannel` (no `SocketChannel`), which is incompatible with Jetty's `SelectorManager`. Jetty 12.0.22 introduced the public `Transport` SPI plus `MemoryEndPointPipe`, which together let us hand Jetty a synthetic endpoint and pump bytes from any I/O primitive. This keeps the existing HTTP client, auth, retries, observability, and caching paths untouched.

## Tests

* `TunnelRouteTableTest`, `TunnelBootstrapTest`, `TunnelTransportTest`, `TunnelAwareHttpClientHelperTest`, `HttpClientAdapterTunnelTest` in `ikanos-engine`.
* `ZitiTunnelTest` in `ikanos-tunnel-ziti`.
* `TestServiceLoaderFakeTunnel` — test-only ServiceLoader provider that lets `TunnelBootstrap`'s discovery path execute on the engine test classpath without dragging OpenZiti in.

**Test results (clean build):**

```
ikanos-engine     : 777 tests, 0 failures, 0 errors
ikanos-tunnel-ziti:   7 tests, 0 failures, 0 errors
```

## Out of scope for this PR

* Version bump — Phase 2 is additive, no public-API breakage, so the parent stays at `1.0.0-alpha3-SNAPSHOT` for now. A bump can ride along with Phase 3 (`reverse-tunnel-phases-3+`) if the blueprint calls for it.
* CLI/UX surface (Phase 3): no new CLI flags, no shipyard-playground touchpoints, no docs updates beyond the blueprint already in `blueprints/`.

## Reviewer checklist

- [ ] Merge #513 first (this PR is stacked on `feat/reverse-tunnel-phases-0-1`).
- [ ] Confirm the SPI surface in `io.ikanos.engine.consumes.tunnel` is acceptable for additional vendors (e.g. Tailscale, ngrok, ssh-tunnel).
- [ ] Verify the `MemoryEndPointPipe` byte-pump pattern in `TunnelTransport` — particularly the failure paths in `EndPointToChannelPump.onCompleteFailure` and `ChannelToEndPointPump.failed`.
- [ ] Sanity-check that `TunnelBootstrap`'s system-property handoff to `ZitiTunnel` is the right ergonomics, or whether we should pass the identity through `Tunnel.start(Map<String, Object>)` in Phase 3.

Refs blueprint: `blueprints/reverse-tunnel-private-network.md`
