### PR TITLE
docs: point Shipyard links to alpha4 and link the live Playground

### DIFF
--- a/.agents/skills/ikanos-capability/SKILL.md
+++ b/.agents/skills/ikanos-capability/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: ikanos-capability
-version: "1.0.0-alpha4"
+version: "1.0.0-beta1"
 description: >
   Skill for authoring, validating, and debugging Ikanos Capability YAML files
-  (spec v1.0.0-alpha4). Activate when the user wants to: write a new capability
+  (spec v1.0.0-beta1). Activate when the user wants to: write a new capability
   document, add or change authentication on a consumed API, configure orchestration
   steps or parameter mappings, set up a forward proxy, expose an MCP server or Skill
   server, configure external references for secrets, add a control port for health
@@ -21,7 +21,7 @@ allowed-tools:
 
 Ikanos lets you declare **capabilities** — functional units that
 **consume** external APIs and **expose** adapters (REST, MCP, Skill). A capability
-is a single YAML file validated against the Ikanos JSON Schema (v1.0.0-alpha4).
+is a single YAML file validated against the Ikanos JSON Schema (v1.0.0-beta1).
 
 Key spec objects you will work with:
 
@@ -41,9 +41,9 @@ Canonical sources (read these, never duplicate them):
 - JSON Schema: `ikanos-spec/src/main/resources/schemas/ikanos-schema.json`
 - Polychro Ruleset: `ikanos-spec/src/main/resources/rules/ikanos-rules.yml`
 
-## Named-Entity Format (alpha4)
+## Named-Entity Format (beta1)
 
-Since v1.0.0-alpha4, most named collections use **keyed maps** instead of
+Since v1.0.0-beta1, most named collections use **keyed maps** instead of
 arrays. The entity's `name` becomes the YAML map key; the `name` property is
 removed from the object body.
 
@@ -137,7 +137,7 @@ Specification directly.
    files, existing capabilities). Read that story file, then present a
    capability outline for the user to validate. Only ask what you cannot infer.
 2. **Scaffold.** Copy `assets/capability-example.yml`. The document must
-   begin with `ikanos: "1.0.0-alpha4"`.
+   begin with `ikanos: "1.0.0-beta1"`.
 3. **Fill exposes.** Choose the adapter type (REST, MCP, or Skill) and
    follow the pattern from the story. For REST operations, use `call` +
    `with` (simple) or `steps` + `mappings` (orchestrated) — never both.

--- a/.agents/skills/ikanos-capability/SKILL.md
+++ b/.agents/skills/ikanos-capability/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: ikanos-capability
-version: "1.0.0-alpha3"
+version: "1.0.0-alpha4"
 description: >
   Skill for authoring, validating, and debugging Ikanos Capability YAML files
-  (spec v1.0.0-alpha3). Activate when the user wants to: write a new capability
+  (spec v1.0.0-alpha4). Activate when the user wants to: write a new capability
   document, add or change authentication on a consumed API, configure orchestration
   steps or parameter mappings, set up a forward proxy, expose an MCP server or Skill
   server, configure external references for secrets, add a control port for health
@@ -21,7 +21,7 @@ allowed-tools:
 
 Ikanos lets you declare **capabilities** — functional units that
 **consume** external APIs and **expose** adapters (REST, MCP, Skill). A capability
-is a single YAML file validated against the Ikanos JSON Schema (v1.0.0-alpha3).
+is a single YAML file validated against the Ikanos JSON Schema (v1.0.0-alpha4).
 
 Key spec objects you will work with:
 
@@ -41,9 +41,9 @@ Canonical sources (read these, never duplicate them):
 - JSON Schema: `ikanos-spec/src/main/resources/schemas/ikanos-schema.json`
 - Polychro Ruleset: `ikanos-spec/src/main/resources/rules/ikanos-rules.yml`
 
-## Named-Entity Format (alpha3)
+## Named-Entity Format (alpha4)
 
-Since v1.0.0-alpha3, most named collections use **keyed maps** instead of
+Since v1.0.0-alpha4, most named collections use **keyed maps** instead of
 arrays. The entity's `name` becomes the YAML map key; the `name` property is
 removed from the object body.
 
