### PR TITLE
feat: update mac-os image for cli actions

### DIFF
--- a/.github/workflows/publish-cli-bin.yml
+++ b/.github/workflows/publish-cli-bin.yml
@@ -23,7 +23,7 @@ jobs:
             artifact_name: ikanos-cli-linux-arm64
             
           # macOS Apple Silicon (ARM64)
-          - os: macos-latest  # macos-14+ uses Mx runners
+          - os: macos-26  # macos-26+ uses Mx runners
             artifact_name: ikanos-cli-macos-arm64
             
           # Windows AMD64
@@ -92,7 +92,7 @@ jobs:
             artifact_name: ikanos-cli-linux-amd64
           - os: ubuntu-24.04-arm
             artifact_name: ikanos-cli-linux-arm64
-          - os: macos-latest
+          - os: macos-26
             artifact_name: ikanos-cli-macos-arm64
           - os: windows-latest
             artifact_name: ikanos-cli-windows-amd64.exe


### PR DESCRIPTION
## Related Issue

Closes https://github.com/orgs/naftiko/projects/10/views/13?pane=issue&itemId=193529656

---

## What does this PR do?

update mac-os image for cli actions

---

## Tests

https://github.com/naftiko/ikanos/actions/runs/27191871692

---

## Checklist

- [ ] CI is green (build + tests)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

