### PR TITLE
feat: add 'scan loops must reach the boundary' rule to bugfix skill (#568)

### DIFF
--- a/.agents/skills/bugfix/SKILL.md
+++ b/.agents/skills/bugfix/SKILL.md
@@ -414,6 +414,9 @@ time via Phase 7 — always with the user's approval.
   `JsonPathEvaluator.toDotNotation` builds the lookup path; any disagreement makes
   `sourceMap.resolve(...)` return null and the diagnostic silently loses its range. PR #33:
   a dotted-key test passed by coincidence — pin the collision, don't assume uniqueness.)*
+- **Scan loops must reach the boundary.** When searching a sequence for a delimiter, never
+  bound at `< length() - 1` (it skips the last element); test the marker as the **first** and
+  **last** character, not just mid-string. *(PR #33: `endOfPlainScalar` missed a terminal `#`.)*
 
 **Don't:**
 - Don't write the fix before the failing test exists and is confirmed red.


### PR DESCRIPTION
## Related Issue

Closes #568

---

## What does this PR do?

Adds one **Do** entry to the Pre-Code Checklist of the `bugfix` skill
(`.agents/skills/bugfix/SKILL.md`):

> **Scan loops must reach the boundary.** When searching a sequence for a delimiter, never
> bound at `< length() - 1` (it skips the last element); test the marker as the **first** and
> **last** character, not just mid-string. *(PR #33: `endOfPlainScalar` missed a terminal `#`.)*

This captures an avoidable, generalizable off-by-one bug class that surfaced as a review
finding on naftiko/polychro PR #33: a delimiter scan bounded at `i < line.length() - 1` never
matched a `#` that was the line's last character (an empty trailing comment), so the computed
source range wrongly included the trailing ` #`. It is tactical and bugfix-specific, so it
belongs in the skill's checklist rather than `AGENTS.md`.

The rule was produced by the skill's own Phase 7 (capitalize) loop — dogfooding the
continuous-improvement design.

---

## Tests

None — this PR only edits a skill Markdown file (`.agents/skills/bugfix/SKILL.md`); there is
no executable code to test. The full file was re-read after the edit to confirm coherence: the
new entry follows the existing Do/Don't format (bold lead-in + italic source lesson), the
`Don't:` block and all section headings remain intact, and no H2 heading is duplicated.

---

## Documentation

- [ ] Update Notion documentation
- [x] Ensure our internal technical documentation (specs, user docs, test docs) reflects the current implementation (no drift)

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Naftiko Claude Opus 4.8
tool: VS Code Copilot Chat
confidence: high
source_event: bugfix skill Phase 7 (capitalize) on polychro PR #33
discovery_method: code_review
review_focus: .agents/skills/bugfix/SKILL.md (Pre-Code Checklist)
```
