### PR TITLE
fix: populate SLF4J MDC with trace_id/span_id on MCP and REST requests

### DIFF
--- a/ikanos-engine/pom.xml
+++ b/ikanos-engine/pom.xml
@@ -24,6 +24,15 @@
         <dependency>
             <groupId>org.restlet</groupId>
             <artifactId>org.restlet</artifactId>
+            <exclusions>
+                <!-- Jetty 12 bundles its own SLF4J provider which conflicts with Logback.
+                     Logback is the intended provider for log-trace correlation (trace_id/span_id
+                     MDC keys via OpenTelemetryAppender). See issue #548. -->
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-slf4j-impl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.restlet</groupId>

--- a/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/McpServerResource.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/McpServerResource.java
@@ -100,6 +100,7 @@ public class McpServerResource extends ServerResource {
             Span span = TelemetryBootstrap.get().startServerSpan("mcp", rpcMethod,
                     extractedContext, null, capabilityName);
             try (Scope scope = span.makeCurrent()) {
+                TelemetryBootstrap.populateMdc(span);
                 // Delegate to the shared protocol dispatcher
                 ObjectNode result = dispatcher.dispatch(root);
 
@@ -114,6 +115,7 @@ public class McpServerResource extends ServerResource {
                 TelemetryBootstrap.recordError(span, e);
                 throw e;
             } finally {
+                TelemetryBootstrap.clearMdc();
                 TelemetryBootstrap.endSpan(span);
             }
 

--- a/ikanos-engine/src/main/java/io/ikanos/engine/exposes/rest/ResourceRestlet.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/exposes/rest/ResourceRestlet.java
@@ -77,6 +77,7 @@ public class ResourceRestlet extends Restlet {
         long startNanos = System.nanoTime();
         boolean error = false;
         try (Scope scope = span.makeCurrent()) {
+            TelemetryBootstrap.populateMdc(span);
             boolean handled = handleFromOperationSpec(request, response);
 
             if (!handled && getResourceSpec().getForward() != null) {
@@ -101,6 +102,7 @@ public class ResourceRestlet extends Restlet {
                     : response.getStatus() != null
                             ? String.valueOf(response.getStatus().getCode()) : "200";
             telemetry.getMetrics().recordRequest("rest", operationId, status, durationSec);
+            TelemetryBootstrap.clearMdc();
             TelemetryBootstrap.endSpan(span);
         }
     }

--- a/ikanos-engine/src/main/java/io/ikanos/engine/exposes/skill/SkillServerResource.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/exposes/skill/SkillServerResource.java
@@ -61,6 +61,7 @@ abstract class SkillServerResource extends ServerResource {
         long startNanos = System.nanoTime();
         boolean error = false;
         try (Scope scope = span.makeCurrent()) {
+            TelemetryBootstrap.populateMdc(span);
             return super.handle();
         } catch (Exception e) {
             error = true;
@@ -74,6 +75,7 @@ abstract class SkillServerResource extends ServerResource {
                     : getResponse() != null && getResponse().getStatus() != null
                             ? String.valueOf(getResponse().getStatus().getCode()) : "200";
             telemetry.getMetrics().recordRequest("skill", operationId, status, durationSec);
+            TelemetryBootstrap.clearMdc();
             TelemetryBootstrap.endSpan(span);
         }
     }

--- a/ikanos-engine/src/main/java/io/ikanos/engine/observability/TelemetryBootstrap.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/observability/TelemetryBootstrap.java
@@ -446,4 +446,32 @@ public class TelemetryBootstrap {
             span.end();
         }
     }
+
+    /**
+     * Populates the SLF4J MDC with {@code trace_id} and {@code span_id} from the given span so
+     * that Logback pattern tokens {@code %X{trace_id}} and {@code %X{span_id}} are non-empty in
+     * log lines emitted during the span's lifetime.
+     *
+     * <p>Must be called after {@link Span#makeCurrent()} and paired with {@link #clearMdc()}
+     * in a {@code finally} block. This is required because
+     * {@code opentelemetry-logback-appender-1.0} is a log-forwarding appender, not an MDC bridge —
+     * it does not automatically populate MDC keys for pattern interpolation. See issue #548.</p>
+     */
+    public static void populateMdc(Span span) {
+        if (span == null) return;
+        io.opentelemetry.api.trace.SpanContext ctx = span.getSpanContext();
+        if (ctx.isValid()) {
+            org.slf4j.MDC.put("trace_id", ctx.getTraceId());
+            org.slf4j.MDC.put("span_id", ctx.getSpanId());
+        }
+    }
+
+    /**
+     * Removes the {@code trace_id} and {@code span_id} keys from the SLF4J MDC.
+     * Must be called in the {@code finally} block that pairs with {@link #populateMdc(Span)}.
+     */
+    public static void clearMdc() {
+        org.slf4j.MDC.remove("trace_id");
+        org.slf4j.MDC.remove("span_id");
+    }
 }

--- a/ikanos-engine/src/main/java/io/ikanos/engine/observability/TelemetryBootstrap.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/observability/TelemetryBootstrap.java
@@ -46,6 +46,18 @@ public class TelemetryBootstrap {
 
     static final String INSTRUMENTATION_NAME = "io.ikanos.engine";
 
+    /**
+     * SLF4J MDC key for the current trace id. Must match the {@code %X{trace_id}} token in
+     * {@code logback.xml}. See issue #548.
+     */
+    public static final String MDC_TRACE_ID = "trace_id";
+
+    /**
+     * SLF4J MDC key for the current span id. Must match the {@code %X{span_id}} token in
+     * {@code logback.xml}. See issue #548.
+     */
+    public static final String MDC_SPAN_ID = "span_id";
+
     public static final AttributeKey<String> ATTR_ADAPTER_TYPE = AttributeKey.stringKey("ikanos.adapter.type");
     public static final AttributeKey<String> ATTR_CAPABILITY = AttributeKey.stringKey("ikanos.capability");
     public static final AttributeKey<String> ATTR_OPERATION_ID = AttributeKey.stringKey("ikanos.operation.id");
@@ -461,8 +473,8 @@ public class TelemetryBootstrap {
         if (span == null) return;
         io.opentelemetry.api.trace.SpanContext ctx = span.getSpanContext();
         if (ctx.isValid()) {
-            org.slf4j.MDC.put("trace_id", ctx.getTraceId());
-            org.slf4j.MDC.put("span_id", ctx.getSpanId());
+            org.slf4j.MDC.put(MDC_TRACE_ID, ctx.getTraceId());
+            org.slf4j.MDC.put(MDC_SPAN_ID, ctx.getSpanId());
         }
     }
 
@@ -471,7 +483,7 @@ public class TelemetryBootstrap {
      * Must be called in the {@code finally} block that pairs with {@link #populateMdc(Span)}.
      */
     public static void clearMdc() {
-        org.slf4j.MDC.remove("trace_id");
-        org.slf4j.MDC.remove("span_id");
+        org.slf4j.MDC.remove(MDC_TRACE_ID);
+        org.slf4j.MDC.remove(MDC_SPAN_ID);
     }
 }

--- a/ikanos-engine/src/main/java/io/ikanos/engine/observability/TelemetryBootstrap.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/observability/TelemetryBootstrap.java
@@ -22,6 +22,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
@@ -32,6 +33,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
+import org.slf4j.MDC;
 
 /**
  * Bootstraps the OpenTelemetry SDK for the Naftiko engine.
@@ -471,10 +473,10 @@ public class TelemetryBootstrap {
      */
     public static void populateMdc(Span span) {
         if (span == null) return;
-        io.opentelemetry.api.trace.SpanContext ctx = span.getSpanContext();
+        SpanContext ctx = span.getSpanContext();
         if (ctx.isValid()) {
-            org.slf4j.MDC.put(MDC_TRACE_ID, ctx.getTraceId());
-            org.slf4j.MDC.put(MDC_SPAN_ID, ctx.getSpanId());
+            MDC.put(MDC_TRACE_ID, ctx.getTraceId());
+            MDC.put(MDC_SPAN_ID, ctx.getSpanId());
         }
     }
 
@@ -483,7 +485,7 @@ public class TelemetryBootstrap {
      * Must be called in the {@code finally} block that pairs with {@link #populateMdc(Span)}.
      */
     public static void clearMdc() {
-        org.slf4j.MDC.remove(MDC_TRACE_ID);
-        org.slf4j.MDC.remove(MDC_SPAN_ID);
+        MDC.remove(MDC_TRACE_ID);
+        MDC.remove(MDC_SPAN_ID);
     }
 }

--- a/ikanos-engine/src/main/resources/logback.xml
+++ b/ikanos-engine/src/main/resources/logback.xml
@@ -1,11 +1,14 @@
 <configuration>
-  <!-- Bridges the OTel span context into the Logback MDC (trace_id, span_id).
-       Required for %X{trace_id} and %X{span_id} in the pattern below to be non-empty.
+  <!-- Forwards log events (with their MDC attributes) to the OTel log pipeline.
+       This appender does NOT populate the MDC: TelemetryBootstrap.populateMdc() is what makes
+       %X{trace_id} and %X{span_id} in the pattern below non-empty (see issue #548).
        See: https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/logback/logback-appender-1.0 -->
   <appender name="OpenTelemetry"
             class="io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender">
     <captureExperimentalAttributes>false</captureExperimentalAttributes>
-    <captureMdcAttributes>*</captureMdcAttributes>
+    <!-- Least-privilege: export only the correlation keys we own, never arbitrary third-party
+         MDC data that embedding applications may set (issue #548 review). -->
+    <captureMdcAttributes>trace_id,span_id</captureMdcAttributes>
   </appender>
 
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">

--- a/ikanos-engine/src/main/resources/logback.xml
+++ b/ikanos-engine/src/main/resources/logback.xml
@@ -1,4 +1,13 @@
 <configuration>
+  <!-- Bridges the OTel span context into the Logback MDC (trace_id, span_id).
+       Required for %X{trace_id} and %X{span_id} in the pattern below to be non-empty.
+       See: https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/logback/logback-appender-1.0 -->
+  <appender name="OpenTelemetry"
+            class="io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender">
+    <captureExperimentalAttributes>false</captureExperimentalAttributes>
+    <captureMdcAttributes>*</captureMdcAttributes>
+  </appender>
+
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
       <pattern>%d{ISO8601} [%thread] %-5level %logger{36} - traceId=%X{trace_id} spanId=%X{span_id} - %msg%n</pattern>
@@ -6,5 +15,6 @@
   </appender>
   <root level="INFO">
     <appender-ref ref="CONSOLE" />
+    <appender-ref ref="OpenTelemetry" />
   </root>
 </configuration>

--- a/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ObservabilityMcpHttpLayerTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ObservabilityMcpHttpLayerTest.java
@@ -1,0 +1,234 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.ikanos.Capability;
+import io.ikanos.engine.observability.OtelTestFixtures;
+import io.ikanos.engine.observability.TelemetryBootstrap;
+import io.ikanos.spec.IkanosSpec;
+import io.ikanos.spec.util.VersionHelper;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.restlet.Context;
+import org.restlet.Request;
+import org.restlet.Response;
+import org.restlet.data.MediaType;
+import org.restlet.data.Method;
+import org.restlet.representation.StringRepresentation;
+import org.slf4j.MDC;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Non-regression tests for issue #548: during a {@code tools/call} MCP request processed through
+ * {@link McpServerResource}, the Logback MDC must contain non-empty {@code trace_id} and
+ * {@code span_id} keys for log-trace correlation to work.
+ *
+ * <p>The underlying cause: {@code logback.xml} referenced {@code %X{trace_id}} / {@code %X{span_id}}
+ * but did not include the {@code OpenTelemetryAppender} that populates those MDC keys. As a result,
+ * both fields were always empty regardless of whether a span existed.</p>
+ */
+class ObservabilityMcpHttpLayerTest {
+
+    private static final String SCHEMA_VERSION = VersionHelper.getSchemaVersion();
+
+    private final InMemorySpanExporter exporter = InMemorySpanExporter.create();
+
+    @BeforeEach
+    void setUp() {
+        OpenTelemetrySdk sdk = OpenTelemetrySdk.builder()
+                .setTracerProvider(OtelTestFixtures.tracerProvider(exporter))
+                .setPropagators(OtelTestFixtures.w3cPropagators())
+                .build();
+        TelemetryBootstrap.init(sdk);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TelemetryBootstrap.reset();
+        exporter.reset();
+        MDC.clear();
+    }
+
+    // ─── helpers ──────────────────────────────────────────────────────────────
+
+    private Capability capabilityFromYaml(String yaml) throws Exception {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        IkanosSpec spec = mapper.readValue(yaml, IkanosSpec.class);
+        return new Capability(spec);
+    }
+
+    private static String weatherCapabilityYaml() {
+        return """
+                ikanos: "%s"
+                info:
+                  display: "weather-capability"
+                capability:
+                  exposes:
+                    - type: "mcp"
+                      address: "localhost"
+                      port: 0
+                      namespace: "weather"
+                      tools:
+                        - name: "get-forecast"
+                          description: "Returns the weather forecast for a location"
+                          ref: "forecast.get-forecast"
+                          inputParameters:
+                            - name: "location"
+                              type: "string"
+                              description: "City name"
+                              required: true
+                  aggregates:
+                    - namespace: "forecast"
+                      flows:
+                        - name: "get-forecast"
+                          inputParameters:
+                            - name: "location"
+                              type: "string"
+                          outputParameters:
+                            - name: "summary"
+                              type: "string"
+                              value: "Sunny"
+                  consumes: []
+                """.formatted(SCHEMA_VERSION);
+    }
+
+    /**
+     * Builds a {@link McpServerResource} wired in-process without starting a real HTTP server,
+     * mirroring what {@link McpServerAdapter#initHttpTransport} does at runtime.
+     */
+    private McpServerResource buildResource(Capability capability) {
+        McpServerAdapter adapter = (McpServerAdapter) capability.getServerAdapters().get(0);
+        ProtocolDispatcher dispatcher = new ProtocolDispatcher(adapter);
+        Map<String, Boolean> sessions = new ConcurrentHashMap<>();
+
+        Context ctx = new Context();
+        ctx.getAttributes().put("dispatcher", dispatcher);
+        ctx.getAttributes().put("activeSessions", sessions);
+        ctx.getAttributes().put("capabilityName", "weather-capability");
+
+        McpServerResource resource = new McpServerResource();
+        Request request = new Request(Method.POST, "http://localhost/mcp");
+        Response response = new Response(request);
+        resource.init(ctx, request, response);
+        return resource;
+    }
+
+    private static StringRepresentation toolsCallBody(String toolName) {
+        return new StringRepresentation(
+                """
+                {"jsonrpc":"2.0","id":1,"method":"tools/call",\
+                "params":{"name":"%s","arguments":{"location":"Paris"}}}""".formatted(toolName),
+                MediaType.APPLICATION_JSON);
+    }
+
+    // ─── tests ────────────────────────────────────────────────────────────────
+
+    /**
+     * Regression test for issue #548.
+     *
+     * <p>During the execution of a {@code tools/call} request, the OTel span context must be
+     * bridged into the Logback MDC so that {@code %X{trace_id}} and {@code %X{span_id}} are
+     * non-empty in log lines. Without the {@code OpenTelemetryAppender} in {@code logback.xml},
+     * these values are always empty.</p>
+     */
+    @Test
+    void mcpToolsCallShouldPopulateMdcTraceIdAndSpanIdDuringExecution() throws Exception {
+        Capability capability = capabilityFromYaml(weatherCapabilityYaml());
+        McpServerResource resource = buildResource(capability);
+
+        // Capture MDC state from inside the span scope by intercepting via a custom
+        // ProtocolDispatcher subclass is not possible without reflection. Instead we rely
+        // on the OTel → MDC bridge being active: after handlePost() completes, the span is
+        // ended and the MDC is cleared. We therefore capture a snapshot mid-flight via a
+        // capturing Restlet context attribute set by an instrumented dispatcher.
+        //
+        // Simpler approach: wrap the handlePost call inside a scope where we can observe MDC.
+        // The OpenTelemetry Logback appender populates MDC synchronously within the span scope.
+        // We verify by asserting that the MDC was non-empty at some point during the call.
+        AtomicReference<String> capturedTraceId = new AtomicReference<>();
+        AtomicReference<String> capturedSpanId = new AtomicReference<>();
+
+        // Re-wire the dispatcher so we can observe MDC during dispatch
+        McpServerAdapter adapter = (McpServerAdapter) capability.getServerAdapters().get(0);
+        ProtocolDispatcher capturingDispatcher = new ProtocolDispatcher(adapter) {
+            @Override
+            public com.fasterxml.jackson.databind.node.ObjectNode dispatch(
+                    com.fasterxml.jackson.databind.JsonNode root) {
+                // At this point we are inside the SERVER span scope created by McpServerResource
+                capturedTraceId.set(MDC.get("trace_id"));
+                capturedSpanId.set(MDC.get("span_id"));
+                return super.dispatch(root);
+            }
+        };
+
+        Map<String, Boolean> sessions = new ConcurrentHashMap<>();
+        Context ctx = new Context();
+        ctx.getAttributes().put("dispatcher", capturingDispatcher);
+        ctx.getAttributes().put("activeSessions", sessions);
+        ctx.getAttributes().put("capabilityName", "weather-capability");
+
+        McpServerResource observedResource = new McpServerResource();
+        Request request = new Request(Method.POST, "http://localhost/mcp");
+        Response response = new Response(request);
+        observedResource.init(ctx, request, response);
+
+        observedResource.handlePost(toolsCallBody("get-forecast"));
+
+        assertNotNull(capturedTraceId.get(),
+                "MDC trace_id must be non-null inside the span scope (issue #548: "
+                + "OpenTelemetryAppender missing from logback.xml)");
+        assertFalse(capturedTraceId.get().isBlank(),
+                "MDC trace_id must not be blank inside the span scope — was: '"
+                + capturedTraceId.get() + "'");
+
+        assertNotNull(capturedSpanId.get(),
+                "MDC span_id must be non-null inside the span scope (issue #548)");
+        assertFalse(capturedSpanId.get().isBlank(),
+                "MDC span_id must not be blank inside the span scope — was: '"
+                + capturedSpanId.get() + "'");
+    }
+
+    /**
+     * The MDC must be cleared after the request completes so that subsequent unrelated log lines
+     * from the same thread do not carry a stale traceId.
+     */
+    @Test
+    void mcpToolsCallShouldClearMdcAfterRequestCompletes() throws Exception {
+        Capability capability = capabilityFromYaml(weatherCapabilityYaml());
+        McpServerResource resource = buildResource(capability);
+
+        resource.handlePost(toolsCallBody("get-forecast"));
+
+        // After the span scope exits, the OTel Logback bridge must have cleared the MDC keys
+        String traceIdAfter = MDC.get("trace_id");
+        String spanIdAfter = MDC.get("span_id");
+
+        assertTrue(traceIdAfter == null || traceIdAfter.isBlank(),
+                "MDC trace_id must be blank after span scope ends — was: '" + traceIdAfter + "'");
+        assertTrue(spanIdAfter == null || spanIdAfter.isBlank(),
+                "MDC span_id must be blank after span scope ends — was: '" + spanIdAfter + "'");
+    }
+}

--- a/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ObservabilityMcpHttpLayerTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ObservabilityMcpHttpLayerTest.java
@@ -45,9 +45,11 @@ import java.util.concurrent.atomic.AtomicReference;
  * {@link McpServerResource}, the Logback MDC must contain non-empty {@code trace_id} and
  * {@code span_id} keys for log-trace correlation to work.
  *
- * <p>The underlying cause: {@code logback.xml} referenced {@code %X{trace_id}} / {@code %X{span_id}}
- * but did not include the {@code OpenTelemetryAppender} that populates those MDC keys. As a result,
- * both fields were always empty regardless of whether a span existed.</p>
+ * <p>The underlying cause: {@link TelemetryBootstrap#populateMdc} was never invoked within the
+ * SERVER span scope, so {@code %X{trace_id}} / {@code %X{span_id}} stayed empty. The
+ * {@code OpenTelemetryAppender} in {@code logback.xml} only forwards log events to the OTel
+ * pipeline — it does not populate MDC keys for pattern interpolation. As a result, both fields
+ * were always empty regardless of whether a span existed.</p>
  */
 class ObservabilityMcpHttpLayerTest {
 
@@ -151,35 +153,28 @@ class ObservabilityMcpHttpLayerTest {
      *
      * <p>During the execution of a {@code tools/call} request, the OTel span context must be
      * bridged into the Logback MDC so that {@code %X{trace_id}} and {@code %X{span_id}} are
-     * non-empty in log lines. Without the {@code OpenTelemetryAppender} in {@code logback.xml},
-     * these values are always empty.</p>
+     * non-empty in log lines. If {@link TelemetryBootstrap#populateMdc} is not called within the
+     * span scope, these values are always empty.</p>
      */
     @Test
     void mcpToolsCallShouldPopulateMdcTraceIdAndSpanIdDuringExecution() throws Exception {
         Capability capability = capabilityFromYaml(weatherCapabilityYaml());
-        McpServerResource resource = buildResource(capability);
 
-        // Capture MDC state from inside the span scope by intercepting via a custom
-        // ProtocolDispatcher subclass is not possible without reflection. Instead we rely
-        // on the OTel → MDC bridge being active: after handlePost() completes, the span is
-        // ended and the MDC is cleared. We therefore capture a snapshot mid-flight via a
-        // capturing Restlet context attribute set by an instrumented dispatcher.
-        //
-        // Simpler approach: wrap the handlePost call inside a scope where we can observe MDC.
-        // The OpenTelemetry Logback appender populates MDC synchronously within the span scope.
-        // We verify by asserting that the MDC was non-empty at some point during the call.
+        // The SERVER span scope is entered inside McpServerResource.handlePost(). To observe the
+        // MDC state mid-request (while the span is current), we subclass ProtocolDispatcher and
+        // capture the MDC inside dispatch(), which runs within that scope. This needs no
+        // reflection: ProtocolDispatcher.dispatch is overridable and the resource invokes it.
         AtomicReference<String> capturedTraceId = new AtomicReference<>();
         AtomicReference<String> capturedSpanId = new AtomicReference<>();
 
-        // Re-wire the dispatcher so we can observe MDC during dispatch
         McpServerAdapter adapter = (McpServerAdapter) capability.getServerAdapters().get(0);
         ProtocolDispatcher capturingDispatcher = new ProtocolDispatcher(adapter) {
             @Override
             public com.fasterxml.jackson.databind.node.ObjectNode dispatch(
                     com.fasterxml.jackson.databind.JsonNode root) {
                 // At this point we are inside the SERVER span scope created by McpServerResource
-                capturedTraceId.set(MDC.get("trace_id"));
-                capturedSpanId.set(MDC.get("span_id"));
+                capturedTraceId.set(MDC.get(TelemetryBootstrap.MDC_TRACE_ID));
+                capturedSpanId.set(MDC.get(TelemetryBootstrap.MDC_SPAN_ID));
                 return super.dispatch(root);
             }
         };
@@ -199,7 +194,7 @@ class ObservabilityMcpHttpLayerTest {
 
         assertNotNull(capturedTraceId.get(),
                 "MDC trace_id must be non-null inside the span scope (issue #548: "
-                + "OpenTelemetryAppender missing from logback.xml)");
+                + "populateMdc() not called within the span scope)");
         assertFalse(capturedTraceId.get().isBlank(),
                 "MDC trace_id must not be blank inside the span scope — was: '"
                 + capturedTraceId.get() + "'");
@@ -223,8 +218,8 @@ class ObservabilityMcpHttpLayerTest {
         resource.handlePost(toolsCallBody("get-forecast"));
 
         // After the span scope exits, the OTel Logback bridge must have cleared the MDC keys
-        String traceIdAfter = MDC.get("trace_id");
-        String spanIdAfter = MDC.get("span_id");
+        String traceIdAfter = MDC.get(TelemetryBootstrap.MDC_TRACE_ID);
+        String spanIdAfter = MDC.get(TelemetryBootstrap.MDC_SPAN_ID);
 
         assertTrue(traceIdAfter == null || traceIdAfter.isBlank(),
                 "MDC trace_id must be blank after span scope ends — was: '" + traceIdAfter + "'");

--- a/ikanos-engine/src/test/java/io/ikanos/engine/exposes/skill/ObservabilitySkillHttpLayerTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/exposes/skill/ObservabilitySkillHttpLayerTest.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.skill;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.ikanos.Capability;
+import io.ikanos.engine.observability.OtelTestFixtures;
+import io.ikanos.engine.observability.TelemetryBootstrap;
+import io.ikanos.spec.IkanosSpec;
+import io.ikanos.spec.exposes.skill.SkillServerSpec;
+import io.ikanos.spec.util.VersionHelper;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.restlet.Context;
+import org.restlet.Request;
+import org.restlet.Response;
+import org.restlet.data.Method;
+import org.restlet.representation.Representation;
+import org.slf4j.MDC;
+
+/**
+ * Regression test for issue #548 (review completeness, PR #553).
+ *
+ * <p>The skill server adapter ({@link SkillServerResource#handle()}) creates a {@code SERVER}
+ * span and makes it current exactly like the REST and MCP adapters. For log-trace correlation to
+ * work, the Logback MDC must contain non-empty {@code trace_id} and {@code span_id} keys while the
+ * span is current — which requires {@link TelemetryBootstrap#populateMdc} to be called within the
+ * span scope and {@link TelemetryBootstrap#clearMdc} in the paired {@code finally} block.</p>
+ *
+ * <p>Before the fix, {@code SkillServerResource.handle()} omitted that pairing, so skill request
+ * log lines always had empty {@code %X{trace_id}} / {@code %X{span_id}} — the same defect #548
+ * fixed for REST and MCP.</p>
+ */
+class ObservabilitySkillHttpLayerTest {
+
+    private static final String SCHEMA_VERSION = VersionHelper.getSchemaVersion();
+
+    private final InMemorySpanExporter exporter = InMemorySpanExporter.create();
+
+    @BeforeEach
+    void setUp() {
+        OpenTelemetrySdk sdk = OpenTelemetrySdk.builder()
+                .setTracerProvider(OtelTestFixtures.tracerProvider(exporter))
+                .setPropagators(OtelTestFixtures.w3cPropagators())
+                .build();
+        TelemetryBootstrap.init(sdk);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TelemetryBootstrap.reset();
+        exporter.reset();
+        MDC.clear();
+    }
+
+    // ─── helpers ──────────────────────────────────────────────────────────────
+
+    private Capability capabilityFromYaml(String yaml) throws Exception {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        IkanosSpec spec = mapper.readValue(yaml, IkanosSpec.class);
+        return new Capability(spec);
+    }
+
+    private static String skillCapabilityYaml() {
+        return """
+                ikanos: "%s"
+                info:
+                  display: "skill-capability"
+                capability:
+                  exposes:
+                    - type: "skill"
+                      address: "localhost"
+                      port: 0
+                      namespace: "orders-skills"
+                      description: "Order management skills catalog"
+                      skills:
+                        onboarding-guide:
+                          description: "A purely descriptive skill with no tools"
+                  consumes: []
+                """.formatted(SCHEMA_VERSION);
+    }
+
+    /**
+     * Builds the {@link Context} that {@link SkillServerAdapter} attaches to each
+     * {@link SkillServerResource}, without starting a real HTTP server.
+     */
+    private Context skillContext(Capability capability) {
+        SkillServerAdapter adapter = (SkillServerAdapter) capability.getServerAdapters().stream()
+                .filter(a -> a instanceof SkillServerAdapter)
+                .findFirst()
+                .orElseThrow();
+        SkillServerSpec serverSpec = adapter.getSkillServerSpec();
+
+        Context ctx = new Context();
+        ctx.getAttributes().put("skillServerSpec", serverSpec);
+        ctx.getAttributes().put("capabilityName", "skill-capability");
+        return ctx;
+    }
+
+    // ─── tests ────────────────────────────────────────────────────────────────
+
+    @Test
+    void skillRequestShouldPopulateMdcTraceIdAndSpanIdDuringExecution() throws Exception {
+        Capability capability = capabilityFromYaml(skillCapabilityYaml());
+        Context ctx = skillContext(capability);
+
+        // Observe the MDC mid-request, while the SERVER span created in
+        // SkillServerResource.handle() is current. CatalogResource.getCatalog() is the @Get
+        // handler invoked by super.handle() within that scope, so overriding it captures the
+        // MDC without reflection.
+        AtomicReference<String> capturedTraceId = new AtomicReference<>();
+        AtomicReference<String> capturedSpanId = new AtomicReference<>();
+
+        CatalogResource resource = new CatalogResource() {
+            @Override
+            public Representation getCatalog() {
+                capturedTraceId.set(MDC.get(TelemetryBootstrap.MDC_TRACE_ID));
+                capturedSpanId.set(MDC.get(TelemetryBootstrap.MDC_SPAN_ID));
+                return super.getCatalog();
+            }
+        };
+        Request request = new Request(Method.GET, "http://localhost/skills");
+        Response response = new Response(request);
+        resource.init(ctx, request, response);
+
+        resource.handle();
+
+        assertNotNull(capturedTraceId.get(),
+                "MDC trace_id must be non-null inside the span scope (issue #548: "
+                + "populateMdc() not called within the span scope)");
+        assertFalse(capturedTraceId.get().isBlank(),
+                "MDC trace_id must not be blank inside the span scope — was: '"
+                + capturedTraceId.get() + "'");
+        assertNotNull(capturedSpanId.get(),
+                "MDC span_id must be non-null inside the span scope (issue #548)");
+        assertFalse(capturedSpanId.get().isBlank(),
+                "MDC span_id must not be blank inside the span scope — was: '"
+                + capturedSpanId.get() + "'");
+    }
+
+    @Test
+    void skillRequestShouldClearMdcAfterRequestCompletes() throws Exception {
+        Capability capability = capabilityFromYaml(skillCapabilityYaml());
+        Context ctx = skillContext(capability);
+
+        CatalogResource resource = new CatalogResource();
+        Request request = new Request(Method.GET, "http://localhost/skills");
+        Response response = new Response(request);
+        resource.init(ctx, request, response);
+
+        resource.handle();
+
+        // The finally block in SkillServerResource.handle() must clear the MDC keys once the
+        // span scope exits, so no trace context leaks into unrelated log lines on the thread.
+        String traceIdAfter = MDC.get(TelemetryBootstrap.MDC_TRACE_ID);
+        String spanIdAfter = MDC.get(TelemetryBootstrap.MDC_SPAN_ID);
+
+        assertTrue(traceIdAfter == null || traceIdAfter.isBlank(),
+                "MDC trace_id must be blank after the span scope ends — was: '" + traceIdAfter + "'");
+        assertTrue(spanIdAfter == null || spanIdAfter.isBlank(),
+                "MDC span_id must be blank after the span scope ends — was: '" + spanIdAfter + "'");
+    }
+}


### PR DESCRIPTION
## Related Issue

Closes #548

---

## What does this PR do?

Fixes empty `traceId` / `spanId` in logs during MCP (and REST) request handling, which prevented log-trace correlation and made the Datadog trace-agent receive no usable data.

Root cause was a combination of three issues:

1. **`logback.xml` lacked the `OpenTelemetryAppender`** — the pattern referenced `%X{trace_id}` / `%X{span_id}` but nothing populated those MDC keys.
2. **`jetty-slf4j-impl` (transitive via Restlet) shadowed Logback** as the active SLF4J provider, so any logback-based fix was silently ineffective.
3. **`opentelemetry-logback-appender-1.0` is a log-forwarding appender, not an MDC bridge** — it does not populate MDC keys for pattern interpolation.

Fix:

- Exclude `jetty-slf4j-impl` from the `org.restlet` dependency so Logback is the active SLF4J provider (`ikanos-engine/pom.xml`).
- Add the `OpenTelemetryAppender` to `logback.xml` for OTLP log forwarding.
- Add `TelemetryBootstrap.populateMdc(Span)` / `clearMdc()` to bridge the active OTel span context into the SLF4J MDC.
- Call those from `McpServerResource` and `ResourceRestlet` (the bug affected REST too, though it was reported on MCP).

---

## Tests

Added `ObservabilityMcpHttpLayerTest` (new) — non-regression tests driving `McpServerResource` end-to-end:

- `mcpToolsCallShouldPopulateMdcTraceIdAndSpanIdDuringExecution` — confirmed to **fail** before the fix and **pass** after.
- `mcpToolsCallShouldClearMdcAfterRequestCompletes` — verifies the MDC is cleared after the span scope exits.

Full suite green: `mvn clean test` — no regressions.

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Naftiko - Claude Opus 4.8
tool: VS Code Copilot Chat
confidence: high
source_event: issue #548 — empty traceId/spanId in MCP request logs
discovery_method: user_report
review_focus: TelemetryBootstrap.java (populateMdc/clearMdc), logback.xml, ikanos-engine/pom.xml
```
