### PR TITLE
fix: trigger for mvn gihtub release publish

### DIFF
--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -1,8 +1,6 @@
 name: Publish Maven to sonatype and GitHub Packages
 
 on:
-  release:
-    types: [published]
   push:
     branches: [main]
     tags:
@@ -12,7 +10,7 @@ on:
 jobs:
 
   github-release:
-    if: github.event_name == 'release'
+    if: startsWith(github.ref, 'refs/tags/v')    
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -28,9 +26,6 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-
-      - name: Strip SNAPSHOT
-        run: mvn versions:set -DremoveSnapshot -DgenerateBackupPoms=false
 
       - name: Publish to GitHub Packages (release)
         run: mvn --batch-mode deploy


### PR DESCRIPTION
## Related Issue

no related issue

---

## What does this PR do?

patches the trigger for maven github release publish to be cohesive with maven central ( we want on tag to release on github & maven central)

---


## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

