### PR TITLE
feat(spec): binary content across a capability — Phase 0 (schema additions)

### DIFF
--- a/ikanos-spec/src/main/resources/schemas/examples/capability-binary-content.yml
+++ b/ikanos-spec/src/main/resources/schemas/examples/capability-binary-content.yml
@@ -1,0 +1,139 @@
+---
+# Binary Content example — Phase 0 of the capability-binary-content blueprint.
+#
+# A photo-library capability that fetches original-resolution image bytes from
+# an upstream API and exposes them three ways from a single consumed operation:
+#   - a REST endpoint GET /photos/{imo}/image returning image/jpeg
+#   - an MCP tool `get-photo` (binary-ness inherited from the consumed op)
+#   - an MCP resource photos://library/{id}/bytes returning BlobResourceContents
+#
+# At Phase 0 the engine does NOT yet read or buffer bytes — this YAML only
+# exercises the additive schema fields introduced in §5–§8:
+#   - consumes:  outputRawFormat: binary, outputMediaType, maxBinarySize
+#   - aggregates: outputMediaType on a flow
+#   - exposes rest: responses contract + responseBinary shorthand
+#   - exposes mcp: adapter-level maxBinarySize, resource `binary: true`
+# Runtime byte handling lands in Phases 1+.
+ikanos: "1.0.0-beta1"
+
+info:
+  display: "Photo library (binary content example)"
+  description: >
+    Fetch original-resolution photo bytes from an upstream library API and
+    expose them through REST and MCP using a single binary consumed operation.
+  tags:
+    - photos
+    - binary
+    - example
+
+capability:
+  consumes:
+    - type: "http"
+      namespace: "photo-library"
+      description: "Upstream photo library API serving original-resolution image bytes."
+      baseUri: "https://photos.example.org"
+      resources:
+        photos:
+          description: "Photo binary resource."
+          path: "/photos/{id}/binary"
+          operations:
+            download-photo:
+              method: "GET"
+              description: "Download the original-resolution bytes of a photo by id."
+              outputRawFormat: "binary"
+              outputMediaType: "image/jpeg"
+              maxBinarySize: "5MiB"
+              inputParameters:
+                id:
+                  in: "path"
+
+  aggregates:
+    - display: "Photos"
+      namespace: "photos"
+      flows:
+        get-photo:
+          description: "Resolve and return the original bytes of a photo by id."
+          semantics:
+            safe: true
+            idempotent: true
+            cacheable: true
+          outputMediaType: "image/jpeg"
+          inputParameters:
+            id:
+              type: "string"
+              required: true
+              description: "Photo identifier."
+          call: "photo-library.download-photo"
+          with:
+            id: "{{id}}"
+
+  exposes:
+    - type: "rest"
+      address: "0.0.0.0"
+      port: 8080
+      namespace: "photos-api"
+      resources:
+        photo-image:
+          description: "Original-resolution image bytes for a photo."
+          path: "/photos/{{id}}/image"
+          operations:
+            get-photo-image:
+              method: "GET"
+              description: "Return the original image bytes for a photo."
+              inputParameters:
+                id:
+                  in: "path"
+                  type: "string"
+                  description: "Photo identifier."
+              ref: "photos.get-photo"
+              responses:
+                "200":
+                  description: "Original image bytes."
+                  content:
+                    image/jpeg:
+                      binary: true
+                "404":
+                  description: "Photo not found."
+                  content:
+                    application/json:
+                      schema:
+                        type: "object"
+        photo-thumbnail:
+          description: "Thumbnail image bytes for a photo (responseBinary shorthand)."
+          path: "/photos/{{id}}/thumbnail"
+          operations:
+            get-photo-thumbnail:
+              method: "GET"
+              description: "Return a thumbnail image for a photo."
+              inputParameters:
+                id:
+                  in: "path"
+                  type: "string"
+                  description: "Photo identifier."
+              ref: "photos.get-photo"
+              responseBinary:
+                status: 200
+                mediaType: "image/jpeg"
+                description: "Thumbnail image bytes."
+
+    - type: "mcp"
+      address: "0.0.0.0"
+      port: 8765
+      namespace: "photos-mcp"
+      description: "Photo library MCP server exposing image tools and resources."
+      maxBinarySize: "25MiB"
+      tools:
+        get-photo:
+          display: "Get photo"
+          description: "Download the original-resolution bytes of a photo by id."
+          ref: "photos.get-photo"
+      resources:
+        photo-bytes:
+          display: "Photo bytes"
+          uri: "photos://library/{id}/bytes"
+          description: "Original-resolution bytes of a photo."
+          mimeType: "image/jpeg"
+          binary: true
+          call: "photo-library.download-photo"
+          with:
+            id: "{id}"

