### PR TITLE
fix: complete native-image reflect-config for serve + validate (#581)

### DIFF
--- a/.github/workflows/publish-cli-bin.yml
+++ b/.github/workflows/publish-cli-bin.yml
@@ -120,3 +120,66 @@ jobs:
         run: |
           "test`nhttps://api.com`n8080`n" | & ./bin/${{ matrix.artifact_name }} create capability
           & ./bin/${{ matrix.artifact_name }} v test.ikanos.yaml
+
+      # --- Native-image reflection regression guard (#581) ---------------------
+      # alpha4 shipped a native binary with org.restlet and part of the networknt
+      # json-schema-validator classes missing from reflect-config.json, so `serve`
+      # (Restlet HTTP connector) and `validate` (MaxLengthValidator) crashed with
+      # ClassNotFoundException / NoSuchMethodException. These steps fail the build
+      # if those reflection exceptions ever reappear. This workflow is invoked
+      # nightly via workflow_call (smoke-tests job in nightly-quality-gate.yml) and
+      # on release tags — so the native binary is exercised every night on each
+      # branch, not only at release time, without building it on every push.
+      # Single `shell: bash` (Git Bash exists on the Windows runner) — broader
+      # job-style alignment is #582.
+      - name: Native regression — validate (networknt validators)
+        shell: bash
+        run: |
+          BIN="./bin/${{ matrix.artifact_name }}"
+          FIXTURE="ikanos-cli/src/test/resources/native-regression/serve-http.ikanos.yaml"
+          OUT=$("$BIN" validate "$FIXTURE" 2>&1 || true)
+          echo "$OUT"
+          if echo "$OUT" | grep -E "ClassNotFoundException|NoSuchMethodException|ExceptionInInitializerError"; then
+            echo "FAIL: native reflection regression on validate (#581)"
+            exit 1
+          fi
+
+      - name: Native regression — serve (Restlet HTTP connector boots + exposed port listens)
+        shell: bash
+        run: |
+          BIN="./bin/${{ matrix.artifact_name }}"
+          FIXTURE="ikanos-cli/src/test/resources/native-regression/serve-http.ikanos.yaml"
+          REST_PORT=9610
+          "$BIN" serve "$FIXTURE" > serve.log 2>&1 &
+          SERVE_PID=$!
+
+          # A broken reflect-config crashes serve within milliseconds ("No available
+          # server connector"), so the exposed REST port never starts listening. We
+          # probe that port directly over TCP — we deliberately do NOT run `ikanos
+          # health`, which would drag in the unrelated Restlet *client* reflective
+          # surface (and a 30s client timeout); this guard protects the serve-side
+          # connector only.
+          LISTENING=0
+          for i in $(seq 1 20); do
+            if (exec 3<>"/dev/tcp/127.0.0.1/$REST_PORT") 2>/dev/null; then
+              exec 3>&- 3<&- 2>/dev/null || true
+              LISTENING=1
+              break
+            fi
+            # serve may have crashed; stop early if the process is gone
+            kill -0 "$SERVE_PID" 2>/dev/null || break
+            sleep 1
+          done
+
+          kill "$SERVE_PID" 2>/dev/null || true
+
+          echo "----- serve.log -----"; cat serve.log
+
+          if grep -E "ClassNotFoundException|NoSuchMethodException|ExceptionInInitializerError|No available server connector" serve.log; then
+            echo "FAIL: native reflection regression on serve (#581)"
+            exit 1
+          fi
+          if [ "$LISTENING" -ne 1 ]; then
+            echo "FAIL: exposed REST port $REST_PORT never started listening — HTTP connector did not boot (#581)"
+            exit 1
+          fi

--- a/.github/workflows/publish-cli-bin.yml
+++ b/.github/workflows/publish-cli-bin.yml
@@ -98,6 +98,9 @@ jobs:
             artifact_name: ikanos-cli-windows-amd64.exe
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Download binary
         uses: actions/download-artifact@v4
         with:

--- a/ikanos-cli/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/ikanos-cli/src/main/resources/META-INF/native-image/reflect-config.json
@@ -2,7 +2,18 @@
   {
     "name": "com.networknt.schema.TypeValidator",
     "allDeclaredConstructors": true,
-    "allDeclaredMethods": true
+    "allDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "com.fasterxml.jackson.databind.JsonNode",
+          "com.networknt.schema.JsonSchema",
+          "com.networknt.schema.ValidationContext"
+        ]
+      }
+    ]
   },
   {
     "name": "com.networknt.schema.BaseJsonValidator",
@@ -42,19 +53,63 @@
   },
   {
     "name": "com.networknt.schema.EnumValidator",
-    "allDeclaredConstructors": true
+    "allDeclaredConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "com.fasterxml.jackson.databind.JsonNode",
+          "com.networknt.schema.JsonSchema",
+          "com.networknt.schema.ValidationContext"
+        ]
+      }
+    ]
   },
   {
     "name": "com.networknt.schema.ConstValidator",
-    "allDeclaredConstructors": true
+    "allDeclaredConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "com.fasterxml.jackson.databind.JsonNode",
+          "com.networknt.schema.JsonSchema",
+          "com.networknt.schema.ValidationContext"
+        ]
+      }
+    ]
   },
   {
     "name": "com.networknt.schema.OneOfValidator",
-    "allDeclaredConstructors": true
+    "allDeclaredConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "com.fasterxml.jackson.databind.JsonNode",
+          "com.networknt.schema.JsonSchema",
+          "com.networknt.schema.ValidationContext"
+        ]
+      }
+    ]
   },
   {
     "name": "com.networknt.schema.AnyOfValidator",
-    "allDeclaredConstructors": true
+    "allDeclaredConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "com.fasterxml.jackson.databind.JsonNode",
+          "com.networknt.schema.JsonSchema",
+          "com.networknt.schema.ValidationContext"
+        ]
+      }
+    ]
   },
   {
     "name": "com.networknt.schema.AllOfValidator",
@@ -62,43 +117,153 @@
   },
   {
     "name": "com.networknt.schema.NotValidator",
-    "allDeclaredConstructors": true
+    "allDeclaredConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "com.fasterxml.jackson.databind.JsonNode",
+          "com.networknt.schema.JsonSchema",
+          "com.networknt.schema.ValidationContext"
+        ]
+      }
+    ]
   },
   {
     "name": "com.networknt.schema.PropertiesValidator",
-    "allDeclaredConstructors": true
+    "allDeclaredConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "com.fasterxml.jackson.databind.JsonNode",
+          "com.networknt.schema.JsonSchema",
+          "com.networknt.schema.ValidationContext"
+        ]
+      }
+    ]
   },
   {
     "name": "com.networknt.schema.RequiredValidator",
-    "allDeclaredConstructors": true
+    "allDeclaredConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "com.fasterxml.jackson.databind.JsonNode",
+          "com.networknt.schema.JsonSchema",
+          "com.networknt.schema.ValidationContext"
+        ]
+      }
+    ]
   },
   {
     "name": "com.networknt.schema.AdditionalPropertiesValidator",
-    "allDeclaredConstructors": true
+    "allDeclaredConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "com.fasterxml.jackson.databind.JsonNode",
+          "com.networknt.schema.JsonSchema",
+          "com.networknt.schema.ValidationContext"
+        ]
+      }
+    ]
   },
   {
     "name": "com.networknt.schema.RefValidator",
-    "allDeclaredConstructors": true
+    "allDeclaredConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "com.fasterxml.jackson.databind.JsonNode",
+          "com.networknt.schema.JsonSchema",
+          "com.networknt.schema.ValidationContext"
+        ]
+      }
+    ]
   },
   {
     "name": "com.networknt.schema.ItemsValidator202012",
-    "allDeclaredConstructors": true
+    "allDeclaredConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "com.fasterxml.jackson.databind.JsonNode",
+          "com.networknt.schema.JsonSchema",
+          "com.networknt.schema.ValidationContext"
+        ]
+      }
+    ]
   },
   {
     "name": "com.networknt.schema.MinItemsValidator",
-    "allDeclaredConstructors": true
+    "allDeclaredConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "com.fasterxml.jackson.databind.JsonNode",
+          "com.networknt.schema.JsonSchema",
+          "com.networknt.schema.ValidationContext"
+        ]
+      }
+    ]
   },
   {
     "name": "com.networknt.schema.MinimumValidator",
-    "allDeclaredConstructors": true
+    "allDeclaredConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "com.fasterxml.jackson.databind.JsonNode",
+          "com.networknt.schema.JsonSchema",
+          "com.networknt.schema.ValidationContext"
+        ]
+      }
+    ]
   },
   {
     "name": "com.networknt.schema.MaximumValidator",
-    "allDeclaredConstructors": true
+    "allDeclaredConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "com.fasterxml.jackson.databind.JsonNode",
+          "com.networknt.schema.JsonSchema",
+          "com.networknt.schema.ValidationContext"
+        ]
+      }
+    ]
   },
   {
     "name": "com.networknt.schema.PatternValidator",
-    "allDeclaredConstructors": true
+    "allDeclaredConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "com.fasterxml.jackson.databind.JsonNode",
+          "com.networknt.schema.JsonSchema",
+          "com.networknt.schema.ValidationContext"
+        ]
+      }
+    ]
   },
   {
     "name": "io.swagger.v3.core.jackson.ModelResolver",
@@ -546,43 +711,151 @@
     "name": "io.ikanos.spec.IkanosSpec",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
-    "allDeclaredFields": true
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setCapability",
+        "parameterTypes": [
+          "io.ikanos.spec.CapabilitySpec"
+        ]
+      },
+      {
+        "name": "setIkanos",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setInfo",
+        "parameterTypes": [
+          "io.ikanos.spec.InfoSpec"
+        ]
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.consumes.ClientSpec",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
-    "allDeclaredFields": true
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "setNamespace",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setType",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.consumes.http.HttpClientSpec",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
-    "allDeclaredFields": true
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setBaseUri",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setResources",
+        "parameterTypes": [
+          "java.util.Map"
+        ]
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.consumes.http.HttpClientResourceSpec",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
-    "allDeclaredFields": true
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setOperations",
+        "parameterTypes": [
+          "java.util.Map"
+        ]
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.consumes.http.HttpClientOperationSpec",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
-    "allDeclaredFields": true
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.OperationSpec",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
-    "allDeclaredFields": true
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "setDisplay",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setMethod",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.ResourceSpec",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
-    "allDeclaredFields": true
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "setDescription",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setDisplay",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setPath",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.InputParameterSpec",
@@ -647,18 +920,60 @@
   {
     "name": "io.ikanos.spec.exposes.ServerSpecDeserializer",
     "allDeclaredConstructors": true,
-    "allDeclaredMethods": true
+    "allDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.consumes.ClientSpecDeserializer",
     "allDeclaredConstructors": true,
-    "allDeclaredMethods": true
+    "allDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.InfoSpec",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
-    "allDeclaredFields": true
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setCreated",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setDescription",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setDisplay",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setModified",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.StakeholderSpec",
@@ -670,7 +985,13 @@
     "name": "io.ikanos.spec.CapabilitySpec",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
-    "allDeclaredFields": true
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.InputParameterDeserializer",
@@ -768,7 +1089,13 @@
   },
   {
     "name": "io.ikanos.spec.aggregates.AggregateMapDeserializer",
-    "allDeclaredConstructors": true
+    "allDeclaredConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.aggregates.AggregateFlowMapDeserializer",
@@ -776,7 +1103,13 @@
   },
   {
     "name": "io.ikanos.spec.aggregates.AggregateSpecDeserializer",
-    "allDeclaredConstructors": true
+    "allDeclaredConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.aggregates.AggregateFlowSpec",
@@ -786,39 +1119,119 @@
   },
   {
     "name": "io.ikanos.spec.InputParameterMapDeserializer",
-    "allDeclaredConstructors": true
+    "allDeclaredConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.util.OperationStepMapDeserializer",
-    "allDeclaredConstructors": true
+    "allDeclaredConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.OutputParameterListOrMapDeserializer",
-    "allDeclaredConstructors": true
+    "allDeclaredConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.exposes.ServerSpec",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
-    "allDeclaredFields": true
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "setAddress",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setPort",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "setType",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.exposes.rest.RestServerSpec",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
-    "allDeclaredFields": true
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setNamespace",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setResources",
+        "parameterTypes": [
+          "java.util.Map"
+        ]
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.exposes.rest.RestServerResourceSpec",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
-    "allDeclaredFields": true
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setOperations",
+        "parameterTypes": [
+          "java.util.Map"
+        ]
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.exposes.rest.RestServerOperationSpec",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
-    "allDeclaredFields": true
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setCall",
+        "parameterTypes": [
+          "io.ikanos.spec.exposes.ServerCallSpec"
+        ]
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.exposes.rest.RestServerForwardSpec",
@@ -860,7 +1273,15 @@
     "name": "io.ikanos.spec.exposes.ServerCallSpec",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
-    "allDeclaredFields": true
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.util.StepOutputMappingSpec",
@@ -872,13 +1293,67 @@
     "name": "io.ikanos.spec.exposes.skill.ExposedSkillSpec",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
-    "allDeclaredFields": true
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setAllowedTools",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setCompatibility",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setDescription",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setLicense",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.exposes.skill.SkillServerSpec",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
-    "allDeclaredFields": true
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setDescription",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setNamespace",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setSkills",
+        "parameterTypes": [
+          "java.util.Map"
+        ]
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.exposes.skill.SkillToolSpec",
@@ -938,13 +1413,43 @@
     "name": "io.ikanos.spec.exposes.control.ControlServerSpec",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
-    "allDeclaredFields": true
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setManagement",
+        "parameterTypes": [
+          "io.ikanos.spec.exposes.control.ControlManagementSpec"
+        ]
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.exposes.control.ControlManagementSpec",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
-    "allDeclaredFields": true
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setHealth",
+        "parameterTypes": [
+          "boolean"
+        ]
+      },
+      {
+        "name": "setInfo",
+        "parameterTypes": [
+          "boolean"
+        ]
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.exposes.control.ControlLogsEndpointSpec",
@@ -955,7 +1460,13 @@
   {
     "name": "io.ikanos.spec.exposes.control.ControlLogsEndpointSpecDeserializer",
     "allDeclaredConstructors": true,
-    "allDeclaredMethods": true
+    "allDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.exposes.control.ScriptingManagementSpec",
@@ -976,12 +1487,34 @@
   {
     "name": "com.networknt.schema.PropertyNamesValidator",
     "allDeclaredConstructors": true,
-    "allDeclaredMethods": true
+    "allDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "com.fasterxml.jackson.databind.JsonNode",
+          "com.networknt.schema.JsonSchema",
+          "com.networknt.schema.ValidationContext"
+        ]
+      }
+    ]
   },
   {
     "name": "com.networknt.schema.MinPropertiesValidator",
     "allDeclaredConstructors": true,
-    "allDeclaredMethods": true
+    "allDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "com.fasterxml.jackson.databind.JsonNode",
+          "com.networknt.schema.JsonSchema",
+          "com.networknt.schema.ValidationContext"
+        ]
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.util.NamedMapDeserializer",
@@ -989,15 +1522,33 @@
   },
   {
     "name": "io.ikanos.spec.util.BindingSpecDeserializer",
-    "allDeclaredConstructors": true
+    "allDeclaredConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.consumes.http.HttpClientOperationMapDeserializer",
-    "allDeclaredConstructors": true
+    "allDeclaredConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.consumes.http.HttpClientResourceMapDeserializer",
-    "allDeclaredConstructors": true
+    "allDeclaredConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.exposes.mcp.McpPromptArgumentMapDeserializer",
@@ -1016,19 +1567,1292 @@
     "allDeclaredConstructors": true
   },
   {
+    "name": "org.restlet.data.Parameter",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.restlet.engine.connector.HttpClientHelper",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.restlet.Client"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.restlet.engine.connector.HttpServerHelper",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.restlet.Server"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.restlet.ext.jackson.JacksonConverter",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.restlet.ext.slf4j.Slf4jLoggerFacade",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.restlet.resource.Finder",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.restlet.Context",
+          "java.lang.Class"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "com.networknt.schema.MaxLengthValidator",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "com.fasterxml.jackson.databind.JsonNode",
+          "com.networknt.schema.JsonSchema",
+          "com.networknt.schema.ValidationContext"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.encoder.PatternLayoutEncoder",
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.joran.SerializedModelConfigurator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.spi.ILoggingEvent",
+    "methods": [
+      {
+        "name": "getInstant",
+        "parameterTypes": []
+      },
+      {
+        "name": "getKeyValuePairs",
+        "parameterTypes": []
+      },
+      {
+        "name": "getMarkerList",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.util.DefaultJoranConfigurator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.ConsoleAppender",
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.OutputStreamAppender",
+    "methods": [
+      {
+        "name": "setEncoder",
+        "parameterTypes": [
+          "ch.qos.logback.core.encoder.Encoder"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.encoder.Encoder",
+    "methods": [
+      {
+        "name": "valueOf",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.encoder.LayoutWrappingEncoder",
+    "methods": [
+      {
+        "name": "setParent",
+        "parameterTypes": [
+          "ch.qos.logback.core.spi.ContextAware"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.PatternLayoutEncoderBase",
+    "methods": [
+      {
+        "name": "setPattern",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.spi.ContextAware",
+    "methods": [
+      {
+        "name": "valueOf",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "com.fasterxml.jackson.databind.ext.Java7SupportImpl",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.sun.crypto.provider.AESCipher$General",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.sun.crypto.provider.ARCFOURCipher",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Poly1305",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.sun.crypto.provider.DESCipher",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.sun.crypto.provider.DESedeCipher",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.sun.crypto.provider.DHParameters",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.sun.crypto.provider.GaloisCounterMode$AESGCM",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.sun.crypto.provider.TlsMasterSecretGenerator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "groovy.lang.Closure"
+  },
+  {
+    "name": "io.ikanos.Cli",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "name": "io.ikanos.Cli$VersionProvider",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "io.ikanos.cli.ControlPortMixin",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "io.ikanos.cli.CreateCapabilityCommand",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "name": "io.ikanos.cli.CreateCommand",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "name": "io.ikanos.cli.ExportCommand",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "name": "io.ikanos.cli.ExportOpenApiCommand",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "name": "io.ikanos.cli.HealthCommand",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "io.ikanos.cli.ImportCommand",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "name": "io.ikanos.cli.ImportOpenApiCommand",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "name": "io.ikanos.cli.MetricsCommand",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "io.ikanos.cli.ScriptingCommand",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "io.ikanos.cli.ServeCommand",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "io.ikanos.cli.StatusCommand",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "io.ikanos.cli.TracesCommand",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "io.ikanos.cli.ValidateCommand",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "io.ikanos.spec.consumes.http.tunnel.TunnelConfigSpec",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllDeclaredConstructors": true
+  },
+  {
     "name": "io.ikanos.spec.exposes.rest.RestServerOperationMapDeserializer",
-    "allDeclaredConstructors": true
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.exposes.rest.RestServerResourceMapDeserializer",
-    "allDeclaredConstructors": true
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.exposes.skill.ExposedSkillMapDeserializer",
-    "allDeclaredConstructors": true
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
   },
   {
     "name": "io.ikanos.spec.exposes.skill.SkillToolMapDeserializer",
-    "allDeclaredConstructors": true
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "io.opentelemetry.api.incubator.metrics.ExtendedDefaultMeterProvider",
+    "methods": [
+      {
+        "name": "getNoop",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "io.opentelemetry.api.incubator.trace.ExtendedDefaultTracerProvider",
+    "methods": [
+      {
+        "name": "getNoop",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender",
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setCaptureExperimentalAttributes",
+        "parameterTypes": [
+          "boolean"
+        ]
+      },
+      {
+        "name": "setCaptureMdcAttributes",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk"
+  },
+  {
+    "name": "io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfiguration"
+  },
+  {
+    "name": "io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder",
+    "methods": [
+      {
+        "name": "setExemplarFilter",
+        "parameterTypes": [
+          "io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarFilter"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "java.lang.Class",
+    "methods": [
+      {
+        "name": "isRecord",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "java.lang.Object",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "name": "java.lang.Thread",
+    "fields": [
+      {
+        "name": "threadLocalRandomProbe"
+      }
+    ],
+    "methods": [
+      {
+        "name": "isVirtual",
+        "parameterTypes": []
+      },
+      {
+        "name": "ofVirtual",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "java.lang.Thread$Builder",
+    "methods": [
+      {
+        "name": "factory",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "java.lang.management.ManagementFactory",
+    "methods": [
+      {
+        "name": "getRuntimeMXBean",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "java.lang.management.RuntimeMXBean",
+    "methods": [
+      {
+        "name": "getUptime",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "java.nio.file.Path"
+  },
+  {
+    "name": "java.nio.file.Paths",
+    "methods": [
+      {
+        "name": "get",
+        "parameterTypes": [
+          "java.lang.String",
+          "java.lang.String[]"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "java.security.AccessController",
+    "methods": [
+      {
+        "name": "doPrivileged",
+        "parameterTypes": [
+          "java.security.PrivilegedAction"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "java.security.AlgorithmParametersSpi"
+  },
+  {
+    "name": "java.security.KeyStoreSpi"
+  },
+  {
+    "name": "java.security.SecureRandomParameters"
+  },
+  {
+    "name": "java.sql.Connection"
+  },
+  {
+    "name": "java.sql.Date"
+  },
+  {
+    "name": "java.sql.Driver"
+  },
+  {
+    "name": "java.sql.DriverManager",
+    "methods": [
+      {
+        "name": "getConnection",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "getDriver",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "java.sql.Time",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "long"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "java.sql.Timestamp",
+    "methods": [
+      {
+        "name": "valueOf",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "java.time.Duration",
+    "methods": [
+      {
+        "name": "parse",
+        "parameterTypes": [
+          "java.lang.CharSequence"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "java.time.Instant",
+    "methods": [
+      {
+        "name": "parse",
+        "parameterTypes": [
+          "java.lang.CharSequence"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "java.time.LocalDate",
+    "methods": [
+      {
+        "name": "parse",
+        "parameterTypes": [
+          "java.lang.CharSequence"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "java.time.LocalDateTime",
+    "methods": [
+      {
+        "name": "parse",
+        "parameterTypes": [
+          "java.lang.CharSequence"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "java.time.LocalTime",
+    "methods": [
+      {
+        "name": "parse",
+        "parameterTypes": [
+          "java.lang.CharSequence"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "java.time.MonthDay",
+    "methods": [
+      {
+        "name": "parse",
+        "parameterTypes": [
+          "java.lang.CharSequence"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "java.time.OffsetDateTime",
+    "methods": [
+      {
+        "name": "parse",
+        "parameterTypes": [
+          "java.lang.CharSequence"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "java.time.OffsetTime",
+    "methods": [
+      {
+        "name": "parse",
+        "parameterTypes": [
+          "java.lang.CharSequence"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "java.time.Period",
+    "methods": [
+      {
+        "name": "parse",
+        "parameterTypes": [
+          "java.lang.CharSequence"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "java.time.Year",
+    "methods": [
+      {
+        "name": "parse",
+        "parameterTypes": [
+          "java.lang.CharSequence"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "java.time.YearMonth",
+    "methods": [
+      {
+        "name": "parse",
+        "parameterTypes": [
+          "java.lang.CharSequence"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "java.time.ZoneId",
+    "methods": [
+      {
+        "name": "of",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "java.time.ZoneOffset",
+    "methods": [
+      {
+        "name": "of",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "java.time.ZonedDateTime",
+    "methods": [
+      {
+        "name": "parse",
+        "parameterTypes": [
+          "java.lang.CharSequence"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "java.util.concurrent.CopyOnWriteArrayList",
+    "queryAllDeclaredMethods": true,
+    "queryAllDeclaredConstructors": true
+  },
+  {
+    "name": "java.util.concurrent.Executors",
+    "methods": [
+      {
+        "name": "newThreadPerTaskExecutor",
+        "parameterTypes": [
+          "java.util.concurrent.ThreadFactory"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "java.util.concurrent.atomic.AtomicBoolean",
+    "fields": [
+      {
+        "name": "value"
+      }
+    ]
+  },
+  {
+    "name": "java.util.concurrent.atomic.AtomicReference",
+    "fields": [
+      {
+        "name": "value"
+      }
+    ]
+  },
+  {
+    "name": "java.util.concurrent.atomic.DoubleAdder"
+  },
+  {
+    "name": "java.util.concurrent.atomic.LongAdder"
+  },
+  {
+    "name": "java.util.concurrent.atomic.Striped64",
+    "fields": [
+      {
+        "name": "base"
+      },
+      {
+        "name": "cellsBusy"
+      }
+    ]
+  },
+  {
+    "name": "javax.security.auth.Subject",
+    "methods": [
+      {
+        "name": "callAs",
+        "parameterTypes": [
+          "javax.security.auth.Subject",
+          "java.util.concurrent.Callable"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "javax.security.auth.x500.X500Principal",
+    "fields": [
+      {
+        "name": "thisX500Name"
+      }
+    ],
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "sun.security.x509.X500Name"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "net.logstash.logback.marker.LogstashMarker"
+  },
+  {
+    "name": "org.eclipse.jetty.util.TypeUtil",
+    "methods": [
+      {
+        "name": "getClassLoaderLocation",
+        "parameterTypes": [
+          "java.lang.Class"
+        ]
+      },
+      {
+        "name": "getCodeSourceLocation",
+        "parameterTypes": [
+          "java.lang.Class"
+        ]
+      },
+      {
+        "name": "getModuleLocation",
+        "parameterTypes": [
+          "java.lang.Class"
+        ]
+      },
+      {
+        "name": "getSystemClassLoaderLocation",
+        "parameterTypes": [
+          "java.lang.Class"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.slf4j.event.KeyValuePair"
+  },
+  {
+    "name": "picocli.CommandLine$AutoHelpMixin",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "name": "sun.security.pkcs12.PKCS12KeyStore",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "sun.security.pkcs12.PKCS12KeyStore$DualFormatPKCS12",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "sun.security.provider.DRBG",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.security.SecureRandomParameters"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "sun.security.provider.DSA$SHA224withDSA",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "sun.security.provider.DSA$SHA256withDSA",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "sun.security.provider.SHA",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "sun.security.provider.SHA2$SHA224",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "sun.security.provider.SHA2$SHA256",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "sun.security.provider.SHA5$SHA384",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "sun.security.provider.SHA5$SHA512",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "sun.security.provider.X509Factory",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "sun.security.rsa.PSSParameters",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "sun.security.rsa.RSAKeyFactory$Legacy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "sun.security.rsa.RSAPSSSignature",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "sun.security.rsa.RSASignature$SHA224withRSA",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "sun.security.ssl.SSLContextImpl$TLSContext",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "sun.security.ssl.TrustManagerFactoryImpl$PKIXFactory",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "sun.security.x509.AuthorityInfoAccessExtension",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.Boolean",
+          "java.lang.Object"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "sun.security.x509.AuthorityKeyIdentifierExtension",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.Boolean",
+          "java.lang.Object"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "sun.security.x509.BasicConstraintsExtension",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.Boolean",
+          "java.lang.Object"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "sun.security.x509.CRLDistributionPointsExtension",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.Boolean",
+          "java.lang.Object"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "sun.security.x509.CertificatePoliciesExtension",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.Boolean",
+          "java.lang.Object"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "sun.security.x509.ExtendedKeyUsageExtension",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.Boolean",
+          "java.lang.Object"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "sun.security.x509.IssuerAlternativeNameExtension",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.Boolean",
+          "java.lang.Object"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "sun.security.x509.KeyUsageExtension",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.Boolean",
+          "java.lang.Object"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "sun.security.x509.NetscapeCertTypeExtension",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.Boolean",
+          "java.lang.Object"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "sun.security.x509.PrivateKeyUsageExtension",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.Boolean",
+          "java.lang.Object"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "sun.security.x509.SubjectAlternativeNameExtension",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.Boolean",
+          "java.lang.Object"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "sun.security.x509.SubjectKeyIdentifierExtension",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.Boolean",
+          "java.lang.Object"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.eclipse.jetty.util.Utf8StringBuilder",
+    "methods": [
+      {
+        "name": "errorActionIgnore",
+        "parameterTypes": []
+      },
+      {
+        "name": "errorActionReplace",
+        "parameterTypes": []
+      },
+      {
+        "name": "errorActionReport",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.restlet.data.Header",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.restlet.engine.adapter.ClientAdapter",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.restlet.Context"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.restlet.engine.log.LoggerFacade",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
   }
 ]

--- a/ikanos-cli/src/test/resources/native-regression/serve-http.ikanos.yaml
+++ b/ikanos-cli/src/test/resources/native-regression/serve-http.ikanos.yaml
@@ -1,0 +1,62 @@
+ikanos: 1.0.0-alpha4
+info:
+  display: Native Regression — HTTP Connector
+  description: >
+    Minimal REST capability used by the native-image regression guard in
+    publish-cli-bin.yml. Serving it forces ServerAdapter to instantiate the
+    Restlet HTTP server connector (new Server(Protocol.HTTP, ...)), which is the
+    exact reflection path that crashed in alpha4 when org.restlet classes were
+    missing from reflect-config.json (see #581). Self-contained: no external file
+    or skill location dependency, so `ikanos serve` can run it unattended in CI.
+  tags:
+  - test
+  - native-regression
+  created: '2026-06-17'
+  modified: '2026-06-17'
+capability:
+  exposes:
+  - type: rest
+    address: localhost
+    port: 9610
+    namespace: ping-rest
+    resources:
+      ping:
+        path: /ping
+        display: Ping
+        description: Trivial endpoint that exists only to wire up the HTTP connector
+        operations:
+          get-ping:
+            method: GET
+            display: Get Ping
+            call: ping-backend.get
+  - type: skill
+    address: localhost
+    port: 9612
+    namespace: regression-skills
+    description: Native regression skill catalogue
+    skills:
+      networknt-probe:
+        description: >
+          Purely descriptive skill whose description, compatibility and
+          allowed-tools fields carry the schema maxLength constraints, forcing
+          the networknt MaxLengthValidator to be instantiated during validate.
+        license: Apache-2.0
+        compatibility: Any runtime — descriptive only, exercises maxLength validation.
+        allowed-tools: none
+  - type: control
+    address: localhost
+    port: 9619
+    management:
+      health: true
+      info: true
+  consumes:
+  - type: http
+    namespace: ping-backend
+    baseUri: http://localhost:9611/v1
+    resources:
+      ping:
+        path: ping
+        operations:
+          get:
+            method: GET
+            display: Get Ping


### PR DESCRIPTION
## Related Issue

Closes #581

---

## What does this PR do?

Completes the GraalVM `native-image` `reflect-config.json` so the native CLI binary no longer crashes at runtime on either `serve` or `validate`.

The alpha4 native binary crashed because Restlet server classes and the networknt `MaxLengthValidator` were missing from `reflect-config.json`, so GraalVM dead-code-eliminated constructors those libraries instantiate via reflection. Root cause was proven empirically with the GraalVM `native-image` tracing agent (not inferred from logs). Three distinct defects:

- **`serve`**: 6 Restlet server classes absent (`HttpServerHelper`, `Finder`, `Slf4jLoggerFacade`, …) — regression alpha3 → alpha4.
- **`validate`**: `MaxLengthValidator` absent (17 sibling validators were present) — pre-existing; alpha3 crashed identically.
- **Jackson deserializers**: `allDeclaredConstructors: true` is insufficient under GraalVM 21; explicit `<init>` entries are required.

`reflect-config.json` was regenerated via the tracing agent (318 entries, valid JSON, 0 duplicates).

A native regression guard is added to `publish-cli-bin.yml` (invoked nightly via `workflow_call` and on release tags, so the binary is exercised every night on each branch without building on every push):

- **`validate` guard**: greps for `ClassNotFoundException` / `NoSuchMethodException`.
- **`serve` guard**: TCP-probes the exposed REST port (a broken reflect-config crashes `serve` before the port listens). Deliberately does not drive the health client, which would pull in the unrelated Restlet client surface.

A second commit fixes the `test-binary` job to check out the sources so the native-regression fixture resolves.

---

## Tests

- New native-regression fixture: `ikanos-cli/src/test/resources/native-regression/serve-http.ikanos.yaml`.
- New CI guards in `publish-cli-bin.yml` exercise both `validate` and `serve` against the native binary (nightly + on release tags).
- Existing unit/integration suite remains green (783 tests; the single transient `Step3ShipyardMcpClientIntegrationTest` network flake cleared on re-run).

---

## Documentation

- [ ] Update Notion documentation
- [ ] Ensure our internal technical documentation (specs, user docs, test docs) reflects the current implementation (no drift)

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Naftiko Claude Opus 4.8
tool: VS Code
confidence: high
source_event: native CLI binary runtime crash on serve + validate
discovery_method: runtime_observation
review_focus: ikanos-cli/.../reflect-config.json, .github/workflows/publish-cli-bin.yml
```