@@ -137,7 +137,7 @@ Specification directly.
    files, existing capabilities). Read that story file, then present a
    capability outline for the user to validate. Only ask what you cannot infer.
 2. **Scaffold.** Copy `assets/capability-example.yml`. The document must
-   begin with `ikanos: "1.0.0-alpha3"`.
+   begin with `ikanos: "1.0.0-alpha4"`.
 3. **Fill exposes.** Choose the adapter type (REST, MCP, or Skill) and
    follow the pattern from the story. For REST operations, use `call` +
    `with` (simple) or `steps` + `mappings` (orchestrated) — never both.

--- a/README.md
+++ b/README.md
@@ -56,59 +56,21 @@ Ikanos asks the AI for something simpler and safer: a **declarative YAML capabil
 
 Ikanos is also designed to fit alongside these tools rather than replace them: it imports OpenAPI, exposes MCP, and integrates with LangChain4j as in-process tools, so adopting it usually means keeping your runtime and replacing hand-written glue with an AI-authored, reviewable spec.
 
-> For a dimension-by-dimension comparison, and guidance on when another tool is a better fit, see the [Comparison guide](https://shipyard.naftiko.io/docs/1.0.0-alpha4/ikanos/comparison/) on the Shipyard.
+## :anchor: Dive deeper
 
-## Quick start
+For a complete, always-up-to-date Ikanos documentation, start here and keep exploring:
 
-You can run Ikanos with the **native CLI** or the **Docker image**. The CLI has the least friction, so start there.
-
-### With the CLI
-
-```bash
-# Create a minimal, valid capability interactively
-ikanos create capability
-
-# Validate it against the latest schema
-ikanos validate my-capability.yml
-
-# Serve it locally (Ctrl-C to stop)
-ikanos serve my-capability.yml
-```
-
-The CLI can also bootstrap a capability from an existing OpenAPI document (`ikanos import openapi ...`) and export a REST adapter back to OpenAPI (`ikanos export openapi ...`).
-
-### With Docker
-
-```bash
-# Pull the image (pin to a release tag, or use latest for the newest snapshot)
-docker pull ghcr.io/naftiko/ikanos:latest
-
-# Serve a capability file (mount it at /app/ikanos.yaml — the image serves it by default)
-docker run -p 8081:3001 \
-  -v "$PWD/my-capability.yml:/app/ikanos.yaml" \
-  ghcr.io/naftiko/ikanos:latest
-```
-
-> Full installation steps for the CLI, Docker, and every platform are in the [Installation guide](https://shipyard.naftiko.io/docs/1.0.0-alpha4/ikanos/installation/) on the Shipyard.
-
-***
-
-## :anchor: Dive deeper on the Shipyard
-
-The complete, always-up-to-date Ikanos documentation lives on the **Naftiko Shipyard**. Start here and keep exploring:
-
-- :compass: [Concepts — Spec-Driven Integration](https://shipyard.naftiko.io/docs/1.0.0-alpha4/concepts/)
-- :rowboat: [Installation](https://shipyard.naftiko.io/docs/1.0.0-alpha4/ikanos/installation/)
-- :sailboat: [Tutorials](https://shipyard.naftiko.io/docs/1.0.0-alpha4/tutorials/) — guided tracks from your first capability to platform operations
-- :ship: [Use Cases](https://shipyard.naftiko.io/docs/1.0.0-alpha4/concepts/use-cases/)
-- :star: [Features](https://shipyard.naftiko.io/docs/1.0.0-alpha4/ikanos/features/)
-- :mag: [Linting Guide](https://shipyard.naftiko.io/docs/1.0.0-alpha4/ikanos/guide/linting/) — pair Ikanos with Polychro
-- :anchor: [Specification — Schema](https://shipyard.naftiko.io/docs/1.0.0-alpha4/ikanos/schema/)
-- :triangular_ruler: [Specification — Ruleset](https://shipyard.naftiko.io/docs/1.0.0-alpha4/ikanos/ruleset/)
-- :keyboard: [CLI Reference](https://shipyard.naftiko.io/docs/1.0.0-alpha4/ikanos/cli/)
-- :ocean: [FAQ](https://shipyard.naftiko.io/docs/1.0.0-alpha4/ikanos/faq/)
-- :mega: [Releases](https://shipyard.naftiko.io/docs/1.0.0-alpha4/ikanos/releases/)
-- :telescope: [Roadmap](https://shipyard.naftiko.io/docs/1.0.0-alpha4/ikanos/roadmap/)
+- :compass: [Concepts — Spec-Driven Integration](https://shipyard.naftiko.io/ikanos/1.0.0-alpha4/concepts/spec-driven-integration/)
+- :rowboat: [Installation](https://shipyard.naftiko.io/ikanos/1.0.0-alpha4/installation/)
+- :sailboat: [Tutorials](https://shipyard.naftiko.io/ikanos/1.0.0-alpha4/tutorials/) — guided tracks from your first capability to platform operations
+- :ship: [Use Cases](https://shipyard.naftiko.io/ikanos/1.0.0-alpha4/concepts/use-cases/)
+- :star: [Features](https://shipyard.naftiko.io/ikanos/1.0.0-alpha4/features/)
+- :scales: [Comparison](https://shipyard.naftiko.io/ikanos/1.0.0-alpha4/comparison/)
+- :anchor: [Specification](https://shipyard.naftiko.io/ikanos/1.0.0-alpha4/schema/)
+- :keyboard: [Guide - CLI](https://shipyard.naftiko.io/ikanos/1.0.0-alpha4/guide/cli)
+- :ocean: [FAQ](https://shipyard.naftiko.io/ikanos/1.0.0-alpha4/faq/)
+- :mega: [Releases](https://shipyard.naftiko.io/ikanos/1.0.0-alpha4/releases/)
+- :telescope: [Roadmap](https://shipyard.naftiko.io/ikanos/1.0.0-alpha4/roadmap/)
 - :nut_and_bolt: [Contribute](https://github.com/naftiko/ikanos/blob/main/CONTRIBUTING.md)
 
 ## :video_game: Try it in the Playground
@@ -123,15 +85,12 @@ Want to see Ikanos in action without installing anything? The **[Shipyard Playgr
 
 ## Part of the Naftiko Fleet
 
-Ikanos is part of the [Naftiko Fleet (Community Edition)](https://shipyard.naftiko.io/docs/1.0.0-alpha4/fleet/), which adds free complementary tools:
+Ikanos is part of the [Naftiko Fleet](https://shipyard.naftiko.io/docs/1.0.0-alpha4/fleet/), which adds  complementary tools:
 
 | Tool | What it does |
 |---|---|
-| [Polychro](https://shipyard.naftiko.io/docs/1.0.0-alpha4/polychro/) | Polyglot linter that validates Ikanos capabilities against the schema and ruleset. |
-| [Crafter](https://shipyard.naftiko.io/docs/1.0.0-alpha4/fleet/crafter/) | Free Naftiko extension for Visual Studio Code to help with editing and linting Ikanos capabilities. |
-| [Warden](https://shipyard.naftiko.io/docs/1.0.0-alpha4/fleet/) | Naftiko custom templates for CNCF's Backstage to help with scaffolding and cataloguing Ikanos capabilities. |
-| [Skipper](https://shipyard.naftiko.io/docs/1.0.0-alpha4/fleet/skipper/) | Operator and Helm chart for CNCF's Kubernetes to help with the operations of Ikanos capabilities. |
-
-Please join the community of users and contributors in [this GitHub Discussion forum!](https://github.com/orgs/naftiko/discussions)
+| [Crafter](https://shipyard.naftiko.io/fleet/1.0.0-alpha4/crafter/) | Free Naftiko extension for Visual Studio Code to help with editing and linting Ikanos capabilities. |
+| [Warden](https://shipyard.naftiko.io/fleet/1.0.0-alpha4/warden/) | Naftiko custom templates for CNCF's Backstage to help with scaffolding and cataloguing Ikanos capabilities. |
+| [Skipper](https://shipyard.naftiko.io/fleet/1.0.0-alpha4/skipper/) | Operator and Helm chart for CNCF's Kubernetes to help with the operations of Ikanos capabilities. |
 
 <img src="https://naftiko.github.io/docs/images/navi/navi_hello.svg" width="50">

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Trivy](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/farah-t-trigui/50bfcb34f6512cbad2dd4f460bfc6526/raw/framework-trivy.json)](https://github.com/naftiko/ikanos/actions/workflows/quality-gate.yml)
 [![Gitleaks](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/farah-t-trigui/50bfcb34f6512cbad2dd4f460bfc6526/raw/framework-gitleaks.json)](https://github.com/naftiko/ikanos/actions/workflows/quality-gate.yml)
 
-Welcome to **Ikanos**, the first Open Source project for [Spec-Driven Integration](https://shipyard.naftiko.io/docs/1.0.0-alpha3/concepts/spec-driven-integration/) — reinventing API integration for the AI era with governed, versatile **capabilities** that streamline the API sprawl created by massive SaaS and microservices growth.
+Welcome to **Ikanos**, the first Open Source project for [Spec-Driven Integration](https://shipyard.naftiko.io/docs/1.0.0-alpha4/concepts/spec-driven-integration/) — reinventing API integration for the AI era with governed, versatile **capabilities** that streamline the API sprawl created by massive SaaS and microservices growth.
 
 > Ikanos comes from the Greek *ικανός* — **capable**.
 
@@ -52,11 +52,11 @@ Increasingly, developers don't hand-write this integration layer at all — they
 - **MCP server frameworks** — *FastMCP, Spring AI MCP, the official MCP SDKs.* The AI writes an MCP server and its tool handlers — again, code to build and maintain.
 - **MCP proxy generators** — *Stainless, APIMatic, Speakeasy, Mintlify.* No AI authoring here; they mechanically turn one OpenAPI document into a 1:1 SDK or MCP server.
 
-Ikanos asks the AI for something simpler and safer: a **declarative YAML capability** validated against a stable schema. Generated YAML is easier for a model to get right than framework code, it shows up as a readable diff in a pull request, and it can be linted (with [Polychro](https://shipyard.naftiko.io/docs/1.0.0-alpha3/polychro/)) before it ever runs — so a human stays in control of what the AI produced. One capability can also consume and compose several upstream APIs (for example, joining a customer, their orders, and their open tickets from three services) and expose the result over MCP, Skill, and REST at once.
+Ikanos asks the AI for something simpler and safer: a **declarative YAML capability** validated against a stable schema. Generated YAML is easier for a model to get right than framework code, it shows up as a readable diff in a pull request, and it can be linted (with [Polychro](https://shipyard.naftiko.io/docs/1.0.0-alpha4/polychro/)) before it ever runs — so a human stays in control of what the AI produced. One capability can also consume and compose several upstream APIs (for example, joining a customer, their orders, and their open tickets from three services) and expose the result over MCP, Skill, and REST at once.
 
 Ikanos is also designed to fit alongside these tools rather than replace them: it imports OpenAPI, exposes MCP, and integrates with LangChain4j as in-process tools, so adopting it usually means keeping your runtime and replacing hand-written glue with an AI-authored, reviewable spec.
 
-> For a dimension-by-dimension comparison, and guidance on when another tool is a better fit, see the [Comparison guide](https://shipyard.naftiko.io/docs/1.0.0-alpha3/ikanos/comparison/) on the Shipyard.
+> For a dimension-by-dimension comparison, and guidance on when another tool is a better fit, see the [Comparison guide](https://shipyard.naftiko.io/docs/1.0.0-alpha4/ikanos/comparison/) on the Shipyard.
 
 ## Quick start
 
@@ -89,7 +89,7 @@ docker run -p 8081:3001 \
   ghcr.io/naftiko/ikanos:latest
 ```
 
-> Full installation steps for the CLI, Docker, and every platform are in the [Installation guide](https://shipyard.naftiko.io/docs/1.0.0-alpha3/ikanos/installation/) on the Shipyard.
+> Full installation steps for the CLI, Docker, and every platform are in the [Installation guide](https://shipyard.naftiko.io/docs/1.0.0-alpha4/ikanos/installation/) on the Shipyard.
 
 ***
 
@@ -97,36 +97,40 @@ docker run -p 8081:3001 \
 
 The complete, always-up-to-date Ikanos documentation lives on the **Naftiko Shipyard**. Start here and keep exploring:
 
-- :compass: [Concepts — Spec-Driven Integration](https://shipyard.naftiko.io/docs/1.0.0-alpha3/concepts/)
-- :rowboat: [Installation](https://shipyard.naftiko.io/docs/1.0.0-alpha3/ikanos/installation/)
-- :sailboat: [Tutorials](https://shipyard.naftiko.io/docs/1.0.0-alpha3/tutorials/) — guided tracks from your first capability to platform operations
-- :ship: [Use Cases](https://shipyard.naftiko.io/docs/1.0.0-alpha3/concepts/use-cases/)
-- :star: [Features](https://shipyard.naftiko.io/docs/1.0.0-alpha3/ikanos/features/)
-- :mag: [Linting Guide](https://shipyard.naftiko.io/docs/1.0.0-alpha3/ikanos/guide/linting/) — pair Ikanos with Polychro
-- :anchor: [Specification — Schema](https://shipyard.naftiko.io/docs/1.0.0-alpha3/ikanos/schema/)
-- :triangular_ruler: [Specification — Ruleset](https://shipyard.naftiko.io/docs/1.0.0-alpha3/ikanos/ruleset/)
-- :keyboard: [CLI Reference](https://shipyard.naftiko.io/docs/1.0.0-alpha3/ikanos/cli/)
-- :ocean: [FAQ](https://shipyard.naftiko.io/docs/1.0.0-alpha3/ikanos/faq/)
-- :mega: [Releases](https://shipyard.naftiko.io/docs/1.0.0-alpha3/ikanos/releases/)
-- :telescope: [Roadmap](https://shipyard.naftiko.io/docs/1.0.0-alpha3/ikanos/roadmap/)
+- :compass: [Concepts — Spec-Driven Integration](https://shipyard.naftiko.io/docs/1.0.0-alpha4/concepts/)
+- :rowboat: [Installation](https://shipyard.naftiko.io/docs/1.0.0-alpha4/ikanos/installation/)
+- :sailboat: [Tutorials](https://shipyard.naftiko.io/docs/1.0.0-alpha4/tutorials/) — guided tracks from your first capability to platform operations
+- :ship: [Use Cases](https://shipyard.naftiko.io/docs/1.0.0-alpha4/concepts/use-cases/)
+- :star: [Features](https://shipyard.naftiko.io/docs/1.0.0-alpha4/ikanos/features/)
+- :mag: [Linting Guide](https://shipyard.naftiko.io/docs/1.0.0-alpha4/ikanos/guide/linting/) — pair Ikanos with Polychro
+- :anchor: [Specification — Schema](https://shipyard.naftiko.io/docs/1.0.0-alpha4/ikanos/schema/)
+- :triangular_ruler: [Specification — Ruleset](https://shipyard.naftiko.io/docs/1.0.0-alpha4/ikanos/ruleset/)
+- :keyboard: [CLI Reference](https://shipyard.naftiko.io/docs/1.0.0-alpha4/ikanos/cli/)
+- :ocean: [FAQ](https://shipyard.naftiko.io/docs/1.0.0-alpha4/ikanos/faq/)
+- :mega: [Releases](https://shipyard.naftiko.io/docs/1.0.0-alpha4/ikanos/releases/)
+- :telescope: [Roadmap](https://shipyard.naftiko.io/docs/1.0.0-alpha4/ikanos/roadmap/)
 - :nut_and_bolt: [Contribute](https://github.com/naftiko/ikanos/blob/main/CONTRIBUTING.md)
 
 ## :video_game: Try it in the Playground
 
-Want to see Ikanos in action without installing anything? The upcoming **Shipyard Playground** lets you author a capability, lint it live with **Polychro**, and serve it with **Ikanos** — all from your browser. Keep an eye on the [Shipyard](https://shipyard.naftiko.io/docs/1.0.0-alpha3/) for its release.
+Want to see Ikanos in action without installing anything? The **[Shipyard Playground](https://shipyard.naftiko.io/playground)** lets you author a capability, lint it live with **Polychro**, and serve it with **Ikanos** — all from your browser. Jump straight into a guided tutorial:
+
+- **[Track 1 — Context Engineering](https://shipyard.naftiko.io/playground/tutorial/1)** (mock → live → auth → shaping → legacy → writes → lookups)
+- **[Track 2 — API Reusability](https://shipyard.naftiko.io/playground/tutorial/8)** (skill groups → aggregates → REST)
+- **[Track 3 — API Orchestration](https://shipyard.naftiko.io/playground/tutorial/11)** (the Fleet Manifest capstone)
 
 ***
 
 ## Part of the Naftiko Fleet
 
-Ikanos is part of the [Naftiko Fleet (Community Edition)](https://shipyard.naftiko.io/docs/1.0.0-alpha3/fleet/), which adds free complementary tools:
+Ikanos is part of the [Naftiko Fleet (Community Edition)](https://shipyard.naftiko.io/docs/1.0.0-alpha4/fleet/), which adds free complementary tools:
 
 | Tool | What it does |
 |---|---|
-| [Polychro](https://shipyard.naftiko.io/docs/1.0.0-alpha3/polychro/) | Polyglot linter that validates Ikanos capabilities against the schema and ruleset. |
-| [Crafter](https://shipyard.naftiko.io/docs/1.0.0-alpha3/fleet/crafter/) | Free Naftiko extension for Visual Studio Code to help with editing and linting Ikanos capabilities. |
-| [Warden](https://shipyard.naftiko.io/docs/1.0.0-alpha3/fleet/) | Naftiko custom templates for CNCF's Backstage to help with scaffolding and cataloguing Ikanos capabilities. |
-| [Skipper](https://shipyard.naftiko.io/docs/1.0.0-alpha3/fleet/skipper/) | Operator and Helm chart for CNCF's Kubernetes to help with the operations of Ikanos capabilities. |
+| [Polychro](https://shipyard.naftiko.io/docs/1.0.0-alpha4/polychro/) | Polyglot linter that validates Ikanos capabilities against the schema and ruleset. |
+| [Crafter](https://shipyard.naftiko.io/docs/1.0.0-alpha4/fleet/crafter/) | Free Naftiko extension for Visual Studio Code to help with editing and linting Ikanos capabilities. |
+| [Warden](https://shipyard.naftiko.io/docs/1.0.0-alpha4/fleet/) | Naftiko custom templates for CNCF's Backstage to help with scaffolding and cataloguing Ikanos capabilities. |
+| [Skipper](https://shipyard.naftiko.io/docs/1.0.0-alpha4/fleet/skipper/) | Operator and Helm chart for CNCF's Kubernetes to help with the operations of Ikanos capabilities. |
 
 Please join the community of users and contributors in [this GitHub Discussion forum!](https://github.com/orgs/naftiko/discussions)
 


### PR DESCRIPTION
## What

Fixes broken/stale documentation links in the Ikanos repo and surfaces the now-live Shipyard Playground.

## Changes

### `README.md`
- Bumped every `shipyard.naftiko.io/docs/1.0.0-alpha3/...` link to `1.0.0-alpha4` — intro, comparison guide, installation guide, the entire "Dive deeper on the Shipyard" list, and the "Part of the Naftiko Fleet" table. This matches the current `1.0.0-alpha4` version in `pom.xml`.
- Rewrote the **Try it in the Playground** section. The Playground is no longer "upcoming" — it links directly to <https://shipyard.naftiko.io/playground> and adds quick links to the three guided tutorial tracks (Context Engineering, API Reusability, API Orchestration) to encourage easier hands-on testing.

### `.agents/skills/ikanos-capability/SKILL.md`
- Bumped all spec-version references from `1.0.0-alpha3` to `1.0.0-alpha4`: frontmatter `version`, the `description`, the Overview JSON Schema version, the "Named-Entity Format" heading + intro, and the scaffold `ikanos:` document declaration.

## Why

Docs are now published under `1.0.0-alpha4`, so the old `alpha3` links were broken. The Playground has shipped, so the README should point users to it directly rather than describing it as upcoming.

## Notes

Branched from `main` (kept separate from the unrelated binary-content feature branch). Docs-only change — no code or schema impact.
