### PR TITLE
Chore/increase version alpha4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,8 @@ When writing or generating tests, follow these rules:
 - Write one focused assertion per test, or group only closely related assertions in a single test
 - Name tests in the form `methodShouldDoSomethingWhenCondition`
 - After renaming any string constant that tests assert against (OTel span names, error messages, log markers), run a codebase-wide grep for the old string across **all** test sources — not just the test class that was directly updated. Compilation failures in unrelated tests do not exempt this search from being exhaustive
+- **Spec version in inline YAML inside Java sources** (text blocks, string literals) — never hardcode the version. Inject it via `io.ikanos.spec.util.VersionHelper.getSchemaVersion()` and `String.formatted(...)`, e.g. `private static final String IKANOS = VersionHelper.getSchemaVersion();` then `"""ikanos: "%s" ... """.formatted(IKANOS)`. Rationale: `VersionHelper` reads the Maven-filtered `version.properties` so the value follows `pom.xml` automatically. Do **not** put placeholders in the published schema JSON — it must remain a ready-to-consume artifact
+- **Spec version in YAML / JSON test fixtures** (files under `src/test/resources/`, examples, tutorial capabilities) keeps a real version string. When you add a new fixture location or file extension that contains `ikanos: <version>`, update `scripts/sync-ikanos-version.py` (and `scripts/ikanos_version.py` if the pattern needs extending) in the same PR so the next version bump picks it up. See `CONTRIBUTING.md` → *Writing tests — handling the spec version* for details
 
 **Don't:**
 - Mix unit test patterns (local mock servers, in-process stubs, hardcoded XML/JSON payloads) into integration test classes — each test class must be one type, not both

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,50 @@ This section provides **machine-readable guidance** for AI coding agents contrib
 - Do **not** modify CI/CD workflows, security configs, or branch protection rules
 - Keep the Ikanos Specification as a **first-class citizen** in your context
 
+### Writing tests — handling the spec version
+
+The Ikanos schema pins the spec version via `"const"` (e.g. `1.0.0-alphaN`). Any test
+material that mentions `ikanos: "<version>"` must stay in sync with the project version
+declared in `pom.xml`. To avoid the silent drift we have hit in the past, follow these
+two rules:
+
+- **Inline YAML inside Java sources** (text blocks, string literals, etc.) **must not**
+  hardcode the spec version. Use `io.ikanos.spec.util.VersionHelper.getSchemaVersion()`
+  and inject the value with `String.formatted(...)`:
+
+  ```java
+  import io.ikanos.spec.util.VersionHelper;
+
+  private static final String IKANOS = VersionHelper.getSchemaVersion();
+
+  String yaml = """
+      ikanos: "%s"
+      kind: Capability
+      // ...
+      """.formatted(IKANOS);
+  ```
+
+  Rationale: `VersionHelper` reads the Maven-filtered `version.properties`, so the
+  version follows `pom.xml` automatically — no manual update needed on a version bump.
+  Do **not** add placeholders to the published schema JSON itself; it must remain a
+  ready-to-consume artifact.
+
+- **YAML / JSON test fixtures** (files under `src/test/resources/`, examples, tutorial
+  capabilities, etc.) keep a real version string. Whenever you add a new fixture path
+  or file extension that contains `ikanos: <version>`, **update
+  `scripts/sync-ikanos-version.py`** so the next version bump picks it up. At minimum
+  check:
+  - the directories scanned by `find_files(...)` cover your new location;
+  - the file suffix is included (currently `.yml`, `.yaml`, `.json`);
+  - if the matching pattern in `scripts/ikanos_version.py` needs to be extended, do
+    it in the same PR.
+
+  Run the script locally after editing to confirm it touches your new file:
+
+  ```bash
+  python scripts/sync-ikanos-version.py
+  ```
+
 ### Key files for agent context
 
 | File / Path | Purpose |

