### PR TITLE
fix: resolve VS Code problems for Ikanos and add License badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <img src="https://naftiko.github.io/docs/images/logos/logo_ikanos_horizontal.png" width="300">
 
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/farah-t-trigui/50bfcb34f6512cbad2dd4f460bfc6526/raw/framework-coverage.json)](https://github.com/naftiko/ikanos/actions/workflows/quality-gate.yml)
 [![Bugs](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/farah-t-trigui/50bfcb34f6512cbad2dd4f460bfc6526/raw/framework-bugs.json)](https://github.com/naftiko/ikanos/actions/workflows/quality-gate.yml)
 [![Trivy](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/farah-t-trigui/50bfcb34f6512cbad2dd4f460bfc6526/raw/framework-trivy.json)](https://github.com/naftiko/ikanos/actions/workflows/quality-gate.yml)

--- a/ikanos-engine/src/main/java/io/ikanos/engine/exposes/control/TraceCapturingSpanProcessor.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/exposes/control/TraceCapturingSpanProcessor.java
@@ -29,6 +29,7 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
 
 /**
  * Custom OTel {@link SpanProcessor} that captures completed spans into a {@link TraceRingBuffer}
@@ -48,7 +49,7 @@ public class TraceCapturingSpanProcessor implements SpanProcessor {
     }
 
     @Override
-    public void onStart(Context parentContext, ReadWriteSpan span) {
+    public void onStart(@Nonnull Context parentContext, @Nonnull ReadWriteSpan span) {
         // No action on start
     }
 
@@ -58,7 +59,7 @@ public class TraceCapturingSpanProcessor implements SpanProcessor {
     }
 
     @Override
-    public void onEnd(ReadableSpan span) {
+    public void onEnd(@Nonnull ReadableSpan span) {
         SpanData data = span.toSpanData();
         String traceId = data.getTraceId();
 

--- a/ikanos-engine/src/main/java/io/ikanos/engine/observability/DelegatingSpanProcessor.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/observability/DelegatingSpanProcessor.java
@@ -15,9 +15,10 @@ package io.ikanos.engine.observability;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
+import javax.annotation.Nonnull;
 
 /**
  * A {@link SpanProcessor} that delegates to another processor set after construction.
@@ -34,7 +35,7 @@ class DelegatingSpanProcessor implements SpanProcessor {
     private volatile SpanProcessor delegate;
 
     @Override
-    public void onStart(Context parentContext, ReadWriteSpan span) {
+    public void onStart(@Nonnull Context parentContext, @Nonnull ReadWriteSpan span) {
         SpanProcessor d = delegate;
         if (d != null) {
             d.onStart(parentContext, span);
@@ -48,7 +49,7 @@ class DelegatingSpanProcessor implements SpanProcessor {
     }
 
     @Override
-    public void onEnd(ReadableSpan span) {
+    public void onEnd(@Nonnull ReadableSpan span) {
         SpanProcessor d = delegate;
         if (d != null) {
             d.onEnd(span);

--- a/ikanos-engine/src/main/java/io/ikanos/engine/observability/PullMetricReader.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/observability/PullMetricReader.java
@@ -21,6 +21,7 @@ import io.opentelemetry.sdk.metrics.export.CollectionRegistration;
 import io.opentelemetry.sdk.metrics.export.MetricReader;
 import java.util.Collection;
 import java.util.Collections;
+import javax.annotation.Nonnull;
 
 /**
  * A pull-based {@link MetricReader} that stores the SDK's {@link CollectionRegistration} and
@@ -34,7 +35,7 @@ class PullMetricReader implements MetricReader {
     private volatile CollectionRegistration registration = CollectionRegistration.noop();
 
     @Override
-    public void register(CollectionRegistration registration) {
+    public void register(@Nonnull CollectionRegistration registration) {
         this.registration = registration;
     }
 
@@ -44,7 +45,7 @@ class PullMetricReader implements MetricReader {
     }
 
     @Override
-    public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+    public AggregationTemporality getAggregationTemporality(@Nonnull InstrumentType instrumentType) {
         return AggregationTemporality.CUMULATIVE;
     }
 


### PR DESCRIPTION
## Summary

Resolves the VS Code "Problems" reported for Ikanos and adds a License badge to the README.

## VS Code Problems — definitive fix

The Problems panel reported `Missing non-null annotation` and `needs unchecked conversion to conform to @Nonnull` errors in three engine files:

- `ikanos-engine/.../observability/PullMetricReader.java`
- `ikanos-engine/.../observability/DelegatingSpanProcessor.java`
- `ikanos-engine/.../exposes/control/TraceCapturingSpanProcessor.java`

These are **real Eclipse JDT null-analysis findings**, not stale-cache artifacts — they persist after `Java: Clean Java Language Server Workspace`. The Maven build (`javac`) does not surface them because it does not run JDT null analysis (which is enabled via the checked-in `.settings/org.eclipse.jdt.core.prefs` mapping `@Nonnull` → `javax.annotation.Nonnull`).

The OpenTelemetry SDK declares the overridden method parameters as `@Nonnull`, so each override must repeat the annotation to match the inherited contract.

**Fix:** add `@Nonnull` (`javax.annotation.Nonnull`) to the overriding parameters:

- `SpanProcessor.onStart(@Nonnull Context, @Nonnull ReadWriteSpan)`
- `SpanProcessor.onEnd(@Nonnull ReadableSpan)`
- `MetricReader.register(@Nonnull CollectionRegistration)`
- `MetricReader.getAggregationTemporality(@Nonnull InstrumentType)`

This also clears the paired "needs unchecked conversion" warnings in `DelegatingSpanProcessor`, since the now-`@Nonnull` parameters are forwarded to the delegate without conversion. The approach follows the existing `OtelNullSafety` / `OtelRestletBridge` convention in the same package.

## README change

- Added the **Apache 2.0 License** badge to the top of `README.md`, alongside the existing Coverage / Bugs / Trivy badges.

## Validation

- `mvn -B -pl ikanos-engine -am clean compile --no-transfer-progress` → `BUILD SUCCESS` (exit 0).
- `get_errors` on all three engine files → no errors.
