### PR TITLE
fix: point tutorial test fixtures to local Microcks instead of mocks.naftiko.net

### DIFF
--- a/.github/workflows/nightly-quality-gate.yml
+++ b/.github/workflows/nightly-quality-gate.yml
@@ -55,51 +55,8 @@ jobs:
               -F "file=@$file"
           done
 
-      - name: Patch baseUri in capability files
-        run: |
-          TUTORIAL_DIR="ikanos-engine/src/test/resources/tutorial"
-
-          get_base_uri() {
-            case "$1" in
-              registry) echo "http://localhost:8080/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2" ;;
-              legacy)   echo "http://localhost:8080/rest/naftiko-shipyard-legacy-dockyard-api/1.0.0-alpha2" ;;
-              *)        echo "" ;;
-            esac
-          }
-
-          find "$TUTORIAL_DIR" -name "*.yaml" -o -name "*.yml" | while read file; do
-            COUNT=$(yq '.capability.consumes | length' "$file" 2>/dev/null)
-            { [ -z "$COUNT" ] || [ "$COUNT" = "0" ] || [ "$COUNT" = "null" ]; } && continue
-
-            for i in $(seq 0 $(($COUNT - 1))); do
-              IMPORT=$(yq -r ".capability.consumes[$i].import // \"\"" "$file")
-
-              if [ -n "$IMPORT" ]; then
-                # Import-style: patch the referenced shared file
-                LOCATION=$(yq -r ".capability.consumes[$i].location" "$file")
-                SHARED_FILE="$(dirname "$file")/$LOCATION"
-
-                [ ! -f "$SHARED_FILE" ] && echo "Warning: $SHARED_FILE not found, skipping" && continue
-
-                NAMESPACE=$(yq -r ".consumes[0].namespace" "$SHARED_FILE")
-                BASE_URI=$(get_base_uri "$NAMESPACE")
-                [ -z "$BASE_URI" ] && continue
-
-                echo "Patching shared file $SHARED_FILE: '$NAMESPACE' → $BASE_URI"
-                yq -i ".consumes[0].baseUri = \"$BASE_URI\"" "$SHARED_FILE"
-              else
-                # Inline-style: patch baseUri directly in the tutorial file
-                NAMESPACE=$(yq -r ".capability.consumes[$i].namespace // \"\"" "$file")
-                [ -z "$NAMESPACE" ] && continue
-
-                BASE_URI=$(get_base_uri "$NAMESPACE")
-                [ -z "$BASE_URI" ] && continue
-
-                echo "Patching $file inline: '$NAMESPACE' → $BASE_URI"
-                yq -i ".capability.consumes[$i].baseUri = \"$BASE_URI\"" "$file"
-              fi
-            done
-          done
+      # Tutorial test fixtures already point to http://localhost:8080 (Refs #560).
+      # The 'Patch baseUri' step has been removed.
 
       - name: Prepare shared path
         run: ln -s ikanos-engine/src/test/resources/tutorial/shared shared

--- a/.github/workflows/validate-tuto-examples.yml
+++ b/.github/workflows/validate-tuto-examples.yml
@@ -22,13 +22,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Install jq & yq
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y jq
-        sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq
-        sudo chmod +x /usr/bin/yq
-
     - name: Set up Java
       uses: actions/setup-java@v4
       with:
@@ -68,52 +61,6 @@ jobs:
             -F "file=@$file"
         done
 