--- a/ikanos-cli/src/test/java/io/ikanos/cli/ControlPortMixinTest.java
+++ b/ikanos-cli/src/test/java/io/ikanos/cli/ControlPortMixinTest.java
@@ -20,7 +20,11 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import io.ikanos.spec.util.VersionHelper;
+
 public class ControlPortMixinTest {
+
+    private static final String IKANOS = VersionHelper.getSchemaVersion();
 
     @TempDir
     Path tempDir;
@@ -84,14 +88,14 @@ public class ControlPortMixinTest {
 
         Path yaml = tempDir.resolve("my-capability.yaml");
         Files.writeString(yaml, """
-                ikanos: "1.0.0-alpha2"
+                ikanos: "%s"
                 info:
                   display: Test
                 capability:
                   exposes:
                     - type: control
                       port: 9199
-                """);
+                """.formatted(IKANOS));
 
         String originalDir = System.getProperty("user.dir");
         try {
@@ -136,14 +140,14 @@ public class ControlPortMixinTest {
         // Create a YAML with control port to fall back to
         Path yaml = tempDir.resolve("fallback.yaml");
         Files.writeString(yaml, """
-                ikanos: "1.0.0-alpha2"
+                ikanos: "%s"
                 info:
                   display: Test
                 capability:
                   exposes:
                     - type: control
                       port: 9200
-                """);
+                """.formatted(IKANOS));
 
         String originalDir = System.getProperty("user.dir");
         try {
@@ -168,14 +172,14 @@ public class ControlPortMixinTest {
 
         Path yaml = tempDir.resolve("rest-only.yaml");
         Files.writeString(yaml, """
-                ikanos: "1.0.0-alpha2"
+                ikanos: "%s"
                 info:
                   display: Test
                 capability:
                   exposes:
                     - type: rest
                       port: 8080
-                """);
+                """.formatted(IKANOS));
 
         String originalDir = System.getProperty("user.dir");
         try {
@@ -192,25 +196,25 @@ public class ControlPortMixinTest {
 
         Path yaml1 = tempDir.resolve("a-capability.yaml");
         Files.writeString(yaml1, """
-                ikanos: "1.0.0-alpha2"
+                ikanos: "%s"
                 info:
                   display: Test A
                 capability:
                   exposes:
                     - type: rest
                       port: 8080
-                """);
+                """.formatted(IKANOS));
 
         Path yaml2 = tempDir.resolve("b-capability.yaml");
         Files.writeString(yaml2, """
-                ikanos: "1.0.0-alpha2"
+                ikanos: "%s"
                 info:
                   display: Test B
                 capability:
                   exposes:
                     - type: control
                       port: 9111
-                """);
+                """.formatted(IKANOS));
 
         String originalDir = System.getProperty("user.dir");
         try {
@@ -228,11 +232,11 @@ public class ControlPortMixinTest {
 
         Path yaml = tempDir.resolve("no-control.yaml");
         Files.writeString(yaml, """
-                ikanos: "1.0.0-alpha2"
+                ikanos: "%s"
                 info:
                   display: Test
                 capability: {}
-                """);
+                """.formatted(IKANOS));
 
         String originalDir = System.getProperty("user.dir");
         try {

--- a/ikanos-cli/src/test/java/io/ikanos/cli/ExportOpenApiCommandTest.java
+++ b/ikanos-cli/src/test/java/io/ikanos/cli/ExportOpenApiCommandTest.java
@@ -23,8 +23,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import picocli.CommandLine;
 import io.ikanos.Cli;
+import io.ikanos.spec.util.VersionHelper;
 
 public class ExportOpenApiCommandTest {
+
+    private static final String IKANOS = VersionHelper.getSchemaVersion();
 
     @TempDir
     Path tempDir;
@@ -33,7 +36,7 @@ public class ExportOpenApiCommandTest {
     void exportShouldSucceedWithValidCapabilityFile() throws Exception {
         Path capFile = tempDir.resolve("capability.yml");
         Files.writeString(capFile, """
-                ikanos: "1.0.0-alpha1"
+                ikanos: "%s"
                 info:
                   display: "Test API"
                   description: "A test capability"
@@ -49,7 +52,7 @@ public class ExportOpenApiCommandTest {
                             - method: GET
                               name: list-items
                               description: List all items
-                """);
+                """.formatted(IKANOS));
 
         Path output = tempDir.resolve("openapi.yaml");
 
@@ -71,7 +74,7 @@ public class ExportOpenApiCommandTest {
     void exportShouldSupportJsonFormat() throws Exception {
         Path capFile = tempDir.resolve("capability.yml");
         Files.writeString(capFile, """
-                ikanos: "1.0.0-alpha1"
+                ikanos: "%s"
                 info:
                   display: "JSON Test"
                 capability:
@@ -85,7 +88,7 @@ public class ExportOpenApiCommandTest {
                           operations:
                             - method: GET
                               name: get-data
-                """);
+                """.formatted(IKANOS));
 
         Path output = tempDir.resolve("openapi.json");
 
@@ -112,7 +115,7 @@ public class ExportOpenApiCommandTest {
     void exportShouldFailWhenSpecVersionIsUnsupported() throws Exception {
         Path capFile = tempDir.resolve("capability.yml");
         Files.writeString(capFile, """
-                ikanos: "1.0.0-alpha1"
+                ikanos: "%s"
                 info:
                   display: "Spec Version Test"
                 capability:
@@ -126,7 +129,7 @@ public class ExportOpenApiCommandTest {
                           operations:
                             - method: GET
                               name: list-items
-                """);
+                """.formatted(IKANOS));
 
         CommandLine cmd = new CommandLine(new Cli());
         int exitCode = cmd.execute("export", "openapi", capFile.toString(),
@@ -139,7 +142,7 @@ public class ExportOpenApiCommandTest {
     void exportShouldSupportSpecVersion31() throws Exception {
         Path capFile = tempDir.resolve("spec31-capability.yml");
         Files.writeString(capFile, """
-                ikanos: "1.0.0-alpha1"
+                ikanos: "%s"
                 info:
                   display: "OpenAPI 3.1 Test"
                 capability:
@@ -153,7 +156,7 @@ public class ExportOpenApiCommandTest {
                           operations:
                             - method: GET
                               name: list-items
-                """);
+                """.formatted(IKANOS));
 
         Path output = tempDir.resolve("openapi31.yaml");
 
@@ -169,7 +172,7 @@ public class ExportOpenApiCommandTest {
     void exportShouldUseDefaultOutputPathWhenOutputNotProvided() throws Exception {
         Path capFile = tempDir.resolve("default-output-cap.yml");
         Files.writeString(capFile, """
-                ikanos: "1.0.0-alpha1"
+                ikanos: "%s"
                 info:
                   display: "Default Output Test"
                 capability:
@@ -183,7 +186,7 @@ public class ExportOpenApiCommandTest {
                           operations:
                             - method: GET
                               name: list-items
-                """);
+                """.formatted(IKANOS));
 
         Path expectedOutput = Path.of("openapi.yaml").toAbsolutePath().normalize();
         try {
@@ -201,7 +204,7 @@ public class ExportOpenApiCommandTest {
     void exportShouldUseJsonExtensionForDefaultOutputWhenFormatIsJson() throws Exception {
         Path capFile = tempDir.resolve("json-default-cap.yml");
         Files.writeString(capFile, """
-                ikanos: "1.0.0-alpha1"
+                ikanos: "%s"
                 info:
                   display: "JSON Default Output Test"
                 capability:
@@ -215,7 +218,7 @@ public class ExportOpenApiCommandTest {
                           operations:
                             - method: GET
                               name: list-items
-                """);
+                """.formatted(IKANOS));
 
         Path expectedOutput = Path.of("openapi.json").toAbsolutePath().normalize();
         try {

--- a/ikanos-cli/src/test/java/io/ikanos/cli/ValidateCommandTest.java
+++ b/ikanos-cli/src/test/java/io/ikanos/cli/ValidateCommandTest.java
@@ -114,7 +114,7 @@ public class ValidateCommandTest {
     @Test
     public void callShouldFailWhenSchemaVersionIsUnsupported() {
         Path yaml = tempDir.resolve("capability.yaml");
-        assertDoesNotThrow(() -> Files.writeString(yaml, "ikanos: \"1.0.0-alpha3\"\n"));
+        assertDoesNotThrow(() -> Files.writeString(yaml, "ikanos: \"1.0.0-alpha4\"\n"));
 
         int exitCode = new CommandLine(new ValidateCommand()).execute(yaml.toString(), "9.9");
 
@@ -125,7 +125,7 @@ public class ValidateCommandTest {
     @Test
     public void callShouldFailWhenValidationDetectsSchemaErrors() {
         Path yaml = tempDir.resolve("invalid-capability.yaml");
-        assertDoesNotThrow(() -> Files.writeString(yaml, "ikanos: \"1.0.0-alpha3\"\ninfo: {}\n"));
+        assertDoesNotThrow(() -> Files.writeString(yaml, "ikanos: \"1.0.0-alpha4\"\ninfo: {}\n"));
 
         int exitCode = new CommandLine(new ValidateCommand()).execute(yaml.toString());
 
@@ -153,7 +153,7 @@ public class ValidateCommandTest {
         };
 
         Path yaml = tempDir.resolve("unexpected.yaml");
-        assertDoesNotThrow(() -> Files.writeString(yaml, "ikanos: \"1.0.0-alpha3\"\n"));
+        assertDoesNotThrow(() -> Files.writeString(yaml, "ikanos: \"1.0.0-alpha4\"\n"));
 
         int exitCode = new CommandLine(command).execute(yaml.toString());
 

--- a/ikanos-cli/src/test/resources/control/control-capability.yaml
+++ b/ikanos-cli/src/test/resources/control/control-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../../../ikanos-spec/src/main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 info:
   display: "CLI Control Port Test Capability"
   description: "Test capability for CLI runtime startup"

--- a/ikanos-docs/tutorial/shared/legacy-consumes.yaml
+++ b/ikanos-docs/tutorial/shared/legacy-consumes.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 consumes:
 - namespace: legacy
   type: http

--- a/ikanos-docs/tutorial/shared/registry-consumes.yaml
+++ b/ikanos-docs/tutorial/shared/registry-consumes.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 consumes:
 - namespace: registry
   type: http

--- a/ikanos-docs/tutorial/shared/step11-registry-consumes.yml
+++ b/ikanos-docs/tutorial/shared/step11-registry-consumes.yml
@@ -1,5 +1,5 @@
 # shared/registry-consumes.yaml (final — added get-voyage + cargo resource)
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 consumes:
 - namespace: registry
   type: http

--- a/ikanos-docs/tutorial/shared/step5-registry-consumes.yaml
+++ b/ikanos-docs/tutorial/shared/step5-registry-consumes.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 consumes:
 - namespace: registry
   type: http

--- a/ikanos-docs/tutorial/shared/step6-registry-consumes.yaml
+++ b/ikanos-docs/tutorial/shared/step6-registry-consumes.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 consumes:
 - namespace: registry
   type: http

--- a/ikanos-docs/tutorial/shared/step7-registry-consumes.yml
+++ b/ikanos-docs/tutorial/shared/step7-registry-consumes.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 consumes:
 - namespace: registry
   type: http

--- a/ikanos-docs/tutorial/step-1-shipyard-mock.yml
+++ b/ikanos-docs/tutorial/step-1-shipyard-mock.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 capability:
   exposes:

--- a/ikanos-docs/tutorial/step-10-shipyard-rest-adapter.yml
+++ b/ikanos-docs/tutorial/step-10-shipyard-rest-adapter.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-11-shipyard-fleet-manifest.yml
+++ b/ikanos-docs/tutorial/step-11-shipyard-fleet-manifest.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 info:
   display: "Shipyard Fleet Management"

--- a/ikanos-docs/tutorial/step-2-shipyard-wiring.yml
+++ b/ikanos-docs/tutorial/step-2-shipyard-wiring.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 capability:
   consumes:

--- a/ikanos-docs/tutorial/step-3-shipyard-auth.yml
+++ b/ikanos-docs/tutorial/step-3-shipyard-auth.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-4-shipyard-output-shaping.yml
+++ b/ikanos-docs/tutorial/step-4-shipyard-output-shaping.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-5-shipyard-multi-source.yml
+++ b/ikanos-docs/tutorial/step-5-shipyard-multi-source.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-6-shipyard-write-operations.yml
+++ b/ikanos-docs/tutorial/step-6-shipyard-write-operations.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-7-shipyard-orchestrated-lookup.yml
+++ b/ikanos-docs/tutorial/step-7-shipyard-orchestrated-lookup.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-8-shipyard-skill-groups.yml
+++ b/ikanos-docs/tutorial/step-8-shipyard-skill-groups.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-9-shipyard-aggregates.yml
+++ b/ikanos-docs/tutorial/step-9-shipyard-aggregates.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-basic.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-basic.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 info:
   display: Aggregate Basic Test
   description: Test capability for aggregate function ref resolution

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-hints-override.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-hints-override.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 info:
   display: Aggregate Hints Override Test
   description: Test capability for semantics-to-hints derivation with override

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-invalid-ref.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-invalid-ref.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 info:
   display: "Aggregate Invalid Ref Test"
   description: "Test capability with an unknown aggregate ref"

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-shared-mock.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-shared-mock.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 info:
   display: Aggregate Shared Mock Test
   description: Shared aggregate mock function consumed by MCP and REST refs

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-step-with-namespace.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-step-with-namespace.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 info:
   display: Aggregate Step Namespace Test
   description: Test capability for namespace-qualified references in aggregate function

--- a/ikanos-engine/src/test/resources/baseuri-trailing-slash-capability.yaml
+++ b/ikanos-engine/src/test/resources/baseuri-trailing-slash-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 info:
   display: "BaseUri Trailing Slash Regression Test"
   description: "Capability intentionally using a trailing-slash baseUri to test strict validation"

--- a/ikanos-engine/src/test/resources/control/control-capability.yaml
+++ b/ikanos-engine/src/test/resources/control/control-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../../../ikanos-spec/src/main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 info:
   display: "Control Port Test Capability"
   description: "Test capability for Control Server Adapter deserialization and wiring"

--- a/ikanos-engine/src/test/resources/control/control-observability-disabled.yaml
+++ b/ikanos-engine/src/test/resources/control/control-observability-disabled.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 info:
   display: "Control Port — Observability Disabled"
   description: "Test fixture: observability.enabled=false should suppress /metrics and /traces"

--- a/ikanos-engine/src/test/resources/control/control-scripting-capability.yaml
+++ b/ikanos-engine/src/test/resources/control/control-scripting-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 info:
   display: "Control Port Scripting Test"
   description: "Test capability for scripting governance on the Control Port"

--- a/ikanos-engine/src/test/resources/embedding/embedding-capability.yaml
+++ b/ikanos-engine/src/test/resources/embedding/embedding-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 info:
   display: Embedding Test
   description: Test capability for step handler registry integration

--- a/ikanos-engine/src/test/resources/formats/avro-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/avro-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 info:
   display: Avro Test Capability
   description: Test capability for Avro message decoding from API responses

--- a/ikanos-engine/src/test/resources/formats/csv-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/csv-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 info:
   display: CSV Test Capability
   description: Test capability for CSV parsing from API responses

--- a/ikanos-engine/src/test/resources/formats/html-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/html-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 info:
   display: "HTML Test Capability"
   description: "Test capability for HTML table parsing"

--- a/ikanos-engine/src/test/resources/formats/markdown-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/markdown-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 info:
   display: "Markdown Test Capability"
   description: "Test capability for Markdown parsing"

--- a/ikanos-engine/src/test/resources/formats/proto-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/proto-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 info:
   display: Protobuf Test Capability
   description: Test capability for Protobuf message decoding from API responses

--- a/ikanos-engine/src/test/resources/formats/xml-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/xml-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 info:
   display: XML Test Capability
   description: Test capability for XML parsing from API responses

--- a/ikanos-engine/src/test/resources/formats/yaml-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/yaml-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 info:
   display: YAML Test Capability
   description: Test capability for YAML parsing from API responses

--- a/ikanos-engine/src/test/resources/http/http-body-capability.yaml
+++ b/ikanos-engine/src/test/resources/http/http-body-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 capability:
   exposes:
   - type: rest

--- a/ikanos-engine/src/test/resources/http/http-forward-value-capability.yaml
+++ b/ikanos-engine/src/test/resources/http/http-forward-value-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 info:
   display: HTTP Forward with Value Field Test
   description: Test capability for forward spec with value field supporting Mustache

--- a/ikanos-engine/src/test/resources/http/http-header-query-capability.yaml
+++ b/ikanos-engine/src/test/resources/http/http-header-query-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 capability:
   exposes:
   - type: rest

--- a/ikanos-engine/src/test/resources/imports/aggregates/shared.aggregates.yml
+++ b/ikanos-engine/src/test/resources/imports/aggregates/shared.aggregates.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 aggregates:
   - namespace: "forecast"
     display: "Forecast Domain"

--- a/ikanos-engine/src/test/resources/imports/binds/shared.binds.yml
+++ b/ikanos-engine/src/test/resources/imports/binds/shared.binds.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 binds:
   - namespace: "weather-secrets"
     description: "Weather API credentials"

--- a/ikanos-engine/src/test/resources/imports/consumes/shared-clients.yml
+++ b/ikanos-engine/src/test/resources/imports/consumes/shared-clients.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 consumes:
   - namespace: "weather-http"
     type: "http"

--- a/ikanos-engine/src/test/resources/imports/consumes/shared.consumes.yml
+++ b/ikanos-engine/src/test/resources/imports/consumes/shared.consumes.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 consumes:
   - type: "http"
     namespace: "weather-api"

--- a/ikanos-engine/src/test/resources/imports/exposes/shared-servers.yml
+++ b/ikanos-engine/src/test/resources/imports/exposes/shared-servers.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 exposes:
   - namespace: "weather-rest"
     type: "rest"

--- a/ikanos-engine/src/test/resources/imports/exposes/shared.exposes.yml
+++ b/ikanos-engine/src/test/resources/imports/exposes/shared.exposes.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 exposes:
   - type: "rest"
     namespace: "weather-rest"

--- a/ikanos-engine/src/test/resources/imports/invalid/empty-section.consumes.yml
+++ b/ikanos-engine/src/test/resources/imports/invalid/empty-section.consumes.yml
@@ -1,2 +1,2 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 consumes: []

--- a/ikanos-engine/src/test/resources/mcp/mcp-capability.yaml
+++ b/ikanos-engine/src/test/resources/mcp/mcp-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 info:
   display: MCP Test Capability
   description: Test capability for MCP Server Adapter deserialization and wiring

--- a/ikanos-engine/src/test/resources/mcp/mcp-hints-capability.yaml
+++ b/ikanos-engine/src/test/resources/mcp/mcp-hints-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 info:
   display: MCP Hints Test Capability
   description: Test capability for MCP tool hints (ToolAnnotations) support

--- a/ikanos-engine/src/test/resources/mcp/mcp-resources-prompts-capability.yaml
+++ b/ikanos-engine/src/test/resources/mcp/mcp-resources-prompts-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 info:
   display: MCP Resources & Prompts Test Capability
   description: Test capability for MCP Server Adapter resources and prompts support

--- a/ikanos-engine/src/test/resources/mcp/mcp-stdio-capability.yaml
+++ b/ikanos-engine/src/test/resources/mcp/mcp-stdio-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 info:
   display: MCP Stdio Test Capability
   description: Test capability for MCP Server Adapter with stdio transport

--- a/ikanos-engine/src/test/resources/mcp/mcp-step-with-namespace-capability.yaml
+++ b/ikanos-engine/src/test/resources/mcp/mcp-step-with-namespace-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 capability:
   consumes:
   - namespace: registry

--- a/ikanos-engine/src/test/resources/mcp/mcp-tool-handler-with-mustache-capability.yaml
+++ b/ikanos-engine/src/test/resources/mcp/mcp-tool-handler-with-mustache-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 capability:
   consumes:
   - namespace: registry

--- a/ikanos-engine/src/test/resources/nested-object-output-capability.yaml
+++ b/ikanos-engine/src/test/resources/nested-object-output-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 info:
   display: Nested Object Output Capability
   description: Test fixture for verifying that output mappings correctly resolve nested

--- a/ikanos-engine/src/test/resources/observability/observability-capability.yaml
+++ b/ikanos-engine/src/test/resources/observability/observability-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 info:
   display: "Observability Test Capability"
   description: "Test capability for observability spec deserialization"

--- a/ikanos-engine/src/test/resources/observability/observability-disabled.yaml
+++ b/ikanos-engine/src/test/resources/observability/observability-disabled.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 info:
   display: "Observability Disabled Capability"
   description: "Test capability with observability disabled"

--- a/ikanos-engine/src/test/resources/register.capability.yml
+++ b/ikanos-engine/src/test/resources/register.capability.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 info:
   display: "register"
   description: "Business description of your capability"

--- a/ikanos-engine/src/test/resources/skill-capability.yaml
+++ b/ikanos-engine/src/test/resources/skill-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 info:
   display: Skill Test Capability
   description: Test capability for Skill Server Adapter deserialization and wiring

--- a/ikanos-engine/src/test/resources/tutorial/shared/legacy-consumes.yaml
+++ b/ikanos-engine/src/test/resources/tutorial/shared/legacy-consumes.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 consumes:
 - namespace: legacy
   type: http

--- a/ikanos-engine/src/test/resources/tutorial/shared/registry-consumes.yaml
+++ b/ikanos-engine/src/test/resources/tutorial/shared/registry-consumes.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 consumes:
 - namespace: registry
   type: http

--- a/ikanos-engine/src/test/resources/tutorial/shared/step11-registry-consumes.yml
+++ b/ikanos-engine/src/test/resources/tutorial/shared/step11-registry-consumes.yml
@@ -1,5 +1,5 @@
 # shared/registry-consumes.yaml (final — added get-voyage + cargo resource)
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 consumes:
 - namespace: registry
   type: http

--- a/ikanos-engine/src/test/resources/tutorial/shared/step5-registry-consumes.yaml
+++ b/ikanos-engine/src/test/resources/tutorial/shared/step5-registry-consumes.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 consumes:
 - namespace: registry
   type: http

--- a/ikanos-engine/src/test/resources/tutorial/shared/step6-registry-consumes.yaml
+++ b/ikanos-engine/src/test/resources/tutorial/shared/step6-registry-consumes.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 consumes:
 - namespace: registry
   type: http

--- a/ikanos-engine/src/test/resources/tutorial/shared/step7-registry-consumes.yml
+++ b/ikanos-engine/src/test/resources/tutorial/shared/step7-registry-consumes.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 consumes:
 - namespace: registry
   type: http

--- a/ikanos-engine/src/test/resources/tutorial/step-1-shipyard-mock.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-1-shipyard-mock.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 capability:
   exposes:

--- a/ikanos-engine/src/test/resources/tutorial/step-10-shipyard-rest-adapter.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-10-shipyard-rest-adapter.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-11-shipyard-fleet-manifest.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-11-shipyard-fleet-manifest.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 info:
   display: "Shipyard Fleet Management"

--- a/ikanos-engine/src/test/resources/tutorial/step-2-shipyard-wiring.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-2-shipyard-wiring.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 capability:
   consumes:

--- a/ikanos-engine/src/test/resources/tutorial/step-3-shipyard-auth.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-3-shipyard-auth.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-4-shipyard-output-shaping.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-4-shipyard-output-shaping.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-5-shipyard-multi-source.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-5-shipyard-multi-source.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-6-shipyard-write-operations.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-6-shipyard-write-operations.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-7-shipyard-orchestrated-lookup.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-7-shipyard-orchestrated-lookup.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-8-shipyard-skill-groups.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-8-shipyard-skill-groups.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-9-shipyard-aggregates.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-9-shipyard-aggregates.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-spec/src/main/resources/schemas/examples/reverse-tunnel-ziti.yml
+++ b/ikanos-spec/src/main/resources/schemas/examples/reverse-tunnel-ziti.yml
@@ -8,7 +8,7 @@
 # At Phase 1 the engine does NOT yet wire the tunnel — this YAML validates
 # against the schema and the Polychro rules only. End-to-end execution lands
 # in Phases 2+ (embedded Ziti integration).
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 info:
   display: "CRM reverse-tunnel example"

--- a/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
+++ b/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
@@ -7,7 +7,7 @@
   "properties": {
     "ikanos": {
       "type": "string",
-      "description": "Ikanos specification version. Must be `1.0.0-alpha3`. Signals schema compatibility \u2014 always the first key in a capability file.",
+      "description": "Ikanos specification version. Must be `1.0.0-alpha4`. Signals schema compatibility \u2014 always the first key in a capability file.",
       "const": "1.0.0-alpha4"
     },
     "info": {

--- a/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
+++ b/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ikanos.io/schemas/v1.0.0-alpha3/ikanos.json",
+  "$id": "https://ikanos.io/schemas/v1.0.0-alpha4/ikanos.json",
   "name": "Ikanos Specification",
   "description": "Ikanos Capability Specification \u2014 describes a capability document (adapter + metadata) or a standalone shared file (consumes / exposes / aggregates / binds). A valid document must declare `ikanos` + exactly one of `capability`, `consumes`, `exposes`, `aggregates`, or `binds`. All adapter logic lives under `capability`; shared section definitions live at root.",
   "type": "object",
@@ -8,11 +8,11 @@
     "ikanos": {
       "type": "string",
       "description": "Ikanos specification version. Must be `1.0.0-alpha3`. Signals schema compatibility \u2014 always the first key in a capability file.",
-      "const": "1.0.0-alpha3"
+      "const": "1.0.0-alpha4"
     },
     "info": {
       "$ref": "#/$defs/Info",
-      "description": "Human-readable metadata: label, description, tags, dates, stakeholders.\n\n**When to use** — Required on every capability document. The richer the `description`, the better agents can discover and reason about this capability.\n**Format** — `created` / `modified` must be `YYYY-MM-DD`. `stakeholders[].role` is free-form (`owner`, `editor`, `reviewer`, etc.)."
+      "description": "Human-readable metadata: label, description, tags, dates, stakeholders.\n\n**When to use** \u2014 Required on every capability document. The richer the `description`, the better agents can discover and reason about this capability.\n**Format** \u2014 `created` / `modified` must be `YYYY-MM-DD`. `stakeholders[].role` is free-form (`owner`, `editor`, `reviewer`, etc.)."
     },
     "consumes": {
       "type": "array",
@@ -85,7 +85,7 @@
     },
     "capability": {
       "$ref": "#/$defs/Capability",
-      "description": "Technical body of the capability: what it exposes (`exposes`), what it calls (`consumes`), and shared domain logic (`aggregates`). At least one of `exposes`, `consumes`, or `aggregates` is required.\n\n**See also** — `info` for metadata, `binds` for secrets."
+      "description": "Technical body of the capability: what it exposes (`exposes`), what it calls (`consumes`), and shared domain logic (`aggregates`). At least one of `exposes`, `consumes`, or `aggregates` is required.\n\n**See also** \u2014 `info` for metadata, `binds` for secrets."
     }
   },
   "oneOf": [
@@ -100,28 +100,44 @@
         "ikanos",
         "consumes"
       ],
-      "not": { "required": ["capability"] }
+      "not": {
+        "required": [
+          "capability"
+        ]
+      }
     },
     {
       "required": [
         "ikanos",
         "exposes"
       ],
-      "not": { "required": ["capability"] }
+      "not": {
+        "required": [
+          "capability"
+        ]
+      }
     },
     {
       "required": [
         "ikanos",
         "aggregates"
       ],
-      "not": { "required": ["capability"] }
+      "not": {
+        "required": [
+          "capability"
+        ]
+      }
     },
     {
       "required": [
         "ikanos",
         "binds"
       ],
-      "not": { "required": ["capability"] }
+      "not": {
+        "required": [
+          "capability"
+        ]
+      }
     }
   ],
   "additionalProperties": false,
@@ -285,7 +301,7 @@
     },
     "ConsumedOutputParameter": {
       "type": "object",
-      "description": "Extracts a named value from the raw API response for use in orchestration steps.\n\n**When to use** — Declare one entry per piece of data you need from the response. The `value` JsonPath expression is evaluated against the parsed response body.\n**Usage** — Extracted values are referenced by their key in step `with` mappings and `MappedOutputParameter` definitions.\n**Tip** — For array responses, use JsonPath wildcards (e.g. `$.results[*].id`) to extract a list.",
+      "description": "Extracts a named value from the raw API response for use in orchestration steps.\n\n**When to use** \u2014 Declare one entry per piece of data you need from the response. The `value` JsonPath expression is evaluated against the parsed response body.\n**Usage** \u2014 Extracted values are referenced by their key in step `with` mappings and `MappedOutputParameter` definitions.\n**Tip** \u2014 For array responses, use JsonPath wildcards (e.g. `$.results[*].id`) to extract a list.",
       "properties": {
         "type": {
           "type": "string",
@@ -328,7 +344,7 @@
           "description": "JsonPath expression to extract the value. E.g. $.properties.Name.title[0].text.content"
         },
         "const": {
-          "description": "Schema-level constant for validation and linting. Not used at runtime for value injection — use 'value' instead.",
+          "description": "Schema-level constant for validation and linting. Not used at runtime for value injection \u2014 use 'value' instead.",
           "oneOf": [
             {
               "type": "string"
@@ -1740,7 +1756,7 @@
     },
     "ConsumesHttp": {
       "type": "object",
-      "description": "Inline HTTP API adapter. Declares the base URI, shared input parameters, authentication, and resources for an upstream HTTP service.\n\n**When to use** — Define one `ConsumesHttp` per upstream API (e.g. one for Notion, one for GitHub). Declare it at root-level `consumes[]` to share across capabilities, or under `capability.consumes[]` to scope it locally.\n**Execution model** — The framework uses `namespace` as the call target. Operations are resolved by matching `ConsumedHttpResource.name` + `ConsumedHttpOperation.name`.\n**See also** — `ImportedConsumesHttp` (cross-file reuse), `ForwardConfig` (header forwarding), `Authentication` (security).",
+      "description": "Inline HTTP API adapter. Declares the base URI, shared input parameters, authentication, and resources for an upstream HTTP service.\n\n**When to use** \u2014 Define one `ConsumesHttp` per upstream API (e.g. one for Notion, one for GitHub). Declare it at root-level `consumes[]` to share across capabilities, or under `capability.consumes[]` to scope it locally.\n**Execution model** \u2014 The framework uses `namespace` as the call target. Operations are resolved by matching `ConsumedHttpResource.name` + `ConsumedHttpOperation.name`.\n**See also** \u2014 `ImportedConsumesHttp` (cross-file reuse), `ForwardConfig` (header forwarding), `Authentication` (security).",
       "properties": {
         "namespace": {
           "$ref": "#/$defs/IdentifierKebab",
@@ -1756,7 +1772,7 @@
         },
         "baseUri": {
           "type": "string",
-          "description": "Root URL of the upstream API (scheme + host + optional base path). No path parameters allowed here — use `ConsumedHttpResource.path` for per-resource segments. Example: `https://api.notion.com/v1`.",
+          "description": "Root URL of the upstream API (scheme + host + optional base path). No path parameters allowed here \u2014 use `ConsumedHttpResource.path` for per-resource segments. Example: `https://api.notion.com/v1`.",
           "pattern": "^https?://[^/]+(/[^{]*)?$"
         },
         "inputParameters": {
@@ -1775,7 +1791,7 @@
         },
         "tunnel": {
           "$ref": "#/$defs/TunnelConfig",
-          "description": "Optional reverse-tunnel transport for reaching APIs behind a firewall. When set, the engine dials the consumed API through the configured overlay instead of the public internet. The TLS / authentication layer declared via `authentication` runs unchanged on top of the tunnel.\n\n**Engine support** — declarative only in this schema version; runtime engine wiring lands in a later release. Capabilities that declare `tunnel:` parse and validate today, but the engine still dials the public `baseUri` directly until the embedded tunnel feature is enabled. See the Reverse Tunnel guide for the sidecar pattern that works today."
+          "description": "Optional reverse-tunnel transport for reaching APIs behind a firewall. When set, the engine dials the consumed API through the configured overlay instead of the public internet. The TLS / authentication layer declared via `authentication` runs unchanged on top of the tunnel.\n\n**Engine support** \u2014 declarative only in this schema version; runtime engine wiring lands in a later release. Capabilities that declare `tunnel:` parse and validate today, but the engine still dials the public `baseUri` directly until the embedded tunnel feature is enabled. See the Reverse Tunnel guide for the sidecar pattern that works today."
         },
         "resources": {
           "type": "object",
@@ -1797,7 +1813,7 @@
       "additionalProperties": false
     },
     "TunnelConfig": {
-      "description": "Tunnel transport configuration for a `ConsumesHttp`. Use `type: ziti` to dial through an OpenZiti overlay. Additional types (e.g. `frp`, `cloudflared`) may be added in future versions; the `type` discriminator keeps existing capabilities forward-compatible.\n\n**See also** — `TunnelZiti` for the OpenZiti shape. The capability `binds` block is the recommended source for tunnel identities — never inline the identity JSON directly.",
+      "description": "Tunnel transport configuration for a `ConsumesHttp`. Use `type: ziti` to dial through an OpenZiti overlay. Additional types (e.g. `frp`, `cloudflared`) may be added in future versions; the `type` discriminator keeps existing capabilities forward-compatible.\n\n**See also** \u2014 `TunnelZiti` for the OpenZiti shape. The capability `binds` block is the recommended source for tunnel identities \u2014 never inline the identity JSON directly.",
       "oneOf": [
         {
           "$ref": "#/$defs/TunnelZiti"
@@ -1815,7 +1831,7 @@
         },
         "service": {
           "type": "string",
-          "description": "Ziti service name to dial (e.g. `crm-api`). Defined in the Ziti controller and authorized for this capability's identity. Routing happens by service name — not by IP or DNS."
+          "description": "Ziti service name to dial (e.g. `crm-api`). Defined in the Ziti controller and authorized for this capability's identity. Routing happens by service name \u2014 not by IP or DNS."
         },
         "identity": {
           "type": "string",
@@ -1828,7 +1844,7 @@
             "direct"
           ],
           "default": "fail",
-          "description": "Behavior when the tunnel cannot be established. `fail` (default) — operations return a 503-equivalent. `direct` — engine attempts a direct HTTP call to `baseUri`; NOT recommended for production, intended for local development against a stubbed upstream. The Polychro rule `ikanos-tunnel-fallback-direct-warns` warns when `direct` is used against a non-loopback baseUri."
+          "description": "Behavior when the tunnel cannot be established. `fail` (default) \u2014 operations return a 503-equivalent. `direct` \u2014 engine attempts a direct HTTP call to `baseUri`; NOT recommended for production, intended for local development against a stubbed upstream. The Polychro rule `ikanos-tunnel-fallback-direct-warns` warns when `direct` is used against a non-loopback baseUri."
         }
       },
       "required": [
@@ -1840,7 +1856,7 @@
     },
     "ConsumedHttpResource": {
       "type": "object",
-      "description": "A logical resource group on the upstream API. Combines a path segment with a set of HTTP operations and optional shared parameters.\n\n**When to use** — Each distinct REST resource (e.g. `/databases`, `/pages/{id}`) maps to one `ConsumedHttpResource`. Group operations that share the same base path and lifecycle.\n**Naming** — `name` is used as part of the call reference: `call: namespace.resource-name.operation-name`.\n**See also** — `ConsumedHttpOperation` (individual method + body), `ConsumedInputParameter` (path/query/header params).",
+      "description": "A logical resource group on the upstream API. Combines a path segment with a set of HTTP operations and optional shared parameters.\n\n**When to use** \u2014 Each distinct REST resource (e.g. `/databases`, `/pages/{id}`) maps to one `ConsumedHttpResource`. Group operations that share the same base path and lifecycle.\n**Naming** \u2014 `name` is used as part of the call reference: `call: namespace.resource-name.operation-name`.\n**See also** \u2014 `ConsumedHttpOperation` (individual method + body), `ConsumedInputParameter` (path/query/header params).",
       "properties": {
         "display": {
           "type": "string",
@@ -1855,7 +1871,7 @@
         },
         "description": {
           "type": "string",
-          "description": "Description of what this resource represents in the upstream API (e.g. 'A Notion database object — a structured collection of pages'). Used for agent discovery."
+          "description": "Description of what this resource represents in the upstream API (e.g. 'A Notion database object \u2014 a structured collection of pages'). Used for agent discovery."
         },
         "path": {
           "type": "string",
@@ -1948,7 +1964,7 @@
         },
         "outputSchema": {
           "type": "string",
-          "description": "Format-specific schema or selector:\n- **avro / protobuf** — path to the schema file (required for these formats).\n- **html** — CSS selector to scope table extraction (e.g. `table.results`).\n- **markdown** — Heading prefix to filter sections (e.g. `## Results`).\n- Other formats — unused."
+          "description": "Format-specific schema or selector:\n- **avro / protobuf** \u2014 path to the schema file (required for these formats).\n- **html** \u2014 CSS selector to scope table extraction (e.g. `table.results`).\n- **markdown** \u2014 Heading prefix to filter sections (e.g. `## Results`).\n- Other formats \u2014 unused."
         },
         "outputParameters": {
           "type": "object",
@@ -2066,13 +2082,13 @@
                 "python",
                 "groovy"
               ],
-              "description": "GraalVM language identifier for the script engine. Optional when 'management.scripting.defaultLanguage' is set in the Control Port — the engine falls back to the default."
+              "description": "GraalVM language identifier for the script engine. Optional when 'management.scripting.defaultLanguage' is set in the Control Port \u2014 the engine falls back to the default."
             },
             "location": {
               "type": "string",
               "format": "uri",
               "pattern": "^file:///",
-              "description": "file:/// URI pointing to the scripts directory. Follows the same convention as ExposedSkill.location — a directory root from which 'file' and 'dependencies' are resolved as relative paths. Optional when 'management.scripting.defaultLocation' is set in the Control Port — the engine falls back to the default."
+              "description": "file:/// URI pointing to the scripts directory. Follows the same convention as ExposedSkill.location \u2014 a directory root from which 'file' and 'dependencies' are resolved as relative paths. Optional when 'management.scripting.defaultLocation' is set in the Control Port \u2014 the engine falls back to the default."
             },
             "file": {
               "type": "string",
@@ -2134,7 +2150,7 @@
     },
     "RequestBodyJson": {
       "type": "object",
-      "description": "JSON request body. Sends `data` serialized as `application/json`. `data` can be a static string, object, or array — or a Mustache template string resolved from the execution context.",
+      "description": "JSON request body. Sends `data` serialized as `application/json`. `data` can be a static string, object, or array \u2014 or a Mustache template string resolved from the execution context.",
       "properties": {
         "type": {
           "type": "string",
@@ -2167,7 +2183,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "Content-type variant: `text` → `text/plain`, `xml` → `application/xml`, `sparql` → `application/sparql-query`.",
+          "description": "Content-type variant: `text` \u2192 `text/plain`, `xml` \u2192 `application/xml`, `sparql` \u2192 `application/sparql-query`.",
           "enum": [
             "text",
             "xml",
@@ -2194,7 +2210,7 @@
           "const": "formUrlEncoded"
         },
         "data": {
-          "description": "Form fields. Provide either a pre-encoded string or a key→value object whose values are URL-encoded by the framework.",
+          "description": "Form fields. Provide either a pre-encoded string or a key\u2192value object whose values are URL-encoded by the framework.",
           "oneOf": [
             {
               "type": "string",
@@ -2202,7 +2218,7 @@
             },
             {
               "type": "object",
-              "description": "Key–value map of form fields. Values must be strings; the framework handles encoding.",
+              "description": "Key\u2013value map of form fields. Values must be strings; the framework handles encoding.",
               "additionalProperties": {
                 "type": "string"
               }
@@ -2270,7 +2286,7 @@
       "description": "Raw body string sent as-is. Use a YAML block scalar (`|`) for multi-line payloads. The framework treats the string as JSON by default; pair with a `Content-Type` input parameter to override."
     },
     "RequestBody": {
-      "description": "Request body attached to a `ConsumedHttpOperation`. Choose the variant that matches the upstream API's expected content-type:\n- `json` → `application/json` (object, array, or template string)\n- `text` / `xml` / `sparql` → plain text / XML / SPARQL query\n- `formUrlEncoded` → `application/x-www-form-urlencoded`\n- `multipartForm` → `multipart/form-data` (file uploads)\n- raw string → sent as-is (override content-type via an `inputParameter` with `in: header`)",
+      "description": "Request body attached to a `ConsumedHttpOperation`. Choose the variant that matches the upstream API's expected content-type:\n- `json` \u2192 `application/json` (object, array, or template string)\n- `text` / `xml` / `sparql` \u2192 plain text / XML / SPARQL query\n- `formUrlEncoded` \u2192 `application/x-www-form-urlencoded`\n- `multipartForm` \u2192 `multipart/form-data` (file uploads)\n- raw string \u2192 sent as-is (override content-type via an `inputParameter` with `in: header`)",
       "oneOf": [
         {
           "$ref": "#/$defs/RequestBodyJson"
@@ -2291,7 +2307,7 @@
     },
     "ForwardConfig": {
       "type": "object",
-      "description": "Configuration for transparently forwarding incoming requests to a `ConsumesHttp` adapter.\n\n**When to use** — Attach to an `ExposesRest` or `ExposesMcp` adapter when you want to proxy or relay requests to an upstream API without writing explicit operation logic.\n**Security** — Only headers listed in `trustedHeaders` are forwarded; all others are stripped to avoid leaking internal headers.\n**See also** — `ConsumesHttp.namespace` as the forward target, `Authentication` on the target adapter for upstream credentials.",
+      "description": "Configuration for transparently forwarding incoming requests to a `ConsumesHttp` adapter.\n\n**When to use** \u2014 Attach to an `ExposesRest` or `ExposesMcp` adapter when you want to proxy or relay requests to an upstream API without writing explicit operation logic.\n**Security** \u2014 Only headers listed in `trustedHeaders` are forwarded; all others are stripped to avoid leaking internal headers.\n**See also** \u2014 `ConsumesHttp.namespace` as the forward target, `Authentication` on the target adapter for upstream credentials.",
       "properties": {
         "targetNamespace": {
           "$ref": "#/$defs/IdentifierKebab",
@@ -2312,7 +2328,7 @@
       "additionalProperties": false
     },
     "Authentication": {
-      "description": "Authentication strategy applied to outgoing requests (on `ConsumesHttp`) or to incoming request validation (on `Exposes*`). Choose the variant matching the upstream or downstream security model:\n- `basic` — HTTP Basic (username + password)\n- `apikey` — API key in header or query string\n- `bearer` — Static Bearer token\n- `digest` — HTTP Digest (username + password)\n- `oauth2` — OAuth 2.1 resource server (JWT validation or token introspection)",
+      "description": "Authentication strategy applied to outgoing requests (on `ConsumesHttp`) or to incoming request validation (on `Exposes*`). Choose the variant matching the upstream or downstream security model:\n- `basic` \u2014 HTTP Basic (username + password)\n- `apikey` \u2014 API key in header or query string\n- `bearer` \u2014 Static Bearer token\n- `digest` \u2014 HTTP Digest (username + password)\n- `oauth2` \u2014 OAuth 2.1 resource server (JWT validation or token introspection)",
       "oneOf": [
         {
           "$ref": "#/$defs/AuthBasic"
@@ -2333,7 +2349,7 @@
     },
     "AuthBasic": {
       "type": "object",
-      "description": "HTTP Basic authentication (`Authorization: Basic <base64(user:pass)>`). Credentials are base64-encoded by the framework at runtime — do not pre-encode them here. Use environment variable expressions (e.g. `$env.MY_PASSWORD`) to avoid hardcoding secrets.",
+      "description": "HTTP Basic authentication (`Authorization: Basic <base64(user:pass)>`). Credentials are base64-encoded by the framework at runtime \u2014 do not pre-encode them here. Use environment variable expressions (e.g. `$env.MY_PASSWORD`) to avoid hardcoding secrets.",
       "properties": {
         "type": {
           "type": "string",
@@ -2355,7 +2371,7 @@
     },
     "AuthApiKey": {
       "type": "object",
-      "description": "API Key authentication. Injects a named key–value pair into every request, either as a request header or a query parameter. Common for services like Notion (`Authorization: Bearer`), OpenWeather (`appid=...`), etc.",
+      "description": "API Key authentication. Injects a named key\u2013value pair into every request, either as a request header or a query parameter. Common for services like Notion (`Authorization: Bearer`), OpenWeather (`appid=...`), etc.",
       "properties": {
         "type": {
           "type": "string",
@@ -2403,7 +2419,7 @@
     },
     "AuthDigest": {
       "type": "object",
-      "description": "HTTP Digest authentication (RFC 7616). The framework performs the full challenge–response handshake automatically. Used by older APIs that require digest over basic.",
+      "description": "HTTP Digest authentication (RFC 7616). The framework performs the full challenge\u2013response handshake automatically. Used by older APIs that require digest over basic.",
       "properties": {
         "type": {
           "type": "string",
@@ -2476,7 +2492,7 @@
     },
     "ExposesSkill": {
       "type": "object",
-      "description": "Skill server adapter — metadata and catalog layer. Skills declare tools derived from sibling api or mcp adapters or defined as local file instructions. Does not execute tools.",
+      "description": "Skill server adapter \u2014 metadata and catalog layer. Skills declare tools derived from sibling api or mcp adapters or defined as local file instructions. Does not execute tools.",
       "properties": {
         "type": {
           "type": "string",
@@ -2640,7 +2656,7 @@
     },
     "ExposesControl": {
       "type": "object",
-      "description": "Control adapter — management plane for health, metrics, traces, and runtime diagnostics. Endpoints are engine-provided, not user-defined.",
+      "description": "Control adapter \u2014 management plane for health, metrics, traces, and runtime diagnostics. Endpoints are engine-provided, not user-defined.",
       "properties": {
         "type": {
           "type": "string",
@@ -2676,7 +2692,7 @@
     },
     "ControlManagementSpec": {
       "type": "object",
-      "description": "Toggle individual control port management endpoint groups. Does not include OTel-dependent endpoints (metrics, traces) — those are configured under observability.",
+      "description": "Toggle individual control port management endpoint groups. Does not include OTel-dependent endpoints (metrics, traces) \u2014 those are configured under observability.",
       "properties": {
         "health": {
           "type": "boolean",
@@ -2794,7 +2810,7 @@
     },
     "ObservabilitySpec": {
       "type": "object",
-      "description": "Spec-driven observability configuration. Controls distributed tracing, metrics collection, and their local exposure on the control port. All fields are optional — defaults to OTel env vars when not specified.",
+      "description": "Spec-driven observability configuration. Controls distributed tracing, metrics collection, and their local exposure on the control port. All fields are optional \u2014 defaults to OTel env vars when not specified.",
       "properties": {
         "enabled": {
           "type": "boolean",

--- a/ikanos-spec/src/test/java/io/ikanos/spec/aggregates/AggregateFlowDeserializationTest.java
+++ b/ikanos-spec/src/test/java/io/ikanos/spec/aggregates/AggregateFlowDeserializationTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.ikanos.spec.IkanosSpec;
+import io.ikanos.spec.util.VersionHelper;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -32,8 +33,10 @@ class AggregateFlowDeserializationTest {
     private static final ObjectMapper MAPPER =
             new ObjectMapper(new YAMLFactory()).findAndRegisterModules();
 
+    private static final String IKANOS = VersionHelper.getSchemaVersion();
+
     private static final String CAPABILITY_WITH_FLOWS = """
-            ikanos: "1.0.0-alpha3"
+            ikanos: "%s"
             capability:
               exposes: []
               consumes: []
@@ -47,7 +50,7 @@ class AggregateFlowDeserializationTest {
                     list-forecasts:
                       description: "List recent forecasts"
                       call: weather-api.list-forecasts
-            """;
+            """.formatted(IKANOS);
 
     @Test
     void flowsKeyShouldDeserializeIntoAggregateFlowSpecMap() throws Exception {

--- a/ikanos-spec/src/test/java/io/ikanos/spec/consumes/http/tunnel/TunnelSchemaValidationTest.java
+++ b/ikanos-spec/src/test/java/io/ikanos/spec/consumes/http/tunnel/TunnelSchemaValidationTest.java
@@ -25,6 +25,8 @@ import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
 
+import io.ikanos.spec.util.VersionHelper;
+
 import java.io.InputStream;
 import java.util.Set;
 
@@ -44,6 +46,7 @@ class TunnelSchemaValidationTest {
     private static JsonSchema schema;
     private static final YAMLMapper YAML = new YAMLMapper();
     private static final ObjectMapper JSON = new ObjectMapper();
+    private static final String IKANOS = VersionHelper.getSchemaVersion();
 
     @BeforeAll
     static void loadSchema() throws Exception {
@@ -79,7 +82,7 @@ class TunnelSchemaValidationTest {
     @DisplayName("schema accepts a ConsumesHttp adapter with a full ziti tunnel block")
     void schemaShouldAcceptConsumesHttpWithZitiTunnel() throws Exception {
         String yaml = """
-            ikanos: "1.0.0-alpha3"
+            ikanos: "%s"
             info:
               display: "demo"
               description: "demo"
@@ -105,7 +108,7 @@ class TunnelSchemaValidationTest {
                       operations:
                         list-customers:
                           method: "GET"
-            """;
+            """.formatted(IKANOS);
         Set<ValidationMessage> errors = validateYaml(yaml);
         assertTrue(errors.isEmpty(), "Expected no validation errors, but got: " + errors);
     }
@@ -114,7 +117,7 @@ class TunnelSchemaValidationTest {
     @DisplayName("schema accepts a ConsumesHttp adapter when tunnel omits the optional fallback")
     void schemaShouldAcceptZitiTunnelWithoutFallback() throws Exception {
         String yaml = """
-            ikanos: "1.0.0-alpha3"
+            ikanos: "%s"
             info:
               display: "demo"
               description: "demo"
@@ -133,7 +136,7 @@ class TunnelSchemaValidationTest {
                       operations:
                         list-customers:
                           method: "GET"
-            """;
+            """.formatted(IKANOS);
         Set<ValidationMessage> errors = validateYaml(yaml);
         assertTrue(errors.isEmpty(), "Expected no validation errors, but got: " + errors);
     }
@@ -142,7 +145,7 @@ class TunnelSchemaValidationTest {
     @DisplayName("schema accepts a ConsumesHttp adapter with no tunnel at all (backward compatible)")
     void schemaShouldAcceptConsumesHttpWithoutTunnel() throws Exception {
         String yaml = """
-            ikanos: "1.0.0-alpha3"
+            ikanos: "%s"
             info:
               display: "demo"
               description: "demo"
@@ -157,7 +160,7 @@ class TunnelSchemaValidationTest {
                       operations:
                         list-customers:
                           method: "GET"
-            """;
+            """.formatted(IKANOS);
         Set<ValidationMessage> errors = validateYaml(yaml);
         assertTrue(errors.isEmpty(), "Expected no validation errors, but got: " + errors);
     }
@@ -176,7 +179,7 @@ class TunnelSchemaValidationTest {
     @DisplayName("schema rejects an unknown tunnel.type value")
     void schemaShouldRejectUnknownTunnelType() throws Exception {
         String yaml = """
-            ikanos: "1.0.0-alpha3"
+            ikanos: "%s"
             info:
               display: "demo"
               description: "demo"
@@ -195,7 +198,7 @@ class TunnelSchemaValidationTest {
                       operations:
                         list-customers:
                           method: "GET"
-            """;
+            """.formatted(IKANOS);
         Set<ValidationMessage> errors = validateYaml(yaml);
         assertFalse(errors.isEmpty(),
             "Expected validation to fail for unknown tunnel.type, but it passed.");
@@ -205,7 +208,7 @@ class TunnelSchemaValidationTest {
     @DisplayName("schema rejects an invalid fallback enum value")
     void schemaShouldRejectInvalidFallbackEnum() throws Exception {
         String yaml = """
-            ikanos: "1.0.0-alpha3"
+            ikanos: "%s"
             info:
               display: "demo"
               description: "demo"
@@ -225,7 +228,7 @@ class TunnelSchemaValidationTest {
                       operations:
                         list-customers:
                           method: "GET"
-            """;
+            """.formatted(IKANOS);
         Set<ValidationMessage> errors = validateYaml(yaml);
         assertFalse(errors.isEmpty(),
             "Expected validation to fail for invalid fallback enum, but it passed.");
@@ -235,7 +238,7 @@ class TunnelSchemaValidationTest {
     @DisplayName("schema rejects a ziti tunnel that is missing the required service field")
     void schemaShouldRejectZitiTunnelWithoutService() throws Exception {
         String yaml = """
-            ikanos: "1.0.0-alpha3"
+            ikanos: "%s"
             info:
               display: "demo"
               description: "demo"
@@ -253,7 +256,7 @@ class TunnelSchemaValidationTest {
                       operations:
                         list-customers:
                           method: "GET"
-            """;
+            """.formatted(IKANOS);
         Set<ValidationMessage> errors = validateYaml(yaml);
         assertFalse(errors.isEmpty(),
             "Expected validation to fail when tunnel.service is missing, but it passed.");
@@ -263,7 +266,7 @@ class TunnelSchemaValidationTest {
     @DisplayName("schema rejects a ziti tunnel that is missing the required identity field")
     void schemaShouldRejectZitiTunnelWithoutIdentity() throws Exception {
         String yaml = """
-            ikanos: "1.0.0-alpha3"
+            ikanos: "%s"
             info:
               display: "demo"
               description: "demo"
@@ -281,7 +284,7 @@ class TunnelSchemaValidationTest {
                       operations:
                         list-customers:
                           method: "GET"
-            """;
+            """.formatted(IKANOS);
         Set<ValidationMessage> errors = validateYaml(yaml);
         assertFalse(errors.isEmpty(),
             "Expected validation to fail when tunnel.identity is missing, but it passed.");
@@ -291,7 +294,7 @@ class TunnelSchemaValidationTest {
     @DisplayName("schema rejects unknown extra properties inside a ziti tunnel block")
     void schemaShouldRejectUnknownTunnelProperties() throws Exception {
         String yaml = """
-            ikanos: "1.0.0-alpha3"
+            ikanos: "%s"
             info:
               display: "demo"
               description: "demo"
@@ -311,7 +314,7 @@ class TunnelSchemaValidationTest {
                       operations:
                         list-customers:
                           method: "GET"
-            """;
+            """.formatted(IKANOS);
         Set<ValidationMessage> errors = validateYaml(yaml);
         assertFalse(errors.isEmpty(),
             "Expected validation to fail for unknown property under tunnel, but it passed.");

--- a/ikanos-spec/src/test/java/io/ikanos/spec/imports/ImportDirectiveDeserializationTest.java
+++ b/ikanos-spec/src/test/java/io/ikanos/spec/imports/ImportDirectiveDeserializationTest.java
@@ -35,6 +35,7 @@ import io.ikanos.spec.exposes.ServerSpec;
 import io.ikanos.spec.exposes.rest.RestServerSpec;
 import io.ikanos.spec.util.BindingSpec;
 import io.ikanos.spec.util.ImportedBindingSpec;
+import io.ikanos.spec.util.VersionHelper;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -52,6 +53,8 @@ import org.junit.jupiter.api.Test;
  * <p>See {@code blueprints/unified-import-mechanism.md} §5 and §16 (Phase 1).</p>
  */
 class ImportDirectiveDeserializationTest {
+
+    private static final String IKANOS = VersionHelper.getSchemaVersion();
 
     private ObjectMapper mapper;
 
@@ -232,7 +235,7 @@ class ImportDirectiveDeserializationTest {
     @DisplayName("a single capability document mixes inline and imported entries in all four sections")
     void documentShouldAllowInlineAndImportedEntriesInTheSameSection() throws Exception {
         String yaml = """
-            ikanos: "1.0.0-alpha3"
+            ikanos: "%s"
             info:
               display: "mixed"
               description: "Capability mixing inline and imported entries."
@@ -263,7 +266,7 @@ class ImportDirectiveDeserializationTest {
                   flows: {}
                 - from: "./shared/maritime-aggregates.yml"
                   import: "fleet-aggregates"
-            """;
+            """.formatted(IKANOS);
 
         IkanosSpec spec = mapper.readValue(yaml, IkanosSpec.class);
 
@@ -296,12 +299,12 @@ class ImportDirectiveDeserializationTest {
     @DisplayName("standalone-exposes document parses with top-level 'exposes' array")
     void standaloneExposesDocumentShouldParseAtRoot() throws Exception {
         String yaml = """
-            ikanos: "1.0.0-alpha3"
+            ikanos: "%s"
             exposes:
               - type: "rest"
                 namespace: "shared-rest"
                 port: 3003
-            """;
+            """.formatted(IKANOS);
 
         IkanosSpec spec = mapper.readValue(yaml, IkanosSpec.class);
 
@@ -313,7 +316,7 @@ class ImportDirectiveDeserializationTest {
     @DisplayName("standalone-aggregates document parses with top-level 'aggregates' array")
     void standaloneAggregatesDocumentShouldParseAtRoot() throws Exception {
         String yaml = """
-            ikanos: "1.0.0-alpha3"
+            ikanos: "%s"
             aggregates:
               - display: "Crew Resolver"
                 namespace: "crew-resolver"
@@ -321,7 +324,7 @@ class ImportDirectiveDeserializationTest {
                   lookup:
                     description: "Lookup"
                     call: "api.lookup"
-            """;
+            """.formatted(IKANOS);
 
         IkanosSpec spec = mapper.readValue(yaml, IkanosSpec.class);
 

--- a/ikanos-spec/src/test/java/io/ikanos/spec/imports/ImportSchemaValidationTest.java
+++ b/ikanos-spec/src/test/java/io/ikanos/spec/imports/ImportSchemaValidationTest.java
@@ -26,6 +26,8 @@ import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
 
+import io.ikanos.spec.util.VersionHelper;
+
 import java.io.InputStream;
 import java.util.Set;
 
@@ -47,6 +49,7 @@ class ImportSchemaValidationTest {
     private static JsonSchema schema;
     private static final YAMLMapper YAML = new YAMLMapper();
     private static final ObjectMapper JSON = new ObjectMapper();
+    private static final String IKANOS = VersionHelper.getSchemaVersion();
 
     @BeforeAll
     static void loadSchema() throws Exception {
@@ -71,7 +74,7 @@ class ImportSchemaValidationTest {
     @DisplayName("schema accepts an import entry inside 'capability.consumes'")
     void schemaShouldAcceptImportEntryInConsumes() throws Exception {
         String yaml = """
-            ikanos: "1.0.0-alpha3"
+            ikanos: "%s"
             info:
               display: "demo"
               description: "demo"
@@ -81,7 +84,7 @@ class ImportSchemaValidationTest {
                   import: "notion"
                   as: "notion-shared"
                   description: "Standard Notion adapter."
-            """;
+            """.formatted(IKANOS);
         Set<ValidationMessage> errors = validateYaml(yaml);
         assertTrue(errors.isEmpty(), "Expected no validation errors, but got: " + errors);
     }
@@ -90,7 +93,7 @@ class ImportSchemaValidationTest {
     @DisplayName("schema accepts an import entry inside 'capability.exposes'")
     void schemaShouldAcceptImportEntryInExposes() throws Exception {
         String yaml = """
-            ikanos: "1.0.0-alpha3"
+            ikanos: "%s"
             info:
               display: "demo"
               description: "demo"
@@ -99,7 +102,7 @@ class ImportSchemaValidationTest {
                 - from: "./shared/maritime.exposes.yml"
                   import: "maritime-rest"
                   as: "fleet-maritime-rest"
-            """;
+            """.formatted(IKANOS);
         Set<ValidationMessage> errors = validateYaml(yaml);
         assertTrue(errors.isEmpty(), "Expected no validation errors, but got: " + errors);
     }
@@ -108,7 +111,7 @@ class ImportSchemaValidationTest {
     @DisplayName("schema accepts an import entry inside 'capability.aggregates'")
     void schemaShouldAcceptImportEntryInAggregates() throws Exception {
         String yaml = """
-            ikanos: "1.0.0-alpha3"
+            ikanos: "%s"
             info:
               display: "demo"
               description: "demo"
@@ -121,7 +124,7 @@ class ImportSchemaValidationTest {
                 - from: "./shared/maritime-aggregates.yml"
                   import: "crew-resolver"
                   as: "fleet-crew-resolver"
-            """;
+            """.formatted(IKANOS);
         Set<ValidationMessage> errors = validateYaml(yaml);
         assertTrue(errors.isEmpty(), "Expected no validation errors, but got: " + errors);
     }
@@ -130,12 +133,12 @@ class ImportSchemaValidationTest {
     @DisplayName("schema accepts an import entry inside top-level 'binds'")
     void schemaShouldAcceptImportEntryInBinds() throws Exception {
         String yaml = """
-            ikanos: "1.0.0-alpha3"
+            ikanos: "%s"
             binds:
               - from: "./shared/prod-secrets.binds.yml"
                 import: "secrets"
                 as: "prod-secrets"
-            """;
+            """.formatted(IKANOS);
         Set<ValidationMessage> errors = validateYaml(yaml);
         assertTrue(errors.isEmpty(), "Expected no validation errors, but got: " + errors);
     }
@@ -146,12 +149,12 @@ class ImportSchemaValidationTest {
     @DisplayName("schema accepts an 'ikanos + exposes' standalone document")
     void schemaShouldAcceptStandaloneExposesDocument() throws Exception {
         String yaml = """
-            ikanos: "1.0.0-alpha3"
+            ikanos: "%s"
             exposes:
               - type: "rest"
                 namespace: "shared-rest"
                 port: 3003
-            """;
+            """.formatted(IKANOS);
         Set<ValidationMessage> errors = validateYaml(yaml);
         assertTrue(errors.isEmpty(), "Expected no validation errors, but got: " + errors);
     }
@@ -160,7 +163,7 @@ class ImportSchemaValidationTest {
     @DisplayName("schema accepts an 'ikanos + aggregates' standalone document")
     void schemaShouldAcceptStandaloneAggregatesDocument() throws Exception {
         String yaml = """
-            ikanos: "1.0.0-alpha3"
+            ikanos: "%s"
             aggregates:
               - display: "Crew Resolver"
                 namespace: "crew-resolver"
@@ -168,7 +171,7 @@ class ImportSchemaValidationTest {
                   find-by-id:
                     description: "Look up a crew member by id."
                     call: "api.lookup"
-            """;
+            """.formatted(IKANOS);
         Set<ValidationMessage> errors = validateYaml(yaml);
         assertTrue(errors.isEmpty(), "Expected no validation errors, but got: " + errors);
     }
@@ -179,7 +182,7 @@ class ImportSchemaValidationTest {
     @DisplayName("schema rejects an import entry missing the 'from' property")
     void schemaShouldRejectImportEntryMissingFrom() throws Exception {
         String yaml = """
-            ikanos: "1.0.0-alpha3"
+            ikanos: "%s"
             info:
               display: "demo"
               description: "demo"
@@ -187,7 +190,7 @@ class ImportSchemaValidationTest {
               consumes:
                 - import: "notion"
                   as: "notion-shared"
-            """;
+            """.formatted(IKANOS);
         Set<ValidationMessage> errors = validateYaml(yaml);
         assertFalse(errors.isEmpty(), "Expected validation errors for missing 'from'");
     }
@@ -196,7 +199,7 @@ class ImportSchemaValidationTest {
     @DisplayName("schema rejects an import entry missing the 'import' property")
     void schemaShouldRejectImportEntryMissingImport() throws Exception {
         String yaml = """
-            ikanos: "1.0.0-alpha3"
+            ikanos: "%s"
             info:
               display: "demo"
               description: "demo"
@@ -204,7 +207,7 @@ class ImportSchemaValidationTest {
               consumes:
                 - from: "./shared/notion.consumes.yml"
                   as: "notion-shared"
-            """;
+            """.formatted(IKANOS);
         Set<ValidationMessage> errors = validateYaml(yaml);
         assertFalse(errors.isEmpty(), "Expected validation errors for missing 'import'");
     }

--- a/ikanos-spec/src/test/resources/capabilities/capability-spurious-name.yml
+++ b/ikanos-spec/src/test/resources/capabilities/capability-spurious-name.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-spec/src/test/resources/capabilities/capability-valid.yml
+++ b/ikanos-spec/src/test/resources/capabilities/capability-valid.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-spec/src/test/resources/imports/aggregate-duplicate-function-name.yaml
+++ b/ikanos-spec/src/test/resources/imports/aggregate-duplicate-function-name.yaml
@@ -1,6 +1,6 @@
 # Aggregate with two functions sharing the same name.
 # Should trigger: ikanos-aggregates-unique-function-name
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 capability:
   aggregates:

--- a/ikanos-spec/src/test/resources/imports/aggregates-namespace-missing.yaml
+++ b/ikanos-spec/src/test/resources/imports/aggregates-namespace-missing.yaml
@@ -1,6 +1,6 @@
 # Standalone source file with an `aggregates` entry that lacks `namespace`.
 # Should trigger: ikanos-aggregates-namespace-required
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 aggregates:
   - label: Weather Service

--- a/ikanos-spec/src/test/resources/imports/capability-aggregates-namespace-missing.yaml
+++ b/ikanos-spec/src/test/resources/imports/capability-aggregates-namespace-missing.yaml
@@ -1,7 +1,7 @@
 # Capability with an inline `aggregates` entry (declares `functions`) that lacks `namespace`.
 # Tests the new `$.capability.aggregates[?(@.functions)]` JSONPath in the rule.
 # Should trigger: ikanos-aggregates-namespace-required
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 capability:
   aggregates:

--- a/ikanos-spec/src/test/resources/imports/capability-exposes-namespace-missing.yaml
+++ b/ikanos-spec/src/test/resources/imports/capability-exposes-namespace-missing.yaml
@@ -1,7 +1,7 @@
 # Capability with an inline `exposes` entry (declares `type`) that lacks `namespace`.
 # Tests the new `$.capability.exposes[?(@.type)]` JSONPath in the rule.
 # Should trigger: ikanos-exposes-namespace-required
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 capability:
   exposes:

--- a/ikanos-spec/src/test/resources/imports/exposes-namespace-missing.yaml
+++ b/ikanos-spec/src/test/resources/imports/exposes-namespace-missing.yaml
@@ -1,6 +1,6 @@
 # Standalone source file with an `exposes` entry that lacks `namespace`.
 # Should trigger: ikanos-exposes-namespace-required
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 exposes:
   - type: rest

--- a/ikanos-spec/src/test/resources/imports/import-duplicate-alias.yaml
+++ b/ikanos-spec/src/test/resources/imports/import-duplicate-alias.yaml
@@ -4,7 +4,7 @@
 # Both entries resolve to effective namespace "weather":
 #   - entry 0: `import: weather` (no `as`)
 #   - entry 1: `import: forecast`, `as: weather`
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 capability:
   consumes:

--- a/ikanos-spec/src/test/resources/imports/import-from-self.yaml
+++ b/ikanos-spec/src/test/resources/imports/import-from-self.yaml
@@ -1,6 +1,6 @@
 # Capability with an import `from` pointing to the current directory (bare dot).
 # Should trigger: ikanos-import-from-not-self
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 capability:
   consumes:

--- a/ikanos-spec/src/test/resources/imports/import-missing-fields.yaml
+++ b/ikanos-spec/src/test/resources/imports/import-missing-fields.yaml
@@ -3,7 +3,7 @@
 # Should trigger:
 #   - ikanos-import-from-required  (entry 0 has `from` but no `import`)
 #   - ikanos-import-import-required (entry 1 has `import` but no `from` and no `type`)
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 capability:
   consumes:

--- a/ikanos-spec/src/test/resources/imports/standalone-with-imports.yaml
+++ b/ikanos-spec/src/test/resources/imports/standalone-with-imports.yaml
@@ -1,6 +1,6 @@
 # Standalone source file (no `capability` key) that contains an import entry.
 # Should trigger: ikanos-standalone-no-imports
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 exposes:
   - namespace: weather

--- a/ikanos-spec/src/test/resources/rules/spectral-semantics-consistent.yaml
+++ b/ikanos-spec/src/test/resources/rules/spectral-semantics-consistent.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 capability:
   aggregates:
   - display: Weather Service

--- a/ikanos-spec/src/test/resources/rules/spectral-semantics-inconsistent.yaml
+++ b/ikanos-spec/src/test/resources/rules/spectral-semantics-inconsistent.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha3
+ikanos: 1.0.0-alpha4
 capability:
   aggregates:
   - display: Weather Service

--- a/ikanos-spec/src/test/resources/rules/spectral-tunnel-fallback-direct-public.yaml
+++ b/ikanos-spec/src/test/resources/rules/spectral-tunnel-fallback-direct-public.yaml
@@ -3,7 +3,7 @@
 #
 # The tunnel uses fallback: direct against a non-loopback baseUri
 # (https://crm.internal). The warn rule must report a violation.
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 info:
   display: "Reverse tunnel — direct fallback on non-loopback baseUri"

--- a/ikanos-spec/src/test/resources/rules/spectral-tunnel-identity-bound.yaml
+++ b/ikanos-spec/src/test/resources/rules/spectral-tunnel-identity-bound.yaml
@@ -4,7 +4,7 @@
 # The tunnel.identity references the "secrets.ZITI_IDENTITY" key, and "secrets"
 # is declared in binds with a matching key. The custom function must accept this
 # document silently.
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 info:
   display: "Reverse tunnel — bound identity reference"

--- a/ikanos-spec/src/test/resources/rules/spectral-tunnel-identity-unbound.yaml
+++ b/ikanos-spec/src/test/resources/rules/spectral-tunnel-identity-unbound.yaml
@@ -4,7 +4,7 @@
 # The tunnel.identity references a Mustache namespace ("secrets") that is NOT
 # declared in binds/capability.binds. The custom function tunnel-identity-binds-ref
 # must report a violation.
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 
 info:
   display: "Reverse tunnel — unbound identity reference"

--- a/ikanos-spec/src/test/resources/skill-capability.yaml
+++ b/ikanos-spec/src/test/resources/skill-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha3"
+ikanos: "1.0.0-alpha4"
 info:
   display: "Skill Test Capability"
   description: "Test capability for Skill Server Adapter deserialization and wiring"

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <graalvm.polyglot.version>24.1.1</graalvm.polyglot.version>
         <groovy.version>4.0.24</groovy.version>
         <openziti.version>0.33.1</openziti.version>
-        <revision>1.0.0-alpha3</revision>
+        <revision>1.0.0-alpha4-SNAPSHOT</revision>
         <!--
           JaCoCo coverage gate (Phase A of the 100 % coverage plan, epic #445).
           Each module's BUNDLE LINE / BRANCH coverage must stay >= these floors.


### PR DESCRIPTION
## Related Issue

N/A — release fix (issue step waived by maintainer)

---

## What does this PR do?

Bumps the Ikanos spec version from `1.0.0-alpha3` to `1.0.0-alpha4` and hardens the
codebase against future version drift. Three distinct actions:

### 1 — YAML/JSON fixtures migrated manually

The version sync script (`scripts/sync-ikanos-version.py`) updated `pom.xml` and the
schema, but missed several files. Fixed manually:

- 26 YAML test fixtures in `ikanos-engine/src/test/resources/` and `ikanos-spec/src/test/resources/`
- Tutorial capabilities in `ikanos-docs/tutorial/shared/` and `ikanos-engine/src/test/resources/tutorial/`
- Schema examples (`reverse-tunnel-ziti.yml`) and the schema itself (`ikanos-schema.json`)

### 2 — `VersionHelper` injection in inline Java YAML text blocks

Test files that embed YAML inline (text blocks / string literals) were hardcoding the
version string. Two files in `ikanos-cli` had never been migrated at all (still on
`alpha1`/`alpha2`). All six affected files now use
`io.ikanos.spec.util.VersionHelper.getSchemaVersion()` via a `String.formatted(...)` call:

```java
private static final String IKANOS = VersionHelper.getSchemaVersion();

String yaml = """
    ikanos: "%s"
    ...
    """.formatted(IKANOS);
```

`VersionHelper` reads the Maven-filtered `version.properties`, so future version bumps
are picked up automatically without touching test code.

Files changed: `TunnelSchemaValidationTest`, `ImportSchemaValidationTest`,
`ImportDirectiveDeserializationTest`, `AggregateFlowDeserializationTest` (ikanos-spec),
`ControlPortMixinTest`, `ExportOpenApiCommandTest` (ikanos-cli).

### 3 — Agent/contributor instructions updated

The rule is now documented in two places so it cannot be missed again:

- **`AGENTS.md`** — two new bullets in "Test Writing Rules / Do":
  inline YAML → `VersionHelper`; YAML/JSON fixtures → update `sync-ikanos-version.py`
- **`CONTRIBUTING.md`** — new subsection "Writing tests — handling the spec version"
  with full examples and rationale

---

## Tests

- `ikanos-spec`: 34/34 tests pass
- `ikanos-cli`: 22/22 tests pass (including the two previously-drifted files)

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Naftiko - Claude Sonnet 4.6
tool: VS Code Copilot Chat
confidence: high
source_event: version bump + test failures
discovery_method: test_failure
review_focus: "ControlPortMixinTest.java, ExportOpenApiCommandTest.java, AGENTS.md, CONTRIBUTING.md"
```
