### PR TITLE
fix: putIfAbsent should verify env var before force none

### DIFF
--- a/ikanos-engine/src/main/java/io/ikanos/engine/observability/TelemetryBootstrap.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/observability/TelemetryBootstrap.java
@@ -204,9 +204,12 @@ public class TelemetryBootstrap {
         } else {
             // No OTLP endpoint in spec — default to none to avoid spurious connection errors
             // to localhost:4317 (e.g. inside Docker). OTel env vars still take precedence.
-            props.putIfAbsent("otel.traces.exporter", "none");
-            props.putIfAbsent("otel.metrics.exporter", "none");
-            props.putIfAbsent("otel.logs.exporter", "none");
+            String envEndpoint = System.getenv("OTEL_EXPORTER_OTLP_ENDPOINT");
+            if (envEndpoint == null || envEndpoint.isBlank()) {
+                props.putIfAbsent("otel.traces.exporter", "none");
+                props.putIfAbsent("otel.metrics.exporter", "none");
+                props.putIfAbsent("otel.logs.exporter", "none");
+            }
         }
         return props;
     }


### PR DESCRIPTION
## Related Issue

Closes https://github.com/naftiko/ikanos/issues/518

---

## What does this PR do?

Only disable if OTEL_EXPORTER_OTLP_ENDPOINT env var is also not set

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

