### PR TITLE
feat: adding documentation section in pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,15 @@ Closes #<!-- issue number -->
 
 ---
 
+## Documentation
+
+<!-- If this PR modifies github actions for example -->
+
+- [ ] Update Notion documentation
+- [ ] Ensure our internal technical documentation (specs, user docs, test docs) reflects the current implementation (no drift)
+
+---
+
 ## Checklist
 
 - [ ] CI is green (build, tests, schema validation, security scans)


### PR DESCRIPTION
## Related Issue

Closes https://github.com/naftiko/ikanos/issues/557

---

## What does this PR do?

Add a section in the PR template : if ... please update the documentation in notion

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