--- a/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
+++ b/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
@@ -896,6 +896,10 @@
         "semantics": {
           "$ref": "#/$defs/Semantics"
         },
+        "outputMediaType": {
+          "type": "string",
+          "description": "Contract-level media type advertised by this flow to downstream `exposes`. Independent of `outputRawFormat`, which is always inherited from the underlying consumed operation (call:) or the terminal step (steps:). Overrides the consumed op's `outputMediaType` for advertisement only; never changes how the entity is parsed."
+        },
         "inputParameters": {
           "type": "object",
           "propertyNames": {
@@ -1079,6 +1083,11 @@
         "description": {
           "type": "string",
           "description": "A meaningful description of this MCP server's purpose. Used as the server instructions sent during MCP initialization."
+        },
+        "maxBinarySize": {
+          "type": "string",
+          "pattern": "^\\d+(\\.\\d+)?(B|KiB|MiB|GiB)?$",
+          "description": "Maximum allowed binary response size before base64-encoding. Accepts sizes like '512KiB', '10MiB', '1GiB'. Default: 10MiB. Can be overridden per consumed operation via `maxBinarySize`."
         },
         "authentication": {
           "$ref": "#/$defs/Authentication",
@@ -1349,6 +1358,11 @@
           "type": "string",
           "description": "MIME type of the resource content per RFC 6838 (e.g. application/json, text/markdown, text/plain).",
           "pattern": "^[a-zA-Z0-9!#$&^_.+-]+\\/[a-zA-Z0-9!#$&^_.+-]+(?:\\s*;\\s*[a-zA-Z0-9!#$&^_.+-]+=(?:[a-zA-Z0-9!#$&^_.+-]+|\"[^\"]*\"))*$"
+        },
+        "binary": {
+          "type": "boolean",
+          "default": false,
+          "description": "For dynamic resources: when true, the resource read returns `BlobResourceContents` (base64 `blob` + `mimeType`) instead of `TextResourceContents`. The target consumed operation must declare `outputRawFormat: binary`. Defaults to false to preserve the text path."
         },
         "call": {
           "type": "string",
@@ -1703,11 +1717,86 @@
           "items": {
             "$ref": "#/$defs/StepOutputMapping"
           }
+        },
+        "responses": {
+          "type": "object",
+          "propertyNames": {
+            "pattern": "^[1-5][0-9X]{2}$"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "description": "A single HTTP status-code entry in a REST operation's response contract. Mirrors the OpenAPI Response Object subset Ikanos exports.",
+            "properties": {
+              "description": {
+                "type": "string",
+                "description": "Human-readable description of this response. Exported verbatim to the OpenAPI `responses.<code>.description`."
+              },
+              "content": {
+                "type": "object",
+                "propertyNames": {
+                  "pattern": "^[a-zA-Z0-9!#$&^_.+-]+\\/[a-zA-Z0-9!#$&^_.+-]+(?:\\s*;\\s*[a-zA-Z0-9!#$&^_.+-]+=(?:[a-zA-Z0-9!#$&^_.+-]+|\"[^\"]*\"))*$"
+                },
+                "additionalProperties": {
+                  "type": "object",
+                  "description": "The payload contract for one media type. Either `binary: true` (raw bytes, exported as `type: string, format: binary`) or an inline structured `schema`.",
+                  "properties": {
+                    "binary": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "When true, this media type returns raw bytes. Exported to OpenAPI as `schema: { type: string, format: binary }`. Requires the terminal consumed operation to declare `outputRawFormat: binary`."
+                    },
+                    "schema": {
+                      "type": "object",
+                      "description": "Inline JSON Schema for a non-binary structured response. Ignored when `binary` is true.",
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "description": "Response payloads keyed by media type (e.g. `image/jpeg`, `application/json`).",
+                "minProperties": 1
+              }
+            },
+            "additionalProperties": false
+          },
+          "description": "Explicit per-status-code response contract for this REST operation, keyed by HTTP status code (e.g. '200', '404'). Used to declare binary response media types and to drive OpenAPI export. Mutually exclusive with `responseBinary`."
+        },
+        "responseBinary": {
+          "type": "object",
+          "description": "Shorthand for a single successful binary response. Normalized into the full `responses` structure at spec load. Mutually exclusive with `responses`.",
+          "properties": {
+            "status": {
+              "type": "integer",
+              "minimum": 100,
+              "maximum": 599,
+              "default": 200,
+              "description": "HTTP status code for the binary response. Defaults to 200."
+            },
+            "mediaType": {
+              "type": "string",
+              "pattern": "^[a-zA-Z0-9!#$&^_.+-]+\\/[a-zA-Z0-9!#$&^_.+-]+(?:\\s*;\\s*[a-zA-Z0-9!#$&^_.+-]+=(?:[a-zA-Z0-9!#$&^_.+-]+|\"[^\"]*\"))*$",
+              "description": "Response media type (e.g. `image/jpeg`, `application/pdf`, `application/octet-stream`)."
+            },
+            "description": {
+              "type": "string",
+              "description": "Human-readable description exported to OpenAPI `responses.<code>.description`."
+            }
+          },
+          "required": [
+            "mediaType"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
         "method"
       ],
+      "not": {
+        "required": [
+          "responses",
+          "responseBinary"
+        ]
+      },
       "anyOf": [
         {
           "properties": {
@@ -1957,10 +2046,20 @@
             "psv",
             "yaml",
             "html",
-            "markdown"
+            "markdown",
+            "binary"
           ],
           "default": "json",
-          "description": "The raw format of the response from the consumed API. It is used to determine how to parse the response and extract the output parameters. Delimited formats: csv (comma), tsv (tab), psv (pipe). Default value is json."
+          "description": "The raw format of the response from the consumed API. It is used to determine how to parse the response and extract the output parameters. Delimited formats: csv (comma), tsv (tab), psv (pipe). Use `binary` to buffer the raw bytes without UTF-8 decoding (images, audio, PDFs, archives) and propagate the upstream Content-Type. Default value is json."
+        },
+        "outputMediaType": {
+          "type": "string",
+          "description": "Contract-level response media type. Independent of `outputRawFormat`: applies equally to parsed responses (JSON, XML, YAML) and to binary responses. Overrides the upstream Content-Type for advertised media types (REST headers, OAS `responses.content.<mediaType>` keys, MCP `TextResourceContents.mimeType` / `BlobResourceContents.mimeType`) but does not change how the entity is parsed."
+        },
+        "maxBinarySize": {
+          "type": "string",
+          "pattern": "^\\d+(\\.\\d+)?(B|KiB|MiB|GiB)?$",
+          "description": "Per-operation override of the adapter-level maxBinarySize. Accepts sizes like '512KiB', '5MiB', '1GiB'. Only meaningful when `outputRawFormat` is `binary`."
         },
         "outputSchema": {
           "type": "string",
@@ -1979,6 +2078,42 @@
       },
       "required": [
         "method"
+      ],
+      "not": {
+        "required": [
+          "responses",
+          "responseBinary"
+        ]
+      },
+      "anyOf": [
+        {
+          "properties": {
+            "outputParameters": {
+              "items": {
+                "$ref": "#/$defs/MappedOutputParameter"
+              }
+            }
+          }
+        },
+        {
+          "required": [
+            "steps"
+          ],
+          "properties": {
+            "mappings": true,
+            "outputParameters": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/OrchestratedOutputParameter"
+              }
+            }
+          }
+        },
+        {
+          "required": [
+            "ref"
+          ]
+        }
       ],
       "additionalProperties": false
     },

--- a/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
+++ b/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
@@ -226,6 +226,11 @@
       "description": "Extended identifier (alphanumeric, hyphens, underscores, and wildcard).",
       "pattern": "^[a-zA-Z0-9-_*]+$"
     },
+    "BinarySize": {
+      "type": "string",
+      "description": "A binary size with a mandatory unit (`B`, `KiB`, `MiB`, or `GiB`), e.g. `512KiB`, `5MiB`, `1GiB`. The unit is required to avoid ambiguity (a bare number has no scale).",
+      "pattern": "^\\d+(\\.\\d+)?(B|KiB|MiB|GiB)$"
+    },
     "ConsumedInputParameter": {
       "type": "object",
       "description": "Describes a single function parameter. A unique parameter is defined by a combination of a name and location.",
@@ -1085,8 +1090,7 @@
           "description": "A meaningful description of this MCP server's purpose. Used as the server instructions sent during MCP initialization."
         },
         "maxBinarySize": {
-          "type": "string",
-          "pattern": "^\\d+(\\.\\d+)?(B|KiB|MiB|GiB)?$",
+          "$ref": "#/$defs/BinarySize",
           "description": "Maximum allowed binary response size before base64-encoding. Accepts sizes like '512KiB', '10MiB', '1GiB'. Default: 10MiB. Can be overridden per consumed operation via `maxBinarySize`."
         },
         "authentication": {
@@ -2057,8 +2061,7 @@
           "description": "Contract-level response media type. Independent of `outputRawFormat`: applies equally to parsed responses (JSON, XML, YAML) and to binary responses. Overrides the upstream Content-Type for advertised media types (REST headers, OAS `responses.content.<mediaType>` keys, MCP `TextResourceContents.mimeType` / `BlobResourceContents.mimeType`) but does not change how the entity is parsed."
         },
         "maxBinarySize": {
-          "type": "string",
-          "pattern": "^\\d+(\\.\\d+)?(B|KiB|MiB|GiB)?$",
+          "$ref": "#/$defs/BinarySize",
           "description": "Per-operation override of the adapter-level maxBinarySize. Accepts sizes like '512KiB', '5MiB', '1GiB'. Only meaningful when `outputRawFormat` is `binary`."
         },
         "outputSchema": {

--- a/ikanos-spec/src/test/java/io/ikanos/spec/binary/BinaryContentSchemaValidationTest.java
+++ b/ikanos-spec/src/test/java/io/ikanos/spec/binary/BinaryContentSchemaValidationTest.java
@@ -139,6 +139,60 @@ class BinaryContentSchemaValidationTest {
         assertFalse(errors.isEmpty(), "Expected a validation error for a malformed maxBinarySize");
     }
 
+    @Test
+    @DisplayName("schema rejects a maxBinarySize with no unit (unit is mandatory)")
+    void schemaShouldRejectMaxBinarySizeWithoutUnit() throws Exception {
+        String yaml = """
+            ikanos: "%s"
+            info:
+              display: "demo"
+              description: "demo"
+            capability:
+              consumes:
+                - type: "http"
+                  namespace: "photo-library"
+                  baseUri: "https://photos.example.org"
+                  resources:
+                    photos:
+                      path: "/photos/{id}/binary"
+                      operations:
+                        download-photo:
+                          method: "GET"
+                          outputRawFormat: "binary"
+                          maxBinarySize: "5"
+            """.formatted(IKANOS);
+        Set<ValidationMessage> errors = validateYaml(yaml);
+        assertFalse(errors.isEmpty(),
+            "Expected a validation error for a unit-less maxBinarySize ('5')");
+    }
+
+    @Test
+    @DisplayName("schema accepts outputMediaType on a non-binary (default JSON) consumed operation")
+    void schemaShouldAcceptOutputMediaTypeOnNonBinaryConsumedOperation() throws Exception {
+        // §4.3.2: outputMediaType is orthogonal to outputRawFormat. A non-binary op
+        // (default JSON parsing) may still advertise a vendor media type variant.
+        String yaml = """
+            ikanos: "%s"
+            info:
+              display: "demo"
+              description: "demo"
+            capability:
+              consumes:
+                - type: "http"
+                  namespace: "github"
+                  baseUri: "https://api.github.com"
+                  resources:
+                    repos:
+                      path: "/repos/{owner}/{repo}"
+                      operations:
+                        get-repo:
+                          method: "GET"
+                          outputMediaType: "application/vnd.github.v3+json"
+            """.formatted(IKANOS);
+        Set<ValidationMessage> errors = validateYaml(yaml);
+        assertTrue(errors.isEmpty(), "Expected no validation errors, but got: " + errors);
+    }
+
     // ----- aggregates (§6) -----
 
     @Test

--- a/ikanos-spec/src/test/java/io/ikanos/spec/binary/BinaryContentSchemaValidationTest.java
+++ b/ikanos-spec/src/test/java/io/ikanos/spec/binary/BinaryContentSchemaValidationTest.java
@@ -1,0 +1,358 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.spec.binary;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+
+import io.ikanos.spec.util.VersionHelper;
+
+import java.io.InputStream;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Validates the additive binary-content schema fields introduced by Phase 0 of the
+ * {@code capability-binary-content} blueprint:
+ *
+ * <ul>
+ *   <li>{@code outputRawFormat: binary} + {@code outputMediaType} + {@code maxBinarySize}
+ *       on a consumed HTTP operation (§5);</li>
+ *   <li>{@code outputMediaType} on an aggregate flow (§6);</li>
+ *   <li>{@code responses} contract and {@code responseBinary} shorthand on a REST operation (§7);</li>
+ *   <li>adapter-level {@code maxBinarySize} on an MCP server and {@code binary: true} on a
+ *       dynamic MCP resource (§8).</li>
+ * </ul>
+ *
+ * <p>Phase 0 is purely additive: the engine does not yet read or buffer bytes.</p>
+ */
+class BinaryContentSchemaValidationTest {
+
+    private static JsonSchema schema;
+    private static final YAMLMapper YAML = new YAMLMapper();
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private static final String IKANOS = VersionHelper.getSchemaVersion();
+
+    @BeforeAll
+    static void loadSchema() throws Exception {
+        try (InputStream in = BinaryContentSchemaValidationTest.class
+                .getClassLoader()
+                .getResourceAsStream("schemas/ikanos-schema.json")) {
+            assertNotNull(in, "schemas/ikanos-schema.json must be on the test classpath");
+            JsonNode schemaNode = JSON.readTree(in);
+            JsonSchemaFactory factory =
+                JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012);
+            schema = factory.getSchema(schemaNode);
+        }
+    }
+
+    private Set<ValidationMessage> validateYaml(String yaml) throws Exception {
+        JsonNode data = YAML.readTree(yaml);
+        return schema.validate(data);
+    }
+
+    private Set<ValidationMessage> validateClasspathYaml(String resource) throws Exception {
+        try (InputStream in = BinaryContentSchemaValidationTest.class
+                .getClassLoader()
+                .getResourceAsStream(resource)) {
+            assertNotNull(in, resource + " must be on the test classpath");
+            JsonNode data = YAML.readTree(in);
+            return schema.validate(data);
+        }
+    }
+
+    // ----- consumes (§5) -----
+
+    @Test
+    @DisplayName("schema accepts outputRawFormat: binary with outputMediaType and maxBinarySize")
+    void schemaShouldAcceptBinaryConsumedOperation() throws Exception {
+        String yaml = """
+            ikanos: "%s"
+            info:
+              display: "demo"
+              description: "demo"
+            capability:
+              consumes:
+                - type: "http"
+                  namespace: "photo-library"
+                  baseUri: "https://photos.example.org"
+                  resources:
+                    photos:
+                      path: "/photos/{id}/binary"
+                      operations:
+                        download-photo:
+                          method: "GET"
+                          outputRawFormat: "binary"
+                          outputMediaType: "image/jpeg"
+                          maxBinarySize: "5MiB"
+            """.formatted(IKANOS);
+        Set<ValidationMessage> errors = validateYaml(yaml);
+        assertTrue(errors.isEmpty(), "Expected no validation errors, but got: " + errors);
+    }
+
+    @Test
+    @DisplayName("schema rejects a maxBinarySize that does not match the size pattern")
+    void schemaShouldRejectMalformedMaxBinarySize() throws Exception {
+        String yaml = """
+            ikanos: "%s"
+            info:
+              display: "demo"
+              description: "demo"
+            capability:
+              consumes:
+                - type: "http"
+                  namespace: "photo-library"
+                  baseUri: "https://photos.example.org"
+                  resources:
+                    photos:
+                      path: "/photos/{id}/binary"
+                      operations:
+                        download-photo:
+                          method: "GET"
+                          outputRawFormat: "binary"
+                          maxBinarySize: "5 megabytes"
+            """.formatted(IKANOS);
+        Set<ValidationMessage> errors = validateYaml(yaml);
+        assertFalse(errors.isEmpty(), "Expected a validation error for a malformed maxBinarySize");
+    }
+
+    // ----- aggregates (§6) -----
+
+    @Test
+    @DisplayName("schema accepts outputMediaType on an aggregate flow")
+    void schemaShouldAcceptOutputMediaTypeOnAggregateFlow() throws Exception {
+        String yaml = """
+            ikanos: "%s"
+            info:
+              display: "demo"
+              description: "demo"
+            capability:
+              consumes:
+                - type: "http"
+                  namespace: "photo-library"
+                  baseUri: "https://photos.example.org"
+                  resources:
+                    photos:
+                      path: "/photos/{id}/binary"
+                      operations:
+                        download-photo:
+                          method: "GET"
+                          outputRawFormat: "binary"
+              aggregates:
+                - display: "Photos"
+                  namespace: "photos"
+                  flows:
+                    get-photo:
+                      description: "Download a photo by id."
+                      outputMediaType: "image/jpeg"
+                      call: "photo-library.download-photo"
+            """.formatted(IKANOS);
+        Set<ValidationMessage> errors = validateYaml(yaml);
+        assertTrue(errors.isEmpty(), "Expected no validation errors, but got: " + errors);
+    }
+
+    // ----- exposes rest (§7) -----
+
+    @Test
+    @DisplayName("schema accepts a REST operation with a binary responses contract")
+    void schemaShouldAcceptRestResponsesBinaryContract() throws Exception {
+        String yaml = """
+            ikanos: "%s"
+            info:
+              display: "demo"
+              description: "demo"
+            capability:
+              consumes:
+                - type: "http"
+                  namespace: "photo-library"
+                  baseUri: "https://photos.example.org"
+                  resources:
+                    photos:
+                      path: "/photos/{id}/binary"
+                      operations:
+                        download-photo:
+                          method: "GET"
+                          outputRawFormat: "binary"
+              exposes:
+                - type: "rest"
+                  port: 8080
+                  namespace: "photos-api"
+                  resources:
+                    photo-image:
+                      path: "/photos/{{id}}/image"
+                      operations:
+                        get-photo-image:
+                          method: "GET"
+                          call: "photo-library.download-photo"
+                          responses:
+                            "200":
+                              description: "Original image bytes."
+                              content:
+                                image/jpeg:
+                                  binary: true
+            """.formatted(IKANOS);
+        Set<ValidationMessage> errors = validateYaml(yaml);
+        assertTrue(errors.isEmpty(), "Expected no validation errors, but got: " + errors);
+    }
+
+    @Test
+    @DisplayName("schema accepts a REST operation with the responseBinary shorthand")
+    void schemaShouldAcceptRestResponseBinaryShorthand() throws Exception {
+        String yaml = """
+            ikanos: "%s"
+            info:
+              display: "demo"
+              description: "demo"
+            capability:
+              consumes:
+                - type: "http"
+                  namespace: "photo-library"
+                  baseUri: "https://photos.example.org"
+                  resources:
+                    photos:
+                      path: "/photos/{id}/binary"
+                      operations:
+                        download-photo:
+                          method: "GET"
+                          outputRawFormat: "binary"
+              exposes:
+                - type: "rest"
+                  port: 8080
+                  namespace: "photos-api"
+                  resources:
+                    photo-image:
+                      path: "/photos/{{id}}/image"
+                      operations:
+                        get-photo-image:
+                          method: "GET"
+                          call: "photo-library.download-photo"
+                          responseBinary:
+                            status: 200
+                            mediaType: "image/jpeg"
+                            description: "Original image bytes."
+            """.formatted(IKANOS);
+        Set<ValidationMessage> errors = validateYaml(yaml);
+        assertTrue(errors.isEmpty(), "Expected no validation errors, but got: " + errors);
+    }
+
+    @Test
+    @DisplayName("schema rejects a REST operation declaring both responses and responseBinary")
+    void schemaShouldRejectBothResponsesAndResponseBinary() throws Exception {
+        String yaml = """
+            ikanos: "%s"
+            info:
+              display: "demo"
+              description: "demo"
+            capability:
+              consumes:
+                - type: "http"
+                  namespace: "photo-library"
+                  baseUri: "https://photos.example.org"
+                  resources:
+                    photos:
+                      path: "/photos/{id}/binary"
+                      operations:
+                        download-photo:
+                          method: "GET"
+                          outputRawFormat: "binary"
+              exposes:
+                - type: "rest"
+                  port: 8080
+                  namespace: "photos-api"
+                  resources:
+                    photo-image:
+                      path: "/photos/{{id}}/image"
+                      operations:
+                        get-photo-image:
+                          method: "GET"
+                          call: "photo-library.download-photo"
+                          responseBinary:
+                            mediaType: "image/jpeg"
+                          responses:
+                            "200":
+                              content:
+                                image/jpeg:
+                                  binary: true
+            """.formatted(IKANOS);
+        Set<ValidationMessage> errors = validateYaml(yaml);
+        assertFalse(errors.isEmpty(),
+            "Expected a validation error when both responses and responseBinary are declared");
+    }
+
+    // ----- exposes mcp (§8) -----
+
+    @Test
+    @DisplayName("schema accepts MCP adapter maxBinarySize and a binary dynamic resource")
+    void schemaShouldAcceptMcpMaxBinarySizeAndBinaryResource() throws Exception {
+        String yaml = """
+            ikanos: "%s"
+            info:
+              display: "demo"
+              description: "demo"
+            capability:
+              consumes:
+                - type: "http"
+                  namespace: "photo-library"
+                  baseUri: "https://photos.example.org"
+                  resources:
+                    photos:
+                      path: "/photos/{id}/binary"
+                      operations:
+                        download-photo:
+                          method: "GET"
+                          outputRawFormat: "binary"
+              exposes:
+                - type: "mcp"
+                  port: 8765
+                  namespace: "photos-mcp"
+                  maxBinarySize: "25MiB"
+                  tools:
+                    get-photo:
+                      description: "Download a photo by id."
+                      call: "photo-library.download-photo"
+                  resources:
+                    photo-bytes:
+                      display: "Photo bytes"
+                      uri: "photos://library/{id}/bytes"
+                      description: "Original-resolution bytes of a photo."
+                      mimeType: "image/jpeg"
+                      binary: true
+                      call: "photo-library.download-photo"
+            """.formatted(IKANOS);
+        Set<ValidationMessage> errors = validateYaml(yaml);
+        assertTrue(errors.isEmpty(), "Expected no validation errors, but got: " + errors);
+    }
+
+    // ----- bundled example -----
+
+    @Test
+    @DisplayName("bundled example capability-binary-content.yml passes schema validation")
+    void schemaShouldAcceptBundledBinaryContentExample() throws Exception {
+        Set<ValidationMessage> errors =
+            validateClasspathYaml("schemas/examples/capability-binary-content.yml");
+        assertTrue(errors.isEmpty(), "Expected no validation errors, but got: " + errors);
+    }
+}


### PR DESCRIPTION
## Summary

Phase 0 of the **Binary Content Across a Capability** blueprint (`blueprints/capability-binary-content.md`). This PR is **purely additive** to the Ikanos JSON schema — no runtime behavior changes. It lets a capability *declare* binary intent across `consumes`, `aggregates`, and `exposes`; the engine wiring lands in Phases 1+.

Closes the Phase 0 deliverable of #583.

## Schema additions

| Definition | Change |
|---|---|
| `BinarySize` (`$def`) | New reusable sized-string primitive `^\d+(\.\d+)?(B\|KiB\|MiB\|GiB)$`. The unit is **mandatory** — a bare number (`"5"`) or sub-byte fractional (`"1.5B"`) has no useful scale and is rejected. Referenced by every `maxBinarySize` site to keep them in sync. |
| `ConsumedHttpOperation` | `binary` added to the `outputRawFormat` enum; new optional `outputMediaType` (string) and `maxBinarySize` (`$ref: BinarySize`). |
| `AggregateFlow` | New optional `outputMediaType`. Deliberately **not** `outputRawFormat` / bare `binary` / `maxBinarySize` (blueprint §6.2 — binary-ness is inherited, never re-declared at the aggregate layer). |
| `ExposedOperation` (REST) | New `responses` contract (`content.<mediaType>.binary: true` + inline `schema`) and the `responseBinary` shorthand (`status` / `mediaType` / `description`). The two are mutually exclusive (`not: { required: [responses, responseBinary] }`). |
| `ExposesMcp` | New adapter-level `maxBinarySize` (`$ref: BinarySize`, default 10MiB). |
| `McpResource` | New `binary: true` shorthand for dynamic resources (defaults false). |

The REST response schemas are defined **inline** on `ExposedOperation` rather than as shared `$defs`, to keep the contract localized to the only definition that uses it.

### Status code typing — deliberate string-vs-integer asymmetry

`responseBinary.status` is an **integer** (`200`), while the keys of the `responses` contract are **strings** (`"200"`, matched by `^[1-5][0-9X]{2}$`). This is intentional and mirrors the blueprint (§7.1 vs §7.2): the `responses` map needs string keys so it can express wildcard ranges (`"2XX"`, `"5XX"`), whereas the single-status `responseBinary` shorthand takes a plain integer. The next reader should not "fix" one to match the other.

## Example + tests

- `schemas/examples/capability-binary-content.yml` — a photo-library capability exercising every new field: one binary consumed operation (`download-photo`) surfaced through an aggregate flow (`photos.get-photo`, with `outputMediaType`), a REST `responses` contract, a REST `responseBinary` shorthand, an MCP tool, and a binary MCP resource.
- `BinaryContentSchemaValidationTest` — happy paths for each section (§5–§8), including `outputMediaType` on a **non-binary** (default JSON) consumed op to lock in the §4.3.2 orthogonality of `outputMediaType` and `outputRawFormat`; negative paths for a malformed `maxBinarySize`, a unit-less `maxBinarySize` (`"5"`), and declaring both `responses` and `responseBinary`; plus a bundled-example check (mirrors `TunnelSchemaValidationTest`).

## Backward compatibility

Strictly additive: no required fields, no renames. Existing specs validate unchanged.

## Validation

`mvn clean test -pl ikanos-spec` → **BinaryContentSchemaValidationTest: 10 tests, 0 failures, 0 errors, BUILD SUCCESS**.

## Out of scope (tracked under #583)

Runtime byte handling, REST/MCP adapter branches, OAS export, the cross-side consistency validations (e.g. REST binary response ⇒ consumed op must be `outputRawFormat: binary`), and docs — Phases 1–7.