-    - name: Patch baseUri in capability files
-      run: |
-        TUTORIAL_DIR="ikanos-engine/src/test/resources/tutorial"
-
-        get_base_uri() {
-          case "$1" in
-            registry) echo "http://localhost:8080/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2" ;;
-            legacy)   echo "http://localhost:8080/rest/naftiko-shipyard-legacy-dockyard-api/1.0.0-alpha2" ;;
-            *)        echo "" ;;
-          esac
-        }
-
-        find "$TUTORIAL_DIR" -name "*.yaml" -o -name "*.yml" | while read file; do
-          COUNT=$(yq '.capability.consumes | length' "$file" 2>/dev/null)
-          { [ -z "$COUNT" ] || [ "$COUNT" = "0" ] || [ "$COUNT" = "null" ]; } && continue
-
-          for i in $(seq 0 $(($COUNT - 1))); do
-            IMPORT=$(yq -r ".capability.consumes[$i].import // \"\"" "$file")
-
-            if [ -n "$IMPORT" ]; then
-              # Import-style: patch the referenced shared file
-              LOCATION=$(yq -r ".capability.consumes[$i].location" "$file")
-              SHARED_FILE="$(dirname "$file")/$LOCATION"
-
-              [ ! -f "$SHARED_FILE" ] && echo "Warning: $SHARED_FILE not found, skipping" && continue
-
-              NAMESPACE=$(yq -r ".consumes[0].namespace" "$SHARED_FILE")
-              BASE_URI=$(get_base_uri "$NAMESPACE")
-              [ -z "$BASE_URI" ] && continue
-
-              echo "Patching shared file $SHARED_FILE: '$NAMESPACE' → $BASE_URI"
-              yq -i ".consumes[0].baseUri = \"$BASE_URI\"" "$SHARED_FILE"
-            else
-              # Inline-style: patch baseUri directly in the tutorial file
-              NAMESPACE=$(yq -r ".capability.consumes[$i].namespace // \"\"" "$file")
-              [ -z "$NAMESPACE" ] && continue
-
-              BASE_URI=$(get_base_uri "$NAMESPACE")
-              [ -z "$BASE_URI" ] && continue
-
-              echo "Patching $file inline: '$NAMESPACE' → $BASE_URI"
-              yq -i ".capability.consumes[$i].baseUri = \"$BASE_URI\"" "$file"
-            fi
-          done
-        done
-        
     - name: Run tests
       env:
         MCP_SERVER_TOKEN: ${{ secrets.MCP_SERVER_TOKEN }}

--- a/ikanos-engine/src/test/resources/tutorial/shared/legacy-consumes.yaml
+++ b/ikanos-engine/src/test/resources/tutorial/shared/legacy-consumes.yaml
@@ -2,7 +2,8 @@ ikanos: 1.0.0-alpha4
 consumes:
 - namespace: legacy
   type: http
-  baseUri: https://mocks.naftiko.net/rest/naftiko-shipyard-legacy-dockyard-api/1.0.0-alpha2
+  # prod: https://mocks.naftiko.net/rest/naftiko-shipyard-legacy-dockyard-api/1.0.0-alpha2
+  baseUri: http://localhost:8080/rest/naftiko-shipyard-legacy-dockyard-api/1.0.0-alpha2
   authentication:
     type: apikey
     key: X-Dock-Key

--- a/ikanos-engine/src/test/resources/tutorial/shared/registry-consumes.yaml
+++ b/ikanos-engine/src/test/resources/tutorial/shared/registry-consumes.yaml
@@ -2,7 +2,8 @@ ikanos: 1.0.0-alpha4
 consumes:
 - namespace: registry
   type: http
-  baseUri: https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2
+  # prod: https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2
+  baseUri: http://localhost:8080/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2
   authentication:
     type: bearer
     token: '{{REGISTRY_TOKEN}}'

--- a/ikanos-engine/src/test/resources/tutorial/shared/step11-registry-consumes.yml
+++ b/ikanos-engine/src/test/resources/tutorial/shared/step11-registry-consumes.yml
@@ -3,7 +3,8 @@ ikanos: "1.0.0-alpha4"
 consumes:
 - namespace: registry
   type: http
-  baseUri: "https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2"
+  # prod: https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2
+  baseUri: "http://localhost:8080/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2"
   authentication:
     type: bearer
     token: "REGISTRY_TOKEN"

--- a/ikanos-engine/src/test/resources/tutorial/shared/step5-registry-consumes.yaml
+++ b/ikanos-engine/src/test/resources/tutorial/shared/step5-registry-consumes.yaml
@@ -2,7 +2,8 @@ ikanos: 1.0.0-alpha4
 consumes:
 - namespace: registry
   type: http
-  baseUri: https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2
+  # prod: https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2
+  baseUri: http://localhost:8080/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2
   authentication:
     type: bearer
     token: '{{REGISTRY_TOKEN}}'

