### PR TITLE
fix: register conditional Jetty reflection classes in native reflect-config (#594)

### DIFF
--- a/ikanos-cli/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/ikanos-cli/src/main/resources/META-INF/native-image/reflect-config.json
@@ -2854,5 +2854,104 @@
         "parameterTypes": []
       }
     ]
+  },
+  {
+    "name": "org.restlet.engine.adapter.ServerAdapter",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "org.eclipse.jetty.server.ForwardedRequestCustomizer$Forwarded",
+    "methods": [
+      {
+        "name": "handleCipherSuite",
+        "parameterTypes": [
+          "org.eclipse.jetty.http.HttpField"
+        ]
+      },
+      {
+        "name": "handleForwardedFor",
+        "parameterTypes": [
+          "org.eclipse.jetty.http.HttpField"
+        ]
+      },
+      {
+        "name": "handleForwardedHost",
+        "parameterTypes": [
+          "org.eclipse.jetty.http.HttpField"
+        ]
+      },
+      {
+        "name": "handleForwardedPort",
+        "parameterTypes": [
+          "org.eclipse.jetty.http.HttpField"
+        ]
+      },
+      {
+        "name": "handleForwardedServer",
+        "parameterTypes": [
+          "org.eclipse.jetty.http.HttpField"
+        ]
+      },
+      {
+        "name": "handleHttps",
+        "parameterTypes": [
+          "org.eclipse.jetty.http.HttpField"
+        ]
+      },
+      {
+        "name": "handleProto",
+        "parameterTypes": [
+          "org.eclipse.jetty.http.HttpField"
+        ]
+      },
+      {
+        "name": "handleRFC7239",
+        "parameterTypes": [
+          "org.eclipse.jetty.http.HttpField"
+        ]
+      },
+      {
+        "name": "handleSslSessionId",
+        "parameterTypes": [
+          "org.eclipse.jetty.http.HttpField"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.eclipse.jetty.util.security.SecurityUtils",
+    "methods": [
+      {
+        "name": "callableToPrivilegedAction",
+        "parameterTypes": [
+          "java.util.concurrent.Callable"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "sun.security.provider.NativePRNG",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.security.SecureRandomParameters"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
   }
 ]

--- a/ikanos-cli/src/test/resources/native-regression/REGRESSION-GUARD-594.md
+++ b/ikanos-cli/src/test/resources/native-regression/REGRESSION-GUARD-594.md
@@ -1,0 +1,99 @@
+# Native real-HTTP regression guard for #594
+
+This file is **documentation for the maintainer**, not a workflow. Per `AGENTS.md`, an agent
+must not edit `.github/workflows/`; the snippet below is authored here and integrated into the
+CI workflow by a human.
+
+## Why this guard exists
+
+[#594](https://github.com/naftiko/ikanos/issues/594): the GraalVM native binary **bound the
+TCP socket but hung on every HTTP request** — conditional Jetty/Restlet reflection classes
+(`NativePRNG`, `SecurityUtils`, `ForwardedRequestCustomizer$Forwarded`, …) were missing from
+`reflect-config.json`, so the request-handling pipeline died silently on the first request.
+
+The existing [#581](https://github.com/naftiko/ikanos/issues/581) native guard in the
+`test-binary` job of `.github/workflows/publish-cli-bin.yml` is **TCP-listen only**
+(`exec 3<>"/dev/tcp/127.0.0.1/$REST_PORT"`). It is *structurally blind* to #594: the socket
+**does** listen; only request handling dies. A guard that catches #594 must issue a **real
+HTTP GET** on the served endpoint and assert a `200` + body.
+
+## What to add
+
+Add the step below to the `test-binary` job in `.github/workflows/publish-cli-bin.yml`,
+**after** the existing `Native regression — serve (… exposed port listens)` step (it reuses
+the same `BIN` resolution pattern). It uses the dedicated, backend-free fixture
+`serve-rest-mock.ikanos.yaml` (port `9620`, `GET /greet` → `Hello from native mock!`) created
+for this issue.
+
+```yaml
+      - name: Native regression — serve REST + real HTTP GET returns 200 (#594)
+        shell: bash
+        run: |
+          BIN="./bin/${{ matrix.artifact_name }}"
+          FIXTURE="ikanos-cli/src/test/resources/native-regression/serve-rest-mock.ikanos.yaml"
+          REST_PORT=9620
+
+          "$BIN" serve "$FIXTURE" > serve-rest-mock.log 2>&1 &
+          SERVE_PID=$!
+
+          # Wait for the exposed REST port to start listening (serve may crash early
+          # on a broken reflect-config, so bail out if the process is gone).
+          LISTENING=0
+          for i in $(seq 1 20); do
+            if (exec 3<>"/dev/tcp/127.0.0.1/$REST_PORT") 2>/dev/null; then
+              exec 3>&- 3<&- 2>/dev/null || true
+              LISTENING=1
+              break
+            fi
+            kill -0 "$SERVE_PID" 2>/dev/null || break
+            sleep 1
+          done
+
+          # Issue a REAL HTTP GET — this is the part the #581 TCP probe cannot do.
+          # #594 manifested as: socket listening, but every GET hangs. Use a short
+          # --max-time so a regression fails fast instead of stalling the job.
+          BODY=""
+          STATUS=000
+          if [ "$LISTENING" -eq 1 ]; then
+            STATUS=$(curl -s -o resp-body.txt -w '%{http_code}' --max-time 15 \
+              "http://127.0.0.1:$REST_PORT/greet" || echo 000)
+            BODY="$(cat resp-body.txt 2>/dev/null || true)"
+          fi
+
+          kill "$SERVE_PID" 2>/dev/null || true
+
+          echo "----- serve-rest-mock.log -----"; cat serve-rest-mock.log
+          echo "----- HTTP status: $STATUS -----"
+          echo "----- HTTP body:   $BODY -----"
+
+          if grep -E "ClassNotFoundException|NoSuchMethodException|ExceptionInInitializerError|No available server connector" serve-rest-mock.log; then
+            echo "FAIL: native reflection regression on serve (#594)"
+            exit 1
+          fi
+          if [ "$LISTENING" -ne 1 ]; then
+            echo "FAIL: exposed REST port $REST_PORT never started listening — HTTP connector did not boot (#594)"
+            exit 1
+          fi
+          if [ "$STATUS" != "200" ]; then
+            echo "FAIL: GET /greet returned HTTP $STATUS, expected 200 — native HTTP request handling is mute (#594)"
+            exit 1
+          fi
+          if ! printf '%s' "$BODY" | grep -q "Hello from native mock!"; then
+            echo "FAIL: GET /greet body did not contain the expected greeting (#594)"
+            exit 1
+          fi
+          echo "PASS: native binary served a real HTTP GET with status 200 and the expected body (#594)"
+```
+
+## Notes
+
+- **Why a dedicated fixture and not the #581 `serve-http.ikanos.yaml`?** `serve-rest-mock`
+  is the *smallest* REST-only surface (one adapter, one static-value operation, no backend,
+  no skill/control port), so a failure points unambiguously at the native HTTP request path
+  rather than at any extra layer. It also has no upstream fan-out, so the GET is deterministic
+  in CI.
+- **`--max-time 15`**: #594's symptom was a hang (~12 s client timeout), so a bounded curl
+  makes a regression fail fast and visibly rather than stalling the runner.
+- **Cross-platform**: the `test-binary` job already runs these steps with `shell: bash` on all
+  matrix OSes; `curl` and bash `/dev/tcp` are available there, matching the existing #581 step.
+- Once integrated and green, this guard closes the last open item on #594.

--- a/ikanos-cli/src/test/resources/native-regression/serve-http.ikanos.yaml
+++ b/ikanos-cli/src/test/resources/native-regression/serve-http.ikanos.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-alpha4
+ikanos: "1.0.0-beta1"
 info:
   display: Native Regression — HTTP Connector
   description: >

--- a/ikanos-cli/src/test/resources/native-regression/serve-rest-mock.ikanos.yaml
+++ b/ikanos-cli/src/test/resources/native-regression/serve-rest-mock.ikanos.yaml
@@ -1,0 +1,38 @@
+ikanos: "1.0.0-beta1"
+info:
+  display: Native Regression — Minimal REST Mock
+  description: >
+    The smallest possible capability that exposes a single REST endpoint and
+    nothing else: one `type: rest` adapter, one mock resource returning a static
+    value, NO consumes, NO skill, NO control, NO backend. It exists to isolate
+    the native-image HTTP question (see #581 / #578): does the native binary
+    answer an HTTP GET at all, for the simplest possible REST surface, with no
+    backend fan-out and no extra adapter in the way? If this mock answers under
+    native, the HTTP-mute observed on serve-http.ikanos.yaml is caused by one of
+    the layers that fixture adds; if it also hangs, the native HTTP server itself
+    is mute. Self-contained: `ikanos serve` can run it unattended.
+  tags:
+  - test
+  - native-regression
+  created: '2026-06-24'
+  modified: '2026-06-24'
+capability:
+  exposes:
+  - type: rest
+    address: localhost
+    port: 9620
+    namespace: mock-rest
+    resources:
+      greet:
+        path: /greet
+        display: Greet
+        description: Mock endpoint returning a static greeting, no backend.
+        operations:
+          get-greeting:
+            method: GET
+            display: Get Greeting
+            description: Returns a fixed greeting without any upstream call.
+            outputParameters:
+              message:
+                type: string
+                value: "Hello from native mock!"


### PR DESCRIPTION
## Related Issue

Closes #594

---

## What does this PR do?

The GraalVM native CLI binary bound the REST/HTTP TCP socket but **hung on every HTTP request** (the JVM served fine, no error logged). Root cause, confirmed empirically with the GraalVM native-image tracing agent reconciled against Oracle's official `graalvm-reachability-metadata` for `jetty-server`: **conditional Jetty/Restlet reflection classes** were missing from `reflect-config.json`. The minimal serve+request path never exercises session-id generation, forwarded-header handling, or lazy `SecureRandom` at startup, so the tracing agent under-captured them — yet the closed-world native image needs them reachable. With them eliminated as dead code, the socket binds but the first request handling hits a missing reflective class and dies silently.

Two earlier hypotheses (missing `JettyServerHelper` / `org.eclipse.jetty.server.*`; a missing `--initialize-at-run-time`) were investigated and **refuted** before the real cause was found.

The fix registers the 5 conditional classes (converted from Oracle's `jetty-server/12.0.1` metadata) in `reflect-config.json` (318 → 323 entries, valid JSON, 0 duplicates):

- `org.eclipse.jetty.server.ForwardedRequestCustomizer$Forwarded`
- `org.eclipse.jetty.util.security.SecurityUtils`
- `sun.security.provider.NativePRNG`
- `com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl`
- `org.restlet.engine.adapter.ServerAdapter`

It also adds a minimal, backend-free fixture `serve-rest-mock.ikanos.yaml` (one `type: rest` adapter, port 9620, `GET /greet` → static `"Hello from native mock!"`) to isolate the native HTTP path, and bumps the existing `serve-http.ikanos.yaml` fixture alpha4 → beta1.

**Scope note**: the fix follows Oracle's metadata as a wide net (review-defensible). Trimming to a proven-minimal set is deliberately out of scope here and tracked in the meta-issue #77 — this PR owns correctness, #77 owns minimisation + tooling.

---

## Tests

- **Decisive manual test (RED → GREEN)**: locally rebuilt native binary (GraalVM CE 21.0.2, `-Pnative`) → `serve serve-rest-mock.ikanos.yaml` @ 9620 → `GET /greet` returns **HTTP 200**, body `{"message":"Hello from native mock!"}`. Pre-fix nightly binary: the same GET hung (~12 s timeout).
- **Regression guard (real-HTTP)**: authored as a documented step snippet in `ikanos-cli/src/test/resources/native-regression/REGRESSION-GUARD-594.md`. It serves the mock fixture and issues a **real HTTP GET** asserting 200 + body — the part the existing #581 guard (TCP-listen only) is structurally unable to catch. Per `AGENTS.md` an agent must not edit `.github/workflows/`, so the snippet is authored here for the maintainer to integrate into the `test-binary` job of `publish-cli-bin.yml`.

---

## Documentation

- [ ] Update Notion documentation
- [x] Ensure our internal technical documentation (specs, user docs, test docs) reflects the current implementation (no drift)

The e2e coverage tracker (`ikanos-docs/testing/feature-coverage-tracker.md`, #590) already records the native HTTP-serve dependency on this issue.

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

> Note: the real-HTTP regression guard lands in CI only once the maintainer integrates the documented snippet into `publish-cli-bin.yml` (agents must not edit workflows). Until then the binary correctness is proven by the decisive manual test above.

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Naftiko Claude Opus 4.8
tool: VS Code Copilot Chat
confidence: high
source_event: e2e coverage audit (#578 / #590) — native serve probe
discovery_method: runtime_observation
review_focus: ikanos-cli/src/main/resources/META-INF/native-image/reflect-config.json
```
