### PR TITLE
docs: point documentation links to the Shipyard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,11 @@
 
 ## Project Context
 
-**Ikanos** is the engine for [Spec-Driven Integration](https://github.com/naftiko/ikanos/wiki/Spec%E2%80%90Driven-Integration). Capabilities are declared entirely in YAML — no Java required. The framework parses them and exposes them via MCP, SKILL, or REST servers.
+**Ikanos** is the engine for [Spec-Driven Integration](https://shipyard.naftiko.io/docs/1.0.0-alpha3/concepts/spec-driven-integration/). Capabilities are declared entirely in YAML — no Java required. The framework parses them and exposes them via MCP, SKILL, or REST servers.
 
 - **Language**: Java 21, Maven build system (multi-module: `ikanos-spec`, `ikanos-engine`, `ikanos-cli`, `ikanos-docs`)
 - **Specification**: `ikanos-spec/src/main/resources/schemas/ikanos-schema.json` — keep this as first-class citizen in your context
-- **Wiki**: https://github.com/naftiko/ikanos/wiki (Specification, Tutorial, Use Cases, FAQ)
+- **Shipyard**: https://shipyard.naftiko.io/docs/1.0.0-alpha3/ikanos/ (Specification, Tutorials, Use Cases, FAQ)
 
 ## Key Files
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ This section provides **machine-readable guidance** for AI coding agents contrib
 - **Specification**: The Ikanos Specification defines the capability schema. See `ikanos-spec/src/main/resources/schemas/ikanos-schema.json` for the latest JSON Schema.
 - **Examples**: `ikanos-spec/src/main/resources/schemas/examples/` contains capability examples. `ikanos-docs/tutorial/` contains step-by-step tutorial capabilities.
 - **Test fixtures**: `ikanos-engine/src/test/resources/` and `ikanos-cli/src/test/resources/` contain YAML capabilities used for unit tests.
-- **Wiki**: the [project wiki](https://github.com/naftiko/ikanos/wiki) contains the full specification, tutorial, FAQ, and use cases.
+- **Shipyard**: the [Naftiko Shipyard](https://shipyard.naftiko.io/docs/1.0.0-alpha3/ikanos/) contains the full specification, tutorials, FAQ, and use cases.
 
 ### Agent contribution rules
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Welcome to **Ikanos**, the first Open Source project for [Spec-Driven Integratio
 
 ## What Ikanos is
 
-Ikanos is the **capability engine** at the heart of the Naftiko Fleet. It reads an Ikanos YAML specification at startup and immediately serves it as a multi-protocol server — **MCP**, **Skill**, **REST**, and **Control** — with **no code generation and no compilation step**. The spec *is* the artifact and the runtime contract.
+Ikanos is a **capability engine** that reads an Ikanos YAML specification at startup and immediately serves it as a multi-protocol server — **MCP**, **Skill**, **REST**, and **Control** — with **no code generation and no compilation step**. The spec *is* the artifact and the runtime contract.
 
 Each capability is a coarse-grained slice of a domain. It consumes existing HTTP-based APIs, optionally orchestrates and transforms the data, then exposes the result in several protocols so that AI agents, web apps, and partners can all consume it the same way. The project ships as three pieces:
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Welcome to **Ikanos**, the first Open Source project for [Spec-Driven Integratio
 
 > Ikanos comes from the Greek *ικανός* — **capable**.
 
-<img src="https://naftiko.github.io/docs/images/technology/architecture_capability.png" width="600">
+<img src="https://naftiko.github.io/docs/images/technology/architecture_capability.png" width="700">
 
 ## What Ikanos is
 

--- a/README.md
+++ b/README.md
@@ -5,55 +5,128 @@
 [![Trivy](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/farah-t-trigui/50bfcb34f6512cbad2dd4f460bfc6526/raw/framework-trivy.json)](https://github.com/naftiko/ikanos/actions/workflows/quality-gate.yml)
 [![Gitleaks](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/farah-t-trigui/50bfcb34f6512cbad2dd4f460bfc6526/raw/framework-gitleaks.json)](https://github.com/naftiko/ikanos/actions/workflows/quality-gate.yml)
 
-Welcome to Ikanos, the first Open Source project for [Spec-Driven Integration](https://github.com/naftiko/ikanos/wiki/Spec%E2%80%90Driven-Integration) reinventing API integration for the AI era with governed and versatile capabilities that streamline API sprawl from massive SaaS and microservices growth.
+Welcome to **Ikanos**, the first Open Source project for [Spec-Driven Integration](https://shipyard.naftiko.io/docs/1.0.0-alpha3/concepts/spec-driven-integration/) — reinventing API integration for the AI era with governed, versatile **capabilities** that streamline the API sprawl created by massive SaaS and microservices growth.
+
+> Ikanos comes from the Greek *ικανός* — **capable**.
 
 <img src="https://naftiko.github.io/docs/images/technology/architecture_capability.png" width="600">
 
-Each capability is a coarse piece of domain that consumes existing HTTP-based APIs then exposes them in several protocols to enable AI integration and self-integrating agents. Ikanos includes a specification, an engine and a CLI.
+## What Ikanos is
+
+Ikanos is the **capability engine** at the heart of the Naftiko Fleet. It reads an Ikanos YAML specification at startup and immediately serves it as a multi-protocol server — **MCP**, **Skill**, **REST**, and **Control** — with **no code generation and no compilation step**. The spec *is* the artifact and the runtime contract.
+
+Each capability is a coarse-grained slice of a domain. It consumes existing HTTP-based APIs, optionally orchestrates and transforms the data, then exposes the result in several protocols so that AI agents, web apps, and partners can all consume it the same way. The project ships as three pieces:
+
+In production, one Ikanos process serves one *capability* as a Docker container. Multiple capabilities running in the same Kubernetes cluster constitute a *ship* while larger organizations operate a *fleet* federating several ships. This is where Naftiko Fleet can help you scale Ikanos from development to governance.
+
+## What Ikanos is *not*
+
+- **Not a code generator.** Tooling can *scaffold* the YAML spec for you, and Ikanos can *export* artifacts from it — such as OpenAPI contracts — but the running capability never compiles or executes generated source. At runtime it does one thing: interpret the YAML spec directly. The spec is the deliverable — and because that deliverable is plain, declarative YAML rather than generated code, it's especially well-suited to **Generative AI**: an LLM can author, edit, and reason about a capability end to end, with no build step in the loop.
+- **Not a service mesh** A classic mesh wraps every pod in a sidecar (or an ambient data plane) to add resiliency, transport security, and traffic control *underneath* your services. Ikanos builds those same concerns into the capability engine itself such as retries, timeouts, circuit breaking, and rate limiting today, mTLS verification on both sides and traffic controls like load-based routing planned next. When your traffic is Ikanos capabilities talking to Ikanos capabilities, there's no sidecar to inject and no mesh to operate — the engine *is* the data plane.
+- **Not a workflow engine.** Ikanos already orchestrates multi-step capabilities; as it grows to cover Agent Orchestration in v1.0+, it adds long-running workflows, durable agent memory, and checkpoints natively — without the bespoke DSLs, BPMN diagrams, or separate runtime of a classic workflow engine. Orchestration stays inside the capability contract and is consumable by AI agents the moment it's declared.
+
+## Key features at a glance
 
 | Feature | Description |
 |---|---|
 | Spec-Driven Integration | Declare capabilities entirely in **YAML** — no Java required |
-| Multi-Protocol Servers | Expose capabilities via **MCP**, **SKILL**, or **REST** servers out of the box |
+| Multi-Protocol Servers | Expose capabilities via **MCP**, **Skill**, **REST**, or **Control** out of the box |
 | Data Format Conversion | Transform **Protobuf**, **XML**, **YAML**, **CSV**, **TSV**, **PSV**, **Avro**, **HTML**, and **Markdown** payloads into JSON |
 | HTTP API Consumption | Connect to any HTTP-based API with built-in authentication support |
 | Templating & Querying | Use **Mustache** templates and **JSONPath** expressions for flexible data mapping |
-| Inline Scripting | Embed **JavaScript**, **Python**, or **Groovy** transformations between API calls with sandboxed execution |
-| Domain-Driven Aggregates | Define reusable domain functions once, expose via multiple adapters — inspired by **DDD** Aggregate pattern |
-| Server Authentication | Secure exposed endpoints with **Bearer**, **API Key**, **Basic**, **Digest**, or **OAuth 2.1** authentication out of the box |
+| Inline Scripting | Embed sandboxed **JavaScript**, **Python**, or **Groovy** transformations between API calls (GraalVM) |
+| Domain-Driven Aggregates | Define reusable domain functions once, expose via multiple adapters — inspired by the **DDD** Aggregate pattern |
+| Server Authentication | Secure exposed endpoints with **Bearer**, **API Key**, **Basic**, **Digest**, or **OAuth 2.1** out of the box |
 | AI Native | Designed for Context Engineering and Agent Orchestration, making capabilities directly consumable by AI agents |
-| OpenAPI Interoperability | Import **Swagger 2.0**, **OAS 3.0/3.1** into consumes adapters, export REST adapters as **OpenAPI** documents |
+| OpenAPI Interoperability | Import **Swagger 2.0**, **OAS 3.0/3.1** into consumes adapters; export REST adapters as **OpenAPI** documents |
 | Control Port | Built-in management plane with **health**, **metrics**, **traces**, and **status** endpoints |
-| Cloud Native Operations| **OpenTelemetry** tracing & RED metrics, **Prometheus** scrape, single **Docker** image for all capabilities |
+| Cloud Native Operations | **OpenTelemetry** tracing & RED metrics, **Prometheus** scrape, single **Docker** image for all capabilities |
 | Extensible | Open-source core extensible with new protocols and adapters |
 
+## How Ikanos compares
+
+Increasingly, developers don't hand-write this integration layer at all — they describe what they want and let generative AI produce the artifact. That shifts the question from *"which tool is nicest to code in?"* to *"which artifact can an AI reliably generate, and can a human still review and govern it?"* The answer depends on what each tool asks the AI to emit:
+
+- **Agentic coding frameworks** — *LangChain, LangChain4j, LlamaIndex, Spring AI.* The AI has to write tools, retrievers, and orchestration as Python/Java — full application code that must compile, run, and be trusted.
+- **MCP server frameworks** — *FastMCP, Spring AI MCP, the official MCP SDKs.* The AI writes an MCP server and its tool handlers — again, code to build and maintain.
+- **MCP proxy generators** — *Stainless, APIMatic, Speakeasy, Mintlify.* No AI authoring here; they mechanically turn one OpenAPI document into a 1:1 SDK or MCP server.
+
+Ikanos asks the AI for something simpler and safer: a **declarative YAML capability** validated against a stable schema. Generated YAML is easier for a model to get right than framework code, it shows up as a readable diff in a pull request, and it can be linted (with [Polychro](https://shipyard.naftiko.io/docs/1.0.0-alpha3/polychro/)) before it ever runs — so a human stays in control of what the AI produced. One capability can also consume and compose several upstream APIs (for example, joining a customer, their orders, and their open tickets from three services) and expose the result over MCP, Skill, and REST at once.
+
+Ikanos is also designed to fit alongside these tools rather than replace them: it imports OpenAPI, exposes MCP, and integrates with LangChain4j as in-process tools, so adopting it usually means keeping your runtime and replacing hand-written glue with an AI-authored, reviewable spec.
+
+> For a dimension-by-dimension comparison, and guidance on when another tool is a better fit, see the [Comparison guide](https://shipyard.naftiko.io/docs/1.0.0-alpha3/ikanos/comparison/) on the Shipyard.
+
+## Quick start
+
+You can run Ikanos with the **native CLI** or the **Docker image**. The CLI has the least friction, so start there.
+
+### With the CLI
+
+```bash
+# Create a minimal, valid capability interactively
+ikanos create capability
+
+# Validate it against the latest schema
+ikanos validate my-capability.yml
+
+# Serve it locally (Ctrl-C to stop)
+ikanos serve my-capability.yml
+```
+
+The CLI can also bootstrap a capability from an existing OpenAPI document (`ikanos import openapi ...`) and export a REST adapter back to OpenAPI (`ikanos export openapi ...`).
+
+### With Docker
+
+```bash
+# Pull the image (pin to a release tag, or use latest for the newest snapshot)
+docker pull ghcr.io/naftiko/ikanos:latest
+
+# Serve a capability file (mount it at /app/ikanos.yaml — the image serves it by default)
+docker run -p 8081:3001 \
+  -v "$PWD/my-capability.yml:/app/ikanos.yaml" \
+  ghcr.io/naftiko/ikanos:latest
+```
+
+> Full installation steps for the CLI, Docker, and every platform are in the [Installation guide](https://shipyard.naftiko.io/docs/1.0.0-alpha3/ikanos/installation/) on the Shipyard.
+
 ***
 
-Here are additional documents to learn more:
+## :anchor: Dive deeper on the Shipyard
 
-- :compass: [Spec-Driven Integration](https://github.com/naftiko/ikanos/wiki/Spec%E2%80%90Driven-Integration)
-- :rowboat: [Installation](https://github.com/naftiko/ikanos/wiki/Installation)
-- :sailboat: [Tutorial - Part 1](https://github.com/naftiko/ikanos/wiki/Tutorial-%E2%80%90-Part-1)
-- :speedboat: [Tutorial - Part 2](https://github.com/naftiko/ikanos/wiki/Tutorial-%E2%80%90-Part-2)
-- :ship: [Guide - Use Cases](https://github.com/naftiko/ikanos/wiki/Guide-%E2%80%90-Use-Cases)
-- :mag: [Guide - Linting](https://github.com/naftiko/ikanos/wiki/Guide-%E2%80%90-Linting)
-- :anchor: [Specification - Schema](https://github.com/naftiko/ikanos/wiki/Specification-%E2%80%90-Schema)
-- :triangular_ruler: [Specification - Rules](https://github.com/naftiko/ikanos/wiki/Specification-%E2%80%90-Rules)
-- :ocean: [FAQ](https://github.com/naftiko/ikanos/wiki/FAQ)
-- :mega: [Releases](https://github.com/naftiko/ikanos/wiki/Releases)
-- :telescope: [Roadmap](https://github.com/naftiko/ikanos/wiki/Roadmap)
+The complete, always-up-to-date Ikanos documentation lives on the **Naftiko Shipyard**. Start here and keep exploring:
+
+- :compass: [Concepts — Spec-Driven Integration](https://shipyard.naftiko.io/docs/1.0.0-alpha3/concepts/)
+- :rowboat: [Installation](https://shipyard.naftiko.io/docs/1.0.0-alpha3/ikanos/installation/)
+- :sailboat: [Tutorials](https://shipyard.naftiko.io/docs/1.0.0-alpha3/tutorials/) — guided tracks from your first capability to platform operations
+- :ship: [Use Cases](https://shipyard.naftiko.io/docs/1.0.0-alpha3/concepts/use-cases/)
+- :star: [Features](https://shipyard.naftiko.io/docs/1.0.0-alpha3/ikanos/features/)
+- :mag: [Linting Guide](https://shipyard.naftiko.io/docs/1.0.0-alpha3/ikanos/guide/linting/) — pair Ikanos with Polychro
+- :anchor: [Specification — Schema](https://shipyard.naftiko.io/docs/1.0.0-alpha3/ikanos/schema/)
+- :triangular_ruler: [Specification — Ruleset](https://shipyard.naftiko.io/docs/1.0.0-alpha3/ikanos/ruleset/)
+- :keyboard: [CLI Reference](https://shipyard.naftiko.io/docs/1.0.0-alpha3/ikanos/cli/)
+- :ocean: [FAQ](https://shipyard.naftiko.io/docs/1.0.0-alpha3/ikanos/faq/)
+- :mega: [Releases](https://shipyard.naftiko.io/docs/1.0.0-alpha3/ikanos/releases/)
+- :telescope: [Roadmap](https://shipyard.naftiko.io/docs/1.0.0-alpha3/ikanos/roadmap/)
 - :nut_and_bolt: [Contribute](https://github.com/naftiko/ikanos/blob/main/CONTRIBUTING.md)
 
+## :video_game: Try it in the Playground
+
+Want to see Ikanos in action without installing anything? The upcoming **Shipyard Playground** lets you author a capability, lint it live with **Polychro**, and serve it with **Ikanos** — all from your browser. Keep an eye on the [Shipyard](https://shipyard.naftiko.io/docs/1.0.0-alpha3/) for its release.
+
 ***
 
-Ikanos is part of [Naftiko Fleet (Community Edition)](https://github.com/naftiko/fleet), which adds free complementary tools:
+## Part of the Naftiko Fleet
+
+Ikanos is part of the [Naftiko Fleet (Community Edition)](https://shipyard.naftiko.io/docs/1.0.0-alpha3/fleet/), which adds free complementary tools:
 
 | Tool | What it does |
 |---|---|
-| [Naftiko Crafter](https://github.com/naftiko/fleet/wiki/Naftiko-Crafter) | Free Naftiko extension for Visual Studio Code to help with the editing and linting of Ikanos capabilities. |
-| [Naftiko Warden](https://github.com/naftiko/fleet/wiki/Naftiko-Warden) | Free Naftiko Warden custom templates for CNCF's Backstage to help with the scaffolding and cataloguing of Ikanos capabilities. |
-| Naftiko Skipper | Free operator and Helm chart for CNCF's Kubernetes to help with the operations of Ikanos capabilities [coming soon]. |
+| [Polychro](https://shipyard.naftiko.io/docs/1.0.0-alpha3/polychro/) | Polyglot linter that validates Ikanos capabilities against the schema and ruleset. |
+| [Crafter](https://shipyard.naftiko.io/docs/1.0.0-alpha3/fleet/crafter/) | Free Naftiko extension for Visual Studio Code to help with editing and linting Ikanos capabilities. |
+| [Warden](https://shipyard.naftiko.io/docs/1.0.0-alpha3/fleet/) | Naftiko custom templates for CNCF's Backstage to help with scaffolding and cataloguing Ikanos capabilities. |
+| [Skipper](https://shipyard.naftiko.io/docs/1.0.0-alpha3/fleet/skipper/) | Operator and Helm chart for CNCF's Kubernetes to help with the operations of Ikanos capabilities. |
 
-Please join the community of users and contributors in [this GitHub Discussion forum!](https://github.com/orgs/naftiko/discussions).
+Please join the community of users and contributors in [this GitHub Discussion forum!](https://github.com/orgs/naftiko/discussions)
 
 <img src="https://naftiko.github.io/docs/images/navi/navi_hello.svg" width="50">


### PR DESCRIPTION
## Summary

Replaces the GitHub Wiki references with the **Naftiko Shipyard** across the contributor-facing documentation, ahead of the upcoming removal of the GitHub Wiki section in favor of the Shipyard.

## Changes

- **`README.md`** — overhaul of the intro and structure to match the latest messaging:
  - Reworded intro + added the Greek etymology callout
  - New sections: *What Ikanos is*, *What Ikanos is not*, *How Ikanos compares*, *Quick start* (CLI + Docker), *Try it in the Playground*
  - Repointed every Wiki/fleet link to `shipyard.naftiko.io/docs/1.0.0-alpha3/...`
  - Refreshed the Fleet table (Polychro, Crafter, Warden, Skipper)
- **`AGENTS.md`** — replaced the Spec-Driven Integration Wiki link and the **Wiki** bullet with the Shipyard (`shipyard.naftiko.io/docs/1.0.0-alpha3/ikanos/`)
- **`CONTRIBUTING.md`** — replaced the **Wiki** reference in the AI-agent repository context with the Shipyard

## Notes

- Documentation-only change — no code, CI, or build impact.
- Relative in-repo links (e.g. schema/ruleset paths) were intentionally left untouched.
