### PR TITLE
chore: sync Ikanos version

### DIFF
--- a/ikanos-cli/src/test/resources/control/control-capability.yaml
+++ b/ikanos-cli/src/test/resources/control/control-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../../../ikanos-spec/src/main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 info:
   display: "CLI Control Port Test Capability"
   description: "Test capability for CLI runtime startup"

--- a/ikanos-docs/tutorial/shared/step11-registry-consumes.yml
+++ b/ikanos-docs/tutorial/shared/step11-registry-consumes.yml
@@ -1,5 +1,5 @@
 # shared/registry-consumes.yaml (final — added get-voyage + cargo resource)
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 consumes:
 - namespace: registry
   type: http

--- a/ikanos-docs/tutorial/shared/step7-registry-consumes.yml
+++ b/ikanos-docs/tutorial/shared/step7-registry-consumes.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 consumes:
 - namespace: registry
   type: http

--- a/ikanos-docs/tutorial/step-1-shipyard-mock.yml
+++ b/ikanos-docs/tutorial/step-1-shipyard-mock.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 
 capability:
   exposes:

--- a/ikanos-docs/tutorial/step-10-shipyard-rest-adapter.yml
+++ b/ikanos-docs/tutorial/step-10-shipyard-rest-adapter.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-11-shipyard-fleet-manifest.yml
+++ b/ikanos-docs/tutorial/step-11-shipyard-fleet-manifest.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 
 info:
   display: "Shipyard Fleet Management"

--- a/ikanos-docs/tutorial/step-2-shipyard-wiring.yml
+++ b/ikanos-docs/tutorial/step-2-shipyard-wiring.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 
 capability:
   consumes:

--- a/ikanos-docs/tutorial/step-3-shipyard-auth.yml
+++ b/ikanos-docs/tutorial/step-3-shipyard-auth.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-4-shipyard-output-shaping.yml
+++ b/ikanos-docs/tutorial/step-4-shipyard-output-shaping.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-5-shipyard-multi-source.yml
+++ b/ikanos-docs/tutorial/step-5-shipyard-multi-source.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-6-shipyard-write-operations.yml
+++ b/ikanos-docs/tutorial/step-6-shipyard-write-operations.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-7-shipyard-orchestrated-lookup.yml
+++ b/ikanos-docs/tutorial/step-7-shipyard-orchestrated-lookup.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-8-shipyard-skill-groups.yml
+++ b/ikanos-docs/tutorial/step-8-shipyard-skill-groups.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-9-shipyard-aggregates.yml
+++ b/ikanos-docs/tutorial/step-9-shipyard-aggregates.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-invalid-ref.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-invalid-ref.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 info:
   display: "Aggregate Invalid Ref Test"
   description: "Test capability with an unknown aggregate ref"

--- a/ikanos-engine/src/test/resources/baseuri-trailing-slash-capability.yaml
+++ b/ikanos-engine/src/test/resources/baseuri-trailing-slash-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 info:
   display: "BaseUri Trailing Slash Regression Test"
   description: "Capability intentionally using a trailing-slash baseUri to test strict validation"

--- a/ikanos-engine/src/test/resources/control/control-capability.yaml
+++ b/ikanos-engine/src/test/resources/control/control-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../../../ikanos-spec/src/main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 info:
   display: "Control Port Test Capability"
   description: "Test capability for Control Server Adapter deserialization and wiring"

--- a/ikanos-engine/src/test/resources/control/control-observability-disabled.yaml
+++ b/ikanos-engine/src/test/resources/control/control-observability-disabled.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 info:
   display: "Control Port — Observability Disabled"
   description: "Test fixture: observability.enabled=false should suppress /metrics and /traces"

--- a/ikanos-engine/src/test/resources/control/control-scripting-capability.yaml
+++ b/ikanos-engine/src/test/resources/control/control-scripting-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 info:
   display: "Control Port Scripting Test"
   description: "Test capability for scripting governance on the Control Port"

--- a/ikanos-engine/src/test/resources/formats/html-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/html-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 info:
   display: "HTML Test Capability"
   description: "Test capability for HTML table parsing"

--- a/ikanos-engine/src/test/resources/formats/markdown-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/markdown-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 info:
   display: "Markdown Test Capability"
   description: "Test capability for Markdown parsing"

--- a/ikanos-engine/src/test/resources/imports/aggregates/shared.aggregates.yml
+++ b/ikanos-engine/src/test/resources/imports/aggregates/shared.aggregates.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 aggregates:
   - namespace: "forecast"
     display: "Forecast Domain"

--- a/ikanos-engine/src/test/resources/imports/binds/shared.binds.yml
+++ b/ikanos-engine/src/test/resources/imports/binds/shared.binds.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 binds:
   - namespace: "weather-secrets"
     description: "Weather API credentials"

--- a/ikanos-engine/src/test/resources/imports/consumes/shared-clients.yml
+++ b/ikanos-engine/src/test/resources/imports/consumes/shared-clients.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 consumes:
   - namespace: "weather-http"
     type: "http"

