### PR TITLE
feat: add round-trip-lookup rule to bugfix skill Pre-Code Checklist

### DIFF
--- a/.agents/skills/bugfix/SKILL.md
+++ b/.agents/skills/bugfix/SKILL.md
@@ -403,6 +403,17 @@ time via Phase 7 — always with the user's approval.
   in inline YAML text blocks — never hardcode it (AGENTS.md).
 - When a test needs mid-execution observation without reflection, document the pattern
   (e.g. an anonymous subclass override) so future tests reuse it instead of reinventing it.
+- When a fix makes a successful lookup depend on **two components that independently
+  produce the same key/path** (e.g. a map indexed by producer A, queried with a path built
+  by producer B), write a **round-trip test** proving the two strings coincide exactly — and
+  that **distinct inputs which could collapse to the same key don't silently alias** (e.g. a
+  flat `"a.b"` key vs nested `a: { b }`) — including edge cases (array indices, the root `$`,
+  keys with special characters). A one-character divergence makes the lookup fail
+  **silently** (null result, no error) and turns the fix into an invisible no-op. *(Lesson
+  from polychro #32: `JacksonSourceMap` indexes ranges by dot-notation path while
+  `JsonPathEvaluator.toDotNotation` builds the lookup path; any disagreement makes
+  `sourceMap.resolve(...)` return null and the diagnostic silently loses its range. PR #33:
+  a dotted-key test passed by coincidence — pin the collision, don't assume uniqueness.)*
 
 **Don't:**
 - Don't write the fix before the failing test exists and is confirmed red.


### PR DESCRIPTION
## Related Issue

Closes #563

---

## What does this PR do?

Adds one entry to the `bugfix` skill Pre-Code Checklist: when a fix makes a lookup
depend on **two components that independently produce the same key/path** (a map indexed
by producer A, queried with a path built by producer B), write a **round-trip test**
proving the two strings coincide — and that distinct inputs which could collapse to the
same key don't silently alias.

The rule was hardened during the polychro PR #33 review (the skill's LEARN phase): a
first dotted-key test passed *by coincidence* (`$.x-meta.owner` is ambiguous between a
flat `"x-meta.owner"` key and a nested `x-meta: { owner }`), which proved the round-trip
was *consistent* but not that the key was *unambiguous*. The entry now requires pinning
the collision case, not assuming uniqueness.

This is a single, focused tightening of an existing checklist item — not a new rule —
keeping the skill lean (no inflation).

---

## Tests

N/A — documentation-only change to a skill Markdown file (`.agents/skills/bugfix/SKILL.md`).
No code paths are affected.

---

## Documentation

- [x] Update Notion documentation
- [x] Ensure our internal technical documentation (specs, user docs, test docs) reflects the current implementation (no drift)

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Claude Opus 4.8
tool: VS Code
confidence: high
source_event: polychro PR #33 review feedback (LEARN phase capitalization)
discovery_method: code_review
review_focus: .agents/skills/bugfix/SKILL.md (Pre-Code Checklist round-trip rule)
```
