### PR TITLE
chore: config publish to docker hub

### DIFF
--- a/.github/workflows/publish-engine-image.yml
+++ b/.github/workflows/publish-engine-image.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-push-to-ghcr:
+  build-and-push:
     runs-on: ubuntu-latest
 
     permissions:
@@ -18,6 +18,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # GHCR login
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -25,11 +26,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Docker Hub login
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Extract metadata (tags & labels)
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/ikanos 
+          images: |
+            ghcr.io/${{ github.repository_owner }}/ikanos
+            docker.io/naftiko/ikanos
           tags: |
             type=sha,prefix=sha-
             type=raw,value=latest


### PR DESCRIPTION
## Related Issue

Closes https://github.com/naftiko/ikanos/issues/543

---

## What does this PR do?

publishes to now both docker and ghcr

---

## Tests

https://github.com/naftiko/ikanos/actions/runs/26641781168

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)


