### PR TITLE
fix: add Microcks setup steps to publish-maven.yml jobs

### DIFF
--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -27,6 +27,21 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
+      - name: Start Microcks
+        run: docker run -d -p 8080:8080 quay.io/microcks/microcks-uber:latest
+
+      - name: Wait for Microcks
+        run: |
+          sleep 15
+          curl -sf http://localhost:8080/api/health || (echo "Microcks failed to start" && exit 1)
+
+      - name: Import OpenAPI specs into Microcks
+        run: |
+          for file in .github/microcks/*.yaml; do
+            echo "Importing $file"
+            curl -s -X POST "http://localhost:8080/api/artifact/upload" -F "file=@$file"
+          done
+
       - name: Publish to GitHub Packages (release)
         run: mvn --batch-mode deploy
         env:
@@ -48,6 +63,21 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
+
+      - name: Start Microcks
+        run: docker run -d -p 8080:8080 quay.io/microcks/microcks-uber:latest
+
+      - name: Wait for Microcks
+        run: |
+          sleep 15
+          curl -sf http://localhost:8080/api/health || (echo "Microcks failed to start" && exit 1)
+
+      - name: Import OpenAPI specs into Microcks
+        run: |
+          for file in .github/microcks/*.yaml; do
+            echo "Importing $file"
+            curl -s -X POST "http://localhost:8080/api/artifact/upload" -F "file=@$file"
+          done
 
       - name: Configure Maven Central
         run: bash ./scripts/builder.sh config_maven_central
@@ -93,6 +123,21 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
+
+      - name: Start Microcks
+        run: docker run -d -p 8080:8080 quay.io/microcks/microcks-uber:latest
+
+      - name: Wait for Microcks
+        run: |
+          sleep 15
+          curl -sf http://localhost:8080/api/health || (echo "Microcks failed to start" && exit 1)
+
+      - name: Import OpenAPI specs into Microcks
+        run: |
+          for file in .github/microcks/*.yaml; do
+            echo "Importing $file"
+            curl -s -X POST "http://localhost:8080/api/artifact/upload" -F "file=@$file"
+          done
 
       - name: Get version
         run: echo "VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)" >> $GITHUB_ENV


### PR DESCRIPTION
## Related Issue

Refs #560

---

## What does this PR do?

The `github-snapshot`, `github-release` and `maven-central` jobs in `publish-maven.yml` all run `mvn deploy` (which executes the full test suite including tutorial integration tests), but were missing the Microcks start / health-wait / spec-import steps that were added to `validate-tuto-examples.yml` and `nightly-quality-gate.yml` in #561.

As a result, every push to `main` triggered a `github-snapshot` run that failed with `HTTP 1001 Communication Error` on all tutorial integration tests — the engine could not reach `localhost:8080` because Microcks was never started.

This PR adds the three Microcks steps to all three jobs, immediately before the `mvn` invocation.

---

## Tests

No test code changed. The fix is purely in the CI workflow. The next `github-snapshot` run triggered by this PR merge will validate the fix.

---

## Documentation

- [ ] Update Notion documentation
- [ ] Ensure our internal technical documentation (specs, user docs, test docs) reflects the current implementation (no drift)

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Claude Sonnet 4.6
tool: VS Code Copilot Chat
confidence: high
source_event: tutorial integration tests failing on every push to main after #561
discovery_method: runtime_observation
review_focus: .github/workflows/publish-maven.yml
```