--- a/ikanos-engine/src/test/resources/tutorial/shared/step6-registry-consumes.yaml
+++ b/ikanos-engine/src/test/resources/tutorial/shared/step6-registry-consumes.yaml
@@ -2,7 +2,8 @@ ikanos: 1.0.0-alpha4
 consumes:
 - namespace: registry
   type: http
-  baseUri: https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2
+  # prod: https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2
+  baseUri: http://localhost:8080/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2
   authentication:
     type: bearer
     token: '{{REGISTRY_TOKEN}}'

--- a/ikanos-engine/src/test/resources/tutorial/shared/step7-registry-consumes.yml
+++ b/ikanos-engine/src/test/resources/tutorial/shared/step7-registry-consumes.yml
@@ -2,7 +2,8 @@ ikanos: "1.0.0-alpha4"
 consumes:
 - namespace: registry
   type: http
-  baseUri: "https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2"
+  # prod: https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2
+  baseUri: "http://localhost:8080/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2"
   authentication:
     type: bearer
     token: "{{REGISTRY_TOKEN}}"

--- a/ikanos-engine/src/test/resources/tutorial/step-2-shipyard-wiring.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-2-shipyard-wiring.yml
@@ -4,7 +4,8 @@ capability:
   consumes:
   - namespace: registry
     type: http
-    baseUri: "https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2"
+    # prod: https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2
+    baseUri: "http://localhost:8080/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2"
     resources:
       ships:
         path: "/ships"

--- a/ikanos-engine/src/test/resources/tutorial/step-3-shipyard-auth.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-3-shipyard-auth.yml
@@ -13,7 +13,8 @@ capability:
   consumes:
   - namespace: registry
     type: http
-    baseUri: "https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2"
+    # prod: https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2
+    baseUri: "http://localhost:8080/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2"
     authentication:
       type: bearer
       token: "{{REGISTRY_TOKEN}}"

--- a/ikanos-engine/src/test/resources/tutorial/step-4-shipyard-output-shaping.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-4-shipyard-output-shaping.yml
@@ -13,7 +13,8 @@ capability:
   consumes:
   - namespace: registry
     type: http
-    baseUri: "https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2"
+    # prod: https://mocks.naftiko.net/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2
+    baseUri: "http://localhost:8080/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2"
     authentication:
       type: bearer
       token: "{{REGISTRY_TOKEN}}"


### PR DESCRIPTION
## Related Issue

Closes #560

---

## What does this PR do?

Tutorial integration test fixtures in `ikanos-engine/src/test/resources/tutorial/` were hardcoding `https://mocks.naftiko.net` as the upstream `baseUri`. Several endpoints on that external service degraded around June 5 2026, causing the nightly quality gate to fail with Jackson parse errors on plain-text error responses.

**Approach:** fix the fixtures directly rather than patching them at runtime.

- Replace `mocks.naftiko.net` with `http://localhost:8080` in all 9 test fixture YAML files (`shared/` + `step-2`, `step-3`, `step-4`). A `# prod: ...` comment is added above each `baseUri` to preserve the original URL for reference.
- Remove the `Install jq & yq` and `Patch baseUri in capability files` steps from `validate-tuto-examples.yml` and `nightly-quality-gate.yml` — they were a fragile CI workaround that is no longer needed now that the fixtures point to the correct host.

`ikanos-docs/tutorial/` (public-facing documentation) and `ikanos-spec/src/test/resources/` (schema validation only, no HTTP calls) are intentionally left unchanged.

---

## Tests

The 15 tutorial integration tests that were failing (steps 2–11 of the Shipyard tutorial) should now pass when Microcks is running on `http://localhost:8080` — which is exactly what both CI workflows do before running `mvn test`.

No new tests were added; no existing test logic was changed. The fix is purely in the YAML fixture files and CI workflow steps.

---

## Documentation

- [ ] Update Notion documentation
- [ ] Ensure our internal technical documentation (specs, user docs, test docs) reflects the current implementation (no drift)

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Claude Sonnet 4.6
tool: VS Code Copilot Chat
confidence: high
source_event: failing tests on main reported by user
discovery_method: test_failure
review_focus: ikanos-engine/src/test/resources/tutorial/
```