--- a/ikanos-engine/src/test/resources/imports/consumes/shared.consumes.yml
+++ b/ikanos-engine/src/test/resources/imports/consumes/shared.consumes.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 consumes:
   - type: "http"
     namespace: "weather-api"

--- a/ikanos-engine/src/test/resources/imports/exposes/shared-servers.yml
+++ b/ikanos-engine/src/test/resources/imports/exposes/shared-servers.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 exposes:
   - namespace: "weather-rest"
     type: "rest"

--- a/ikanos-engine/src/test/resources/imports/exposes/shared.exposes.yml
+++ b/ikanos-engine/src/test/resources/imports/exposes/shared.exposes.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 exposes:
   - type: "rest"
     namespace: "weather-rest"

--- a/ikanos-engine/src/test/resources/imports/invalid/empty-section.consumes.yml
+++ b/ikanos-engine/src/test/resources/imports/invalid/empty-section.consumes.yml
@@ -1,2 +1,2 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 consumes: []

--- a/ikanos-engine/src/test/resources/observability/observability-capability.yaml
+++ b/ikanos-engine/src/test/resources/observability/observability-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 info:
   display: "Observability Test Capability"
   description: "Test capability for observability spec deserialization"

--- a/ikanos-engine/src/test/resources/observability/observability-disabled.yaml
+++ b/ikanos-engine/src/test/resources/observability/observability-disabled.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 info:
   display: "Observability Disabled Capability"
   description: "Test capability with observability disabled"

--- a/ikanos-engine/src/test/resources/register.capability.yml
+++ b/ikanos-engine/src/test/resources/register.capability.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 info:
   display: "register"
   description: "Business description of your capability"

--- a/ikanos-engine/src/test/resources/tutorial/shared/step11-registry-consumes.yml
+++ b/ikanos-engine/src/test/resources/tutorial/shared/step11-registry-consumes.yml
@@ -1,5 +1,5 @@
 # shared/registry-consumes.yaml (final — added get-voyage + cargo resource)
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 consumes:
 - namespace: registry
   type: http

--- a/ikanos-engine/src/test/resources/tutorial/shared/step7-registry-consumes.yml
+++ b/ikanos-engine/src/test/resources/tutorial/shared/step7-registry-consumes.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 consumes:
 - namespace: registry
   type: http

--- a/ikanos-engine/src/test/resources/tutorial/step-1-shipyard-mock.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-1-shipyard-mock.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 
 capability:
   exposes:

--- a/ikanos-engine/src/test/resources/tutorial/step-10-shipyard-rest-adapter.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-10-shipyard-rest-adapter.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-11-shipyard-fleet-manifest.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-11-shipyard-fleet-manifest.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 
 info:
   display: "Shipyard Fleet Management"

--- a/ikanos-engine/src/test/resources/tutorial/step-2-shipyard-wiring.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-2-shipyard-wiring.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 
 capability:
   consumes:

--- a/ikanos-engine/src/test/resources/tutorial/step-3-shipyard-auth.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-3-shipyard-auth.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-4-shipyard-output-shaping.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-4-shipyard-output-shaping.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-5-shipyard-multi-source.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-5-shipyard-multi-source.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-6-shipyard-write-operations.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-6-shipyard-write-operations.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-7-shipyard-orchestrated-lookup.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-7-shipyard-orchestrated-lookup.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-8-shipyard-skill-groups.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-8-shipyard-skill-groups.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-9-shipyard-aggregates.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-9-shipyard-aggregates.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-alpha4"
+ikanos: "1.0.0-beta1"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
+++ b/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ikanos.io/schemas/v1.0.0-alpha4/ikanos.json",
+  "$id": "https://ikanos.io/schemas/v1.0.0-beta1/ikanos.json",
   "name": "Ikanos Specification",
   "description": "Ikanos Capability Specification \u2014 describes a capability document (adapter + metadata) or a standalone shared file (consumes / exposes / aggregates / binds). A valid document must declare `ikanos` + exactly one of `capability`, `consumes`, `exposes`, `aggregates`, or `binds`. All adapter logic lives under `capability`; shared section definitions live at root.",
   "type": "object",
@@ -8,7 +8,7 @@
     "ikanos": {
       "type": "string",
       "description": "Ikanos specification version. Must be `1.0.0-alpha4`. Signals schema compatibility \u2014 always the first key in a capability file.",
-      "const": "1.0.0-alpha4"
+      "const": "1.0.0-beta1"
     },
     "info": {
       "$ref": "#/$defs/Info",


### PR DESCRIPTION
## No related issue

---

## What does this PR do?

Automatically synchronizes the Ikanos version across the repository:
- Updates `ikanos` version in YAML files
- Updates `const` in JSON schema
- Updates `$id` schema URL

Source of truth: `pom.xml`

---

## Tests

No additional tests required.
This change is limited to version synchronization and does not impact runtime behavior.

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main`
- [ ] Small and focused — one concern per PR
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)