### PR TITLE
fix: patch localhost to 0.0.0.0

### DIFF
--- a/ikanos-spec/src/main/java/io/ikanos/spec/exposes/control/ControlServerSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/exposes/control/ControlServerSpec.java
@@ -41,7 +41,7 @@ public class ControlServerSpec extends ServerSpec {
     private final AtomicReference<ObservabilitySpec> observability = new AtomicReference<>();
 
     public ControlServerSpec() {
-        this("localhost", 0);
+        this(null, 0);
     }
 
     public ControlServerSpec(String address, int port) {


### PR DESCRIPTION
## Related Issue

Closes https://github.com/naftiko/ikanos/issues/507

---

## What does this PR do?

The control server should bind to the configured address (0.0.0.0) or default to 0.0.0.0 when unspecified, ensuring the endpoint is reachable via the Pod IP and Kubernetes Service routing.

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---
