### PR TITLE
feat: binary content across REST and MCP exposures (blueprint phases 2-6)

### DIFF
--- a/.agents/skills/ikanos-capability/SKILL.md
+++ b/.agents/skills/ikanos-capability/SKILL.md
@@ -114,6 +114,7 @@ for *how*.
 |---|---|
 | "I want to combine several APIs into a single reusable service" | Read `references/reusable-capability.md` |
 | "I want to expose this API as an MCP server, including tools, resources, and prompts" | Read `references/wrap-api-as-mcp.md` |
+| "I want to return images, audio, PDFs, or other binary bytes from an upstream API through REST or MCP" | Read `references/return-binary-content.md` |
 | "I want to proxy an API today and encapsulate it incrementally" | Read `references/proxy-then-customize.md` |
 | "I want to chain multiple HTTP calls to consumed APIs and expose the result into a single REST operation" | Read `references/chain-api-calls.md` |
 | "I need to go from local test credentials to production secrets" | Read `references/dev-to-production.md` |

--- a/.agents/skills/ikanos-capability/references/return-binary-content.md
+++ b/.agents/skills/ikanos-capability/references/return-binary-content.md
@@ -1,0 +1,266 @@
+---
+name: binary-content-reference
+description: >
+  "Return binary content (images, audio, PDFs, arbitrary bytes)" reference: use this
+  when a consumed HTTP operation returns non-text bytes (image/*, audio/*,
+  application/pdf, application/zip, application/octet-stream, …) and the user wants
+  to expose those bytes faithfully through `exposes.type: rest` and/or
+  `exposes.type: mcp` (tools and resources) instead of having them UTF-8 decoded and
+  corrupted. Covers the `outputRawFormat: binary` opt-in, the `maxBinarySize` cap,
+  and how the engine maps bytes onto REST responses and MCP content blocks.
+
+---
+
+## When to activate this reference
+
+Use this reference when the user wants to:
+
+- expose an upstream endpoint that returns **bytes** — photos, scans, audio clips,
+  PDFs, ZIPs — through a Naftiko capability;
+- build a **photo / media library** or **document workflow** capability where agents
+  must "see", "view", or "download" a binary;
+- serve **static binary files** (a brand logo PNG, a fixture PDF) from an MCP resource;
+- cap the size of buffered binary payloads to protect the engine from OOMs.
+
+Do not use it if:
+
+- the upstream returns text/JSON/XML/YAML — the default text path already handles those;
+- the user wants to *generate* a new image with an agent (that is a generative tool, not
+  binary passthrough);
+- the user needs streaming of multi-gigabyte payloads — binaries are buffered in memory
+  (see `maxBinarySize`), streaming is out of scope.
+
+## Core concept: declare binary once on `consumes`, expose anywhere
+
+Binary handling is **declarative and opt-in**. The engine never sniffs response bodies.
+A consumed HTTP operation opts in with a single flag:
+
+```yaml
+consumes:
+  photos:
+    type: http
+    baseUri: https://api.photolibrary.example.com
+    resources:
+      photoBytes:
+        path: /api/v1/photos/{id}/binary
+        operations:
+          download:
+            method: GET
+            outputRawFormat: binary       # ← do not UTF-8 decode; buffer raw bytes
+            outputMediaType: image/jpeg   # ← optional: pin the contract media type
+            maxBinarySize: 5MiB           # ← optional per-op cap (engine default 10MiB)
+```
+
+Once an operation is flagged binary, the raw bytes flow unchanged to whatever exposes it.
+The bytes are base64-encoded only where the wire protocol requires it (MCP). Output
+mappings (`outputParameters`) are **skipped** for binary responses — they are meaningless
+for opaque bytes — and the engine emits an INFO log when they are present.
+
+### Media-type precedence
+
+The effective media type is resolved in this order:
+
+1. `outputMediaType` declared on the consumed operation (or aggregate flow);
+2. the upstream response `Content-Type`;
+3. for REST exposures, the declared `responseBinary.mediaType` / `responses.<code>` content key;
+4. `application/octet-stream` as a last resort.
+
+### `maxBinarySize`
+
+A hard cap on the buffered payload. Grammar: `^\d+(\.\d+)?(B|KiB|MiB|GiB)?$`
+(e.g. `512KiB`, `5MiB`, `1GiB`). Engine default is **10 MiB**. Above the cap the call fails
+cleanly rather than truncating or OOM-ing:
+
+- **MCP tool** → `CallToolResult` with `isError: true` and the limit in the message;
+- **REST** → `500` server error;
+- **MCP resource** → JSON-RPC error.
+
+Declare it per operation (`consumes.…operations.<op>.maxBinarySize`) or per MCP adapter
+(`exposes[].maxBinarySize`).
+
+## Recipe 1 — REST endpoint returning image bytes
+
+A REST operation backed by a binary consumed op returns the raw bytes with the resolved
+`Content-Type`, and the OpenAPI export describes it as `type: string, format: binary`.
+
+```yaml
+exposes:
+  api:
+    type: rest
+    port: 8080
+    maxBinarySize: 10MiB
+    resources:
+      photoImage:
+        path: /photos/{id}/image
+        operations:
+          get:
+            description: Return the original-resolution photo bytes.
+            call: photos.download
+            with:
+              id: "{{id}}"
+            responseBinary:               # shorthand for a single binary 200 response
+              status: 200
+              mediaType: image/jpeg
+              description: Original image bytes
+```
+
+Exported OpenAPI (truncated):
+
+```yaml
+paths:
+  /photos/{id}/image:
+    get:
+      responses:
+        '200':
+          description: Original image bytes
+          content:
+            image/jpeg:
+              schema:
+                type: string
+                format: binary
+```
+
+> For richer contracts (multiple status codes, several media types), use the full
+> `responses:` map instead of the `responseBinary` shorthand; mark the binary content
+> entry with `binary: true`.
+
+## Recipe 2 — MCP tool returning an image, audio clip, or PDF
+
+A tool whose call (or terminal step) yields binary returns the MCP content block that
+matches the MIME type. **You do not annotate the tool output shape** — you annotate that
+the *upstream* is binary, and the engine dispatches on `Content-Type`:
+
+| Upstream `Content-Type` | MCP content block |
+|-------------------------|-------------------|
+| `image/*`               | `ImageContent` (`data` = base64, `mimeType`) |
+| `audio/*`               | `AudioContent` (`data` = base64, `mimeType`) |
+| anything else           | `EmbeddedResource` → `BlobResourceContents` with a transient `ikanos://transient/…` URI |
+
+```yaml
+exposes:
+  mcp:
+    type: mcp
+    transport: http
+    port: 8765
+    namespace: photos
+    maxBinarySize: 10MiB
+    tools:
+      get-photo:
+        display: Get photo bytes
+        description: |
+          Return the original-resolution image for a photo. Use this when the
+          user asks to "see", "view", or "describe" a photo.
+        call: photos.download
+        with:
+          id: "{{id}}"
+        inputParameters:
+          id: { type: string, required: true }
+        hints:
+          readOnly: true
+          openWorld: false
+```
+
+Tool-call wire output (truncated):
+
+```json
+{
+  "result": {
+    "content": [
+      { "type": "image", "mimeType": "image/jpeg", "data": "/9j/4AAQSkZJRgABAQ..." }
+    ],
+    "isError": false
+  }
+}
+```
+
+A PDF tool is identical except the upstream returns `application/pdf`; the result is an
+`EmbeddedResource` whose `resource.uri` is a synthetic `ikanos://transient/<namespace>/<tool>/<uuid>`.
+
+## Recipe 3 — MCP dynamic resource returning a blob
+
+A dynamic resource backed by a binary consumed op returns `BlobResourceContents`
+(`blob` = base64 + `mimeType`) instead of text:
+
+```yaml
+exposes:
+  mcp:
+    type: mcp
+    transport: http
+    port: 8765
+    namespace: photos
+    resources:
+      photoBytes:
+        name: photo
+        display: Photo bytes
+        uri: "photos://library/{id}/bytes"
+        description: Original-resolution image bytes for a single photo.
+        mimeType: image/jpeg
+        binary: true                      # opt-in; must point at a binary consumed op
+        call: photos.download
+        with:
+          id: "{id}"
+```
+
+Resource-read wire output (truncated):
+
+```json
+{
+  "result": {
+    "contents": [
+      {
+        "uri": "photos://library/img-2026-05-21-001/bytes",
+        "mimeType": "image/jpeg",
+        "blob": "/9j/4AAQSkZJRgABAQ..."
+      }
+    ]
+  }
+}
+```
+
+> If `binary: true` is declared but the target operation does **not** declare
+> `outputRawFormat: binary`, spec load fails fast — this catches the common mistake of
+> declaring binary on one side but not the other.
+
+## Recipe 4 — MCP static binary file
+
+Serve a file from disk. The variant (`text` vs `blob`) is chosen automatically from the
+file's media type; image/audio/PDF/ZIP/octet-stream files return a base64 `blob`, text
+files keep the text path:
+
+```yaml
+exposes:
+  mcp:
+    type: mcp
+    resources:
+      logo:
+        name: logo
+        uri: "files://brand/logo"
+        description: Naftiko brand logo.
+        location: file:///opt/naftiko/assets/logo.png
+        mimeType: image/png               # optional — probed from extension if absent
+```
+
+> Before this feature static binary files were read as UTF-8 and silently corrupted.
+> They now return correct bytes; existing static **text** resources are unchanged.
+
+## Design checklist
+
+- The consumed operation that produces bytes declares `outputRawFormat: binary`.
+- Pin `outputMediaType` when the upstream `Content-Type` is generic or unreliable
+  (many APIs return `application/octet-stream` for real images).
+- Set a `maxBinarySize` appropriate to the payload (per op or per MCP adapter); the
+  engine default is 10 MiB.
+- Do **not** declare `outputParameters` on a binary tool/operation — they are skipped.
+- For MCP dynamic resources, set `binary: true` **and** ensure the called op is binary.
+- For REST, use `responseBinary` (single 200) or a full `responses:` map with
+  `binary: true` on the content entry.
+- Choose the MCP surface by intent: a **tool** for an agent action that returns bytes,
+  a **resource** for addressable readable bytes, a **static** resource for files on disk.
+
+## References
+
+- Blueprint: `blueprints/capability-binary-content.md` (full design, validation rules §11,
+  worked examples §9)
+- Ikanos JSON Schema: `ikanos-spec/src/main/resources/schemas/ikanos-schema.json`
+- Related recipe: `references/wrap-api-as-mcp.md` (general MCP exposition)
+- Related recipe: `references/chain-api-calls.md` (orchestrated multi-step calls)

--- a/.agents/skills/ikanos-capability/references/return-binary-content.md
+++ b/.agents/skills/ikanos-capability/references/return-binary-content.md
@@ -75,8 +75,9 @@ cleanly rather than truncating or OOM-ing:
 - **REST** → `500` server error;
 - **MCP resource** → JSON-RPC error.
 
-Declare it per operation (`consumes.…operations.<op>.maxBinarySize`) or per MCP adapter
-(`exposes[].maxBinarySize`).
+Declare it per operation (`consumes.…operations.<op>.maxBinarySize`) or per exposing adapter
+(`exposes[].maxBinarySize`, on a `type: rest` or `type: mcp` adapter). Precedence is
+latest-wins: per-operation overrides the adapter-level cap, which overrides the engine default.
 
 ## Recipe 1 — REST endpoint returning image bytes
 
@@ -195,7 +196,7 @@ exposes:
         uri: "photos://library/{id}/bytes"
         description: Original-resolution image bytes for a single photo.
         mimeType: image/jpeg
-        binary: true                      # opt-in; must point at a binary consumed op
+        binary: true                      # advisory; the binary path is gated by the consumed op
         call: photos.download
         with:
           id: "{id}"
@@ -217,9 +218,11 @@ Resource-read wire output (truncated):
 }
 ```
 
-> If `binary: true` is declared but the target operation does **not** declare
-> `outputRawFormat: binary`, spec load fails fast — this catches the common mistake of
-> declaring binary on one side but not the other.
+> The blob-vs-text decision is driven by the **consumed** operation: the resource returns
+> `BlobResourceContents` precisely when its `call` (or terminal step) targets an operation that
+> declares `outputRawFormat: binary`. The resource-level `binary: true` is an advisory hint for
+> readers and tooling — it documents intent but is not independently validated, so always make
+> sure the called operation is itself declared binary.
 
 ## Recipe 4 — MCP static binary file
 
@@ -251,7 +254,8 @@ exposes:
 - Set a `maxBinarySize` appropriate to the payload (per op or per MCP adapter); the
   engine default is 10 MiB.
 - Do **not** declare `outputParameters` on a binary tool/operation — they are skipped.
-- For MCP dynamic resources, set `binary: true` **and** ensure the called op is binary.
+- For MCP dynamic resources, ensure the called op declares `outputRawFormat: binary` (the
+  resource `binary: true` flag is an advisory hint, not what triggers the blob path).
 - For REST, use `responseBinary` (single 200) or a full `responses:` map with
   `binary: true` on the content entry.
 - Choose the MCP surface by intent: a **tool** for an agent action that returns bytes,

--- a/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/McpServerAdapter.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/McpServerAdapter.java
@@ -86,11 +86,11 @@ public class McpServerAdapter extends ServerAdapter {
 
         // Create the tool handler (transport-agnostic)
         this.toolHandler = new ToolHandler(capability, serverSpec.getTools(),
-                serverSpec.getNamespace());
+                serverSpec.getNamespace(), serverSpec.getMaxBinarySize());
 
         // Create the resource handler (transport-agnostic)
         this.resourceHandler = new ResourceHandler(capability, serverSpec.getResources(),
-                serverSpec.getNamespace());
+                serverSpec.getNamespace(), serverSpec.getMaxBinarySize());
 
         // Create the prompt handler (transport-agnostic)
         this.promptHandler = new PromptHandler(serverSpec.getPrompts());

--- a/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/ResourceHandler.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/ResourceHandler.java
@@ -53,12 +53,27 @@ public class ResourceHandler {
     private final OperationStepExecutor stepExecutor;
     private final String namespace;
 
+    /**
+     * Adapter-level {@code maxBinarySize} sized string ({@code exposes.<name>.maxBinarySize}), or
+     * {@code null} when none is declared. Threaded into
+     * {@link OperationStepExecutor.HandlingContext#resolveMaxBinaryBytes(String)} (dynamic
+     * resources) and {@link BinarySize#parseOrDefault(String)} (static files) so the per-op value
+     * still wins but the adapter cap overrides the engine default (§4.7 / §8.1).
+     */
+    private final String maxBinarySize;
+
     public ResourceHandler(Capability capability, Map<String, McpServerResourceSpec> resources,
             String namespace) {
+        this(capability, resources, namespace, null);
+    }
+
+    public ResourceHandler(Capability capability, Map<String, McpServerResourceSpec> resources,
+            String namespace, String maxBinarySize) {
         this.capability = capability;
         this.resourceSpecs = resources != null ? new ArrayList<>(resources.values()) : new ArrayList<>();
         this.stepExecutor = new OperationStepExecutor(capability, namespace);
         this.namespace = namespace;
+        this.maxBinarySize = maxBinarySize;
     }
 
     /**
@@ -212,7 +227,7 @@ public class ResourceHandler {
         // application/zip, …) must be returned as a base64 BlobResourceContents. Reading them as
         // UTF-8 text silently corrupts the bytes. Only text-family MIME types take the text path.
         if (isBinaryMime(mimeType)) {
-            long maxBytes = BinarySize.DEFAULT_MAX_BINARY_SIZE_BYTES;
+            long maxBytes = BinarySize.parseOrDefault(maxBinarySize);
             long size = Files.size(resolvedTarget);
             if (size > maxBytes) {
                 throw new OperationStepExecutor.BinarySizeExceededException(size, maxBytes);
@@ -394,7 +409,7 @@ public class ResourceHandler {
                             + "': response is binary (" + found.clientResponseMediaType + ")");
         }
 
-        byte[] bytes = found.readBoundedBytes();
+        byte[] bytes = found.readBoundedBytes(found.resolveMaxBinaryBytes(maxBinarySize));
         if (bytes == null) {
             // No entity to return — degrade to an empty blob rather than throwing.
             bytes = new byte[0];

--- a/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/ResourceHandler.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/ResourceHandler.java
@@ -20,6 +20,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -79,6 +80,18 @@ public class ResourceHandler {
 
         public static ResourceContent text(String uri, String mimeType, String text) {
             return new ResourceContent(uri, mimeType, text, null);
+        }
+
+        /**
+         * Create a binary resource content item. The {@code base64} payload is sent to the agent
+         * as the {@code blob} field of an MCP {@code BlobResourceContents} (§4.5).
+         *
+         * @param uri      the concrete resource URI
+         * @param mimeType the resolved contract media type
+         * @param base64   the base64-encoded bytes
+         */
+        public static ResourceContent binary(String uri, String mimeType, String base64) {
+            return new ResourceContent(uri, mimeType, null, base64);
         }
     }
 
@@ -260,6 +273,14 @@ public class ResourceHandler {
                 stepExecutor.execute(spec.getCall(), spec.getSteps(), parameters,
                         "Resource '" + spec.getName() + "'");
 
+        // Binary path: the consumed operation declared `outputRawFormat: binary`. Buffer the raw
+        // bytes under the maxBinarySize cap and return a BlobResourceContents (base64) instead of
+        // text. outputParameters mappings are skipped — they are nonsensical for raw bytes.
+        // See capability-binary-content.md §4.5 / §8.3.
+        if (found != null && found.isBinary()) {
+            return readBinaryDynamic(spec, uri, found);
+        }
+
         String text = extractContent(spec, found);
         String mimeType = spec.getMimeType() != null ? spec.getMimeType() : "application/json";
         return List.of(ResourceContent.text(uri, mimeType, text));
@@ -285,6 +306,36 @@ public class ResourceHandler {
         String mapped = stepExecutor.applyOutputMappings(responseText,
                 spec.getOutputParameters(), outputRawFormat, outputSchema);
         return mapped != null ? mapped : responseText;
+    }
+
+    /**
+     * Build a binary {@link ResourceContent} for a dynamic resource whose consumed operation
+     * declares {@code outputRawFormat: binary} (§4.5).
+     *
+     * <p>The bytes are buffered under the per-operation {@code maxBinarySize} cap (engine default
+     * 10&nbsp;MiB) and base64-encoded. The media type follows the spec's declared {@code mimeType},
+     * falling back to the resolved upstream/contract type, then {@code application/octet-stream}.
+     * {@code outputParameters} mappings are skipped with an INFO log (§4.6).</p>
+     */
+    private List<ResourceContent> readBinaryDynamic(McpServerResourceSpec spec, String uri,
+            OperationStepExecutor.HandlingContext found) throws IOException {
+        if (spec.getOutputParameters() != null && !spec.getOutputParameters().isEmpty()) {
+            Context.getCurrentLogger().info(
+                    "Skipping outputParameters mappings for resource '" + spec.getName()
+                            + "': response is binary (" + found.clientResponseMediaType + ")");
+        }
+
+        byte[] bytes = found.readBoundedBytes();
+        if (bytes == null) {
+            // No entity to return — degrade to an empty blob rather than throwing.
+            bytes = new byte[0];
+        }
+
+        String mimeType = spec.getMimeType() != null ? spec.getMimeType()
+                : found.clientResponseMediaType != null ? found.clientResponseMediaType
+                        : "application/octet-stream";
+        String base64 = Base64.getEncoder().encodeToString(bytes);
+        return List.of(ResourceContent.binary(uri, mimeType, base64));
     }
 
     /**

--- a/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/ResourceHandler.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/ResourceHandler.java
@@ -29,6 +29,7 @@ import org.restlet.Context;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import io.ikanos.Capability;
+import io.ikanos.engine.util.BinarySize;
 import io.ikanos.engine.util.OperationStepExecutor;
 import io.ikanos.spec.exposes.mcp.McpServerResourceSpec;
 
@@ -206,6 +207,21 @@ public class ResourceHandler {
 
         String mimeType = spec.getMimeType() != null ? spec.getMimeType()
                 : probeMimeType(resolvedTarget);
+
+        // MIME-aware branch (§4.5 / §8.5): binary static files (image/*, audio/*, application/pdf,
+        // application/zip, …) must be returned as a base64 BlobResourceContents. Reading them as
+        // UTF-8 text silently corrupts the bytes. Only text-family MIME types take the text path.
+        if (isBinaryMime(mimeType)) {
+            long maxBytes = BinarySize.DEFAULT_MAX_BINARY_SIZE_BYTES;
+            long size = Files.size(resolvedTarget);
+            if (size > maxBytes) {
+                throw new OperationStepExecutor.BinarySizeExceededException(size, maxBytes);
+            }
+            byte[] bytes = Files.readAllBytes(resolvedTarget);
+            return List.of(ResourceContent.binary(requestedUri, mimeType,
+                    Base64.getEncoder().encodeToString(bytes)));
+        }
+
         String text = Files.readString(resolvedTarget, StandardCharsets.UTF_8);
         return List.of(ResourceContent.text(requestedUri, mimeType, text));
     }
@@ -258,7 +274,60 @@ public class ResourceHandler {
         if (name.endsWith(".yaml") || name.endsWith(".yml")) return "application/yaml";
         if (name.endsWith(".txt")) return "text/plain";
         if (name.endsWith(".xml")) return "application/xml";
+        // Common binary extensions — keeps the binary branch deterministic when the platform
+        // probeContentType returns null (notably on Windows / minimal JREs).
+        if (name.endsWith(".png")) return "image/png";
+        if (name.endsWith(".jpg") || name.endsWith(".jpeg")) return "image/jpeg";
+        if (name.endsWith(".gif")) return "image/gif";
+        if (name.endsWith(".webp")) return "image/webp";
+        if (name.endsWith(".svg")) return "image/svg+xml";
+        if (name.endsWith(".pdf")) return "application/pdf";
+        if (name.endsWith(".zip")) return "application/zip";
+        if (name.endsWith(".mp3")) return "audio/mpeg";
+        if (name.endsWith(".wav")) return "audio/wav";
         return "application/octet-stream";
+    }
+
+    /**
+     * Classifies a media type as text or binary for the purpose of choosing between
+     * {@code TextResourceContents} and {@code BlobResourceContents} (§4.5 / §14).
+     *
+     * <p>Text-family types ({@code text/*}, {@code application/json}, {@code application/yaml},
+     * {@code application/xml}, {@code application/javascript}) take the UTF-8 text path; everything
+     * else (images, audio, PDF, ZIP, {@code application/octet-stream}, …) is treated as binary and
+     * returned as a base64 blob.</p>
+     */
+    static boolean isBinaryMime(String mimeType) {
+        if (mimeType == null || mimeType.isBlank()) {
+            // Unknown type — be safe and treat as binary so bytes are never UTF-8 corrupted.
+            return true;
+        }
+        // Strip any parameters (e.g. "text/plain; charset=utf-8") and normalise.
+        String base = mimeType;
+        int semicolon = base.indexOf(';');
+        if (semicolon >= 0) {
+            base = base.substring(0, semicolon);
+        }
+        base = base.trim().toLowerCase();
+
+        if (base.startsWith("text/")) {
+            return false;
+        }
+        switch (base) {
+            case "application/json":
+            case "application/yaml":
+            case "application/x-yaml":
+            case "application/xml":
+            case "application/javascript":
+                return false;
+            default:
+                // Structured-syntax text suffixes such as application/vnd.api+json or
+                // application/problem+json are still text.
+                if (base.endsWith("+json") || base.endsWith("+xml") || base.endsWith("+yaml")) {
+                    return false;
+                }
+                return true;
+        }
     }
 
     // ── Dynamic resource helpers ─────────────────────────────────────────────────────────────────

--- a/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/ToolHandler.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/ToolHandler.java
@@ -48,16 +48,30 @@ public class ToolHandler {
     private final OperationStepExecutor stepExecutor;
     private final String exposeNamespace;
 
+    /**
+     * Adapter-level {@code maxBinarySize} sized string ({@code exposes.<name>.maxBinarySize}), or
+     * {@code null} when none is declared. Threaded into
+     * {@link OperationStepExecutor.HandlingContext#resolveMaxBinaryBytes(String)} so the per-op
+     * value still wins but the adapter cap overrides the engine default (§4.7 / §8.1).
+     */
+    private final String maxBinarySize;
+
     public ToolHandler(Capability capability, Map<String, McpServerToolSpec> tools) {
         this(capability, tools, null);
     }
 
     public ToolHandler(Capability capability, Map<String, McpServerToolSpec> tools,
             String exposeNamespace) {
+        this(capability, tools, exposeNamespace, null);
+    }
+
+    public ToolHandler(Capability capability, Map<String, McpServerToolSpec> tools,
+            String exposeNamespace, String maxBinarySize) {
         this.capability = capability;
         this.toolSpecs = new ConcurrentHashMap<>();
         this.stepExecutor = new OperationStepExecutor(capability, exposeNamespace);
         this.exposeNamespace = exposeNamespace;
+        this.maxBinarySize = maxBinarySize;
 
         if (tools != null) {
             for (McpServerToolSpec tool : tools.values()) {
@@ -301,8 +315,9 @@ public class ToolHandler {
     /**
      * Build an MCP {@code CallToolResult} for a binary upstream response.
      *
-     * <p>The raw bytes are buffered under the per-operation {@code maxBinarySize} cap (engine
-     * default 10&nbsp;MiB) and base64-encoded into the MIME-appropriate content block via
+     * <p>The raw bytes are buffered under the per-operation {@code maxBinarySize} cap (falling back
+     * to the adapter-level {@code maxBinarySize}, then the engine default 10&nbsp;MiB) and
+     * base64-encoded into the MIME-appropriate content block via
      * {@link #buildBinaryContent}. {@code outputParameters} mappings are skipped with an INFO log
      * (§4.6). When the upstream payload exceeds the cap, an error result is returned rather than an
      * exception, so the agent receives a usable diagnostic.</p>
@@ -317,7 +332,7 @@ public class ToolHandler {
 
         byte[] bytes;
         try {
-            bytes = found.readBoundedBytes();
+            bytes = found.readBoundedBytes(found.resolveMaxBinaryBytes(maxBinarySize));
         } catch (OperationStepExecutor.BinarySizeExceededException e) {
             Context.getCurrentLogger().warning(
                     "Binary tool response exceeded maxBinarySize for '" + toolSpec.getName()

--- a/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/ToolHandler.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/ToolHandler.java
@@ -14,9 +14,11 @@
 package io.ikanos.engine.exposes.mcp;
 
 import java.io.IOException;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import org.restlet.Context;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -267,6 +269,14 @@ public class ToolHandler {
                     true, null, null);
         }
 
+        // Binary path: the consumed operation declared `outputRawFormat: binary`. Buffer the raw
+        // bytes under the maxBinarySize cap and emit the MIME-appropriate MCP content block
+        // (ImageContent / AudioContent / EmbeddedResource). outputParameters mappings are skipped —
+        // they are nonsensical for raw bytes. See capability-binary-content.md §4.4 / §8.2.
+        if (found.isBinary()) {
+            return buildBinaryToolResult(toolSpec, found, isError);
+        }
+
         // Buffer entity text before any mapping to avoid double-read issues
         String responseText = found.clientResponse.getEntity().getText();
 
@@ -286,6 +296,93 @@ public class ToolHandler {
         return new McpSchema.CallToolResult(
                 List.of(new McpSchema.TextContent(responseText != null ? responseText : "")),
                 isError, null, null);
+    }
+
+    /**
+     * Build an MCP {@code CallToolResult} for a binary upstream response.
+     *
+     * <p>The raw bytes are buffered under the per-operation {@code maxBinarySize} cap (engine
+     * default 10&nbsp;MiB) and base64-encoded into the MIME-appropriate content block via
+     * {@link #buildBinaryContent}. {@code outputParameters} mappings are skipped with an INFO log
+     * (§4.6). When the upstream payload exceeds the cap, an error result is returned rather than an
+     * exception, so the agent receives a usable diagnostic.</p>
+     */
+    private McpSchema.CallToolResult buildBinaryToolResult(McpServerToolSpec toolSpec,
+            OperationStepExecutor.HandlingContext found, boolean isError) {
+        if (toolSpec.getOutputParameters() != null && !toolSpec.getOutputParameters().isEmpty()) {
+            Context.getCurrentLogger().info(
+                    "Skipping outputParameters mappings for tool '" + toolSpec.getName()
+                            + "': response is binary (" + found.clientResponseMediaType + ")");
+        }
+
+        byte[] bytes;
+        try {
+            bytes = found.readBoundedBytes();
+        } catch (OperationStepExecutor.BinarySizeExceededException e) {
+            Context.getCurrentLogger().warning(
+                    "Binary tool response exceeded maxBinarySize for '" + toolSpec.getName()
+                            + "': " + e);
+            return new McpSchema.CallToolResult(
+                    List.of(new McpSchema.TextContent(
+                            "Upstream response exceeded maxBinarySize (limit=" + e.getMaxBytes()
+                                    + " bytes)")),
+                    true, null, null);
+        } catch (IOException e) {
+            Context.getCurrentLogger().warning(
+                    "Error buffering binary tool response for '" + toolSpec.getName() + "': " + e);
+            return new McpSchema.CallToolResult(
+                    List.of(new McpSchema.TextContent("Error buffering binary response: "
+                            + e.getMessage())),
+                    true, null, null);
+        }
+
+        if (bytes == null) {
+            return new McpSchema.CallToolResult(
+                    List.of(new McpSchema.TextContent("No binary response entity received")),
+                    true, null, null);
+        }
+
+        String mediaType = found.clientResponseMediaType != null
+                ? found.clientResponseMediaType
+                : "application/octet-stream";
+        McpSchema.Content content = buildBinaryContent(toolSpec.getName(), bytes, mediaType);
+        return new McpSchema.CallToolResult(List.of(content), isError, null, null);
+    }
+
+    /**
+     * Dispatch a base64-encoded binary payload to the MCP content block that matches its MIME type
+     * (§4.4):
+     *
+     * <ul>
+     *   <li>{@code image/*} → {@link McpSchema.ImageContent}</li>
+     *   <li>{@code audio/*} → {@link McpSchema.AudioContent}</li>
+     *   <li>anything else → {@link McpSchema.EmbeddedResource} wrapping a transient
+     *       {@link McpSchema.BlobResourceContents} with a generated, non-addressable URI of the
+     *       form {@code ikanos://transient/{capability}/{toolName}/{uuid}}</li>
+     * </ul>
+     *
+     * @param toolName  the invoked tool name (used in the transient resource URI)
+     * @param bytes     the raw response bytes
+     * @param mediaType the resolved upstream/contract media type (never {@code null})
+     * @return the MIME-appropriate MCP content block
+     */
+    McpSchema.Content buildBinaryContent(String toolName, byte[] bytes, String mediaType) {
+        String data = Base64.getEncoder().encodeToString(bytes);
+        String lower = mediaType.toLowerCase();
+
+        if (lower.startsWith("image/")) {
+            return new McpSchema.ImageContent(null, data, mediaType);
+        }
+        if (lower.startsWith("audio/")) {
+            return new McpSchema.AudioContent(null, data, mediaType);
+        }
+
+        String capabilityName = exposeNamespace != null ? exposeNamespace : "ikanos";
+        String uri = "ikanos://transient/" + capabilityName + "/" + toolName + "/"
+                + UUID.randomUUID();
+        McpSchema.BlobResourceContents blob =
+                new McpSchema.BlobResourceContents(uri, mediaType, data);
+        return new McpSchema.EmbeddedResource(null, blob);
     }
 
     /**

--- a/ikanos-engine/src/main/java/io/ikanos/engine/exposes/rest/ResourceRestlet.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/exposes/rest/ResourceRestlet.java
@@ -412,8 +412,9 @@ public class ResourceRestlet extends Restlet {
      * Return a buffered binary entity for a REST operation whose consumed operation declares
      * {@code outputRawFormat: binary} (§7.5).
      *
-     * <p>The size cap is the per-operation {@code maxBinarySize} (falling back to the engine
-     * default). The {@code Content-Type} follows the precedence in §4.3.1: a declared
+     * <p>The size cap is the per-operation {@code maxBinarySize} when declared, otherwise the REST
+     * adapter-level {@code maxBinarySize} ({@code exposes.<name>.maxBinarySize}), otherwise the
+     * engine default (§4.7). The {@code Content-Type} follows the precedence in §4.3.1: a declared
      * {@code outputMediaType} on the consumed operation wins (resolved inside
      * {@link OperationStepExecutor.HandlingContext#readBoundedBytes(long)}); otherwise the REST
      * response contract's declared binary media type is used; otherwise the resolved upstream type;
@@ -426,7 +427,8 @@ public class ResourceRestlet extends Restlet {
     private boolean sendBinaryResponse(RestServerOperationSpec serverOp, Response response,
             OperationStepExecutor.HandlingContext found) {
         try {
-            byte[] bytes = found.readBoundedBytes(found.resolveMaxBinaryBytes(null));
+            byte[] bytes = found.readBoundedBytes(
+                    found.resolveMaxBinaryBytes(serverSpec.getMaxBinarySize()));
             if (bytes == null) {
                 return false;
             }

--- a/ikanos-engine/src/main/java/io/ikanos/engine/exposes/rest/ResourceRestlet.java
+++ b/ikanos-engine/src/main/java/io/ikanos/engine/exposes/rest/ResourceRestlet.java
@@ -41,7 +41,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.NullNode;
 import java.io.IOException;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import org.restlet.representation.ByteArrayRepresentation;
 
 /**
  * Restlet that handles calls to an API resource
@@ -376,6 +378,13 @@ public class ResourceRestlet extends Restlet {
 
     void sendResponse(RestServerOperationSpec serverOp, Response response,
             OperationStepExecutor.HandlingContext found) {
+        // Binary path: the consumed operation declared `outputRawFormat: binary`. Buffer the raw
+        // bytes with the size cap, return them with the resolved Content-Type, and skip output
+        // mappings (they are nonsensical for raw bytes). See capability-binary-content.md §7.5.
+        if (found.isBinary() && sendBinaryResponse(serverOp, response, found)) {
+            return;
+        }
+
         // Apply output mappings if present or forward the raw entity
         if (serverOp.getOutputParameters() != null && !serverOp.getOutputParameters().isEmpty()) {
             try {
@@ -397,6 +406,72 @@ public class ResourceRestlet extends Restlet {
         }
 
         response.commit();
+    }
+
+    /**
+     * Return a buffered binary entity for a REST operation whose consumed operation declares
+     * {@code outputRawFormat: binary} (§7.5).
+     *
+     * <p>The size cap is the per-operation {@code maxBinarySize} (falling back to the engine
+     * default). The {@code Content-Type} follows the precedence in §4.3.1: a declared
+     * {@code outputMediaType} on the consumed operation wins (resolved inside
+     * {@link OperationStepExecutor.HandlingContext#readBoundedBytes(long)}); otherwise the REST
+     * response contract's declared binary media type is used; otherwise the resolved upstream type;
+     * otherwise {@code application/octet-stream}. {@code outputParameters} mappings are skipped with
+     * an INFO log (§4.6).</p>
+     *
+     * @return {@code true} when the binary entity was written (response committed); {@code false}
+     *         when there were no bytes to return, so the caller falls back to the text path
+     */
+    private boolean sendBinaryResponse(RestServerOperationSpec serverOp, Response response,
+            OperationStepExecutor.HandlingContext found) {
+        try {
+            byte[] bytes = found.readBoundedBytes(found.resolveMaxBinaryBytes(null));
+            if (bytes == null) {
+                return false;
+            }
+
+            if (serverOp.getOutputParameters() != null
+                    && !serverOp.getOutputParameters().isEmpty()) {
+                Context.getCurrentLogger().info(
+                        "Skipping outputParameters mappings for REST operation '"
+                                + resourceSpec.getPath() + " " + serverOp.getMethod()
+                                + "': response is binary (" + found.clientResponseMediaType + ")");
+            }
+
+            // §4.3.1: declared outputMediaType (already applied in clientResponseMediaType) wins;
+            // otherwise prefer the REST response contract's declared binary media type.
+            String mediaType = found.clientResponseMediaType;
+            Optional<String> declaredRestType = serverOp.findBinaryResponseMediaType();
+            boolean hasDeclaredUpstreamType = found.clientOperation != null
+                    && found.clientOperation.getOutputMediaType() != null
+                    && !found.clientOperation.getOutputMediaType().isBlank();
+            if (!hasDeclaredUpstreamType && declaredRestType.isPresent()) {
+                mediaType = declaredRestType.get();
+            }
+            if (mediaType == null || mediaType.isBlank()) {
+                mediaType = MediaType.APPLICATION_OCTET_STREAM.getName();
+            }
+
+            response.setEntity(new ByteArrayRepresentation(bytes, MediaType.valueOf(mediaType)));
+            response.commit();
+            return true;
+        } catch (OperationStepExecutor.BinarySizeExceededException e) {
+            Context.getCurrentLogger().warning("Binary response exceeded maxBinarySize: " + e);
+            response.setStatus(Status.SERVER_ERROR_INTERNAL);
+            response.setEntity(
+                    "Upstream response exceeded maxBinarySize (limit=" + e.getMaxBytes()
+                            + " bytes)",
+                    MediaType.TEXT_PLAIN);
+            response.commit();
+            return true;
+        } catch (IOException e) {
+            Context.getCurrentLogger().warning("Error buffering binary response: " + e);
+            response.setStatus(Status.SERVER_ERROR_INTERNAL);
+            response.setEntity("Error buffering binary response\n\n" + e, MediaType.TEXT_PLAIN);
+            response.commit();
+            return true;
+        }
     }
 
     /**

--- a/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/McpBinaryStdioIntegrationTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/McpBinaryStdioIntegrationTest.java
@@ -1,0 +1,194 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Random;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.restlet.Application;
+import org.restlet.Component;
+import org.restlet.Request;
+import org.restlet.Response;
+import org.restlet.Restlet;
+import org.restlet.data.MediaType;
+import org.restlet.data.Protocol;
+import org.restlet.data.Status;
+import org.restlet.representation.ByteArrayRepresentation;
+import org.restlet.routing.Router;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import io.ikanos.Capability;
+import io.ikanos.spec.IkanosSpec;
+import io.ikanos.spec.util.VersionHelper;
+
+/**
+ * Phase 6 of the binary-content blueprint (capability-binary-content.md §11.3): proves that the
+ * stdio MCP transport round-trips a 1&nbsp;MiB JPEG without corruption.
+ *
+ * <p>The bytes flow upstream HTTP &rarr; {@code ToolHandler} (base64) &rarr; {@code CallToolResult}
+ * &rarr; JSON-RPC frame written to the stdio {@code OutputStream}. We then decode the base64 from
+ * the framed response and assert byte-for-byte equality with the original payload.</p>
+ */
+public class McpBinaryStdioIntegrationTest {
+
+    private String schemaVersion;
+
+    @BeforeEach
+    public void setUp() {
+        schemaVersion = VersionHelper.getSchemaVersion();
+    }
+
+    @Test
+    public void stdioShouldRoundTripOneMiBJpegWithoutCorruption() throws Exception {
+        // A 1 MiB payload with a JPEG SOI marker; content is opaque to the transport.
+        byte[] jpeg = new byte[1024 * 1024];
+        new Random(42).nextBytes(jpeg);
+        jpeg[0] = (byte) 0xFF;
+        jpeg[1] = (byte) 0xD8;
+        jpeg[jpeg.length - 2] = (byte) 0xFF;
+        jpeg[jpeg.length - 1] = (byte) 0xD9;
+
+        int port = findFreePort();
+        Component upstream = createBinaryServer(port, jpeg, MediaType.IMAGE_JPEG);
+        upstream.start();
+
+        try {
+            Capability capability = capabilityFromYaml(binaryStdioCapabilityYaml(port));
+            McpServerAdapter adapter =
+                    (McpServerAdapter) capability.getServerAdapters().get(0);
+            assertTrue(adapter.getMcpServerSpec().isStdio(),
+                    "capability must use the stdio transport");
+
+            ProtocolDispatcher dispatcher = new ProtocolDispatcher(adapter);
+
+            String input = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\","
+                    + "\"params\":{\"protocolVersion\":\"2025-11-25\","
+                    + "\"clientInfo\":{\"name\":\"test\",\"version\":\"1.0\"},"
+                    + "\"capabilities\":{}}}\n"
+                    + "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n"
+                    + "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\","
+                    + "\"params\":{\"name\":\"get-photo\",\"arguments\":{\"id\":\"p-1\"}}}\n";
+
+            ByteArrayInputStream in =
+                    new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8));
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+            StdioJsonRpcHandler handler = new StdioJsonRpcHandler(dispatcher, in, out);
+            handler.run();
+
+            String output = out.toString(StandardCharsets.UTF_8);
+            String[] lines = output.strip().split("\\n");
+            // initialize + tools/call (the notification produces no response line).
+            assertEquals(2, lines.length, "expected initialize + tools/call responses");
+
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode callResponse = mapper.readTree(lines[1]);
+            assertEquals(2, callResponse.path("id").asInt());
+
+            JsonNode result = callResponse.path("result");
+            assertEquals(Boolean.FALSE, result.path("isError").asBoolean(),
+                    "tool call should succeed: " + callResponse);
+            JsonNode content = result.path("content").get(0);
+            assertEquals("image", content.path("type").asText());
+            assertEquals("image/jpeg", content.path("mimeType").asText());
+
+            byte[] decoded = Base64.getDecoder().decode(content.path("data").asText());
+            assertEquals(jpeg.length, decoded.length, "round-tripped length must match");
+            assertArrayEquals(jpeg, decoded, "round-tripped bytes must match exactly");
+        } finally {
+            upstream.stop();
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────────────────────
+
+    private static Capability capabilityFromYaml(String yaml) throws Exception {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        IkanosSpec spec = mapper.readValue(yaml, IkanosSpec.class);
+        return new Capability(spec);
+    }
+
+    private String binaryStdioCapabilityYaml(int port) {
+        return """
+                ikanos: "%s"
+                capability:
+                  consumes:
+                  - namespace: photos
+                    type: http
+                    baseUri: http://localhost:%d
+                    resources:
+                      photoBytes:
+                        path: /photos/binary
+                        operations:
+                          download:
+                            method: GET
+                            outputRawFormat: binary
+                            outputMediaType: "image/jpeg"
+                  exposes:
+                  - type: mcp
+                    transport: stdio
+                    namespace: photos
+                    tools:
+                      get-photo:
+                        description: Get photo bytes
+                        call: photos.download
+                        inputParameters:
+                          id:
+                            type: string
+                            description: Photo id
+                            required: true
+                """.formatted(schemaVersion, port);
+    }
+
+    private static Component createBinaryServer(int port, byte[] bytes, MediaType mediaType) {
+        Component component = new Component();
+        component.getServers().add(Protocol.HTTP, port);
+        component.getDefaultHost().attach(new Application() {
+            @Override
+            public Restlet createInboundRoot() {
+                Router router = new Router(getContext());
+                router.attach("/photos/binary", new Restlet() {
+                    @Override
+                    public void handle(Request request, Response response) {
+                        response.setStatus(Status.SUCCESS_OK);
+                        response.setEntity(new ByteArrayRepresentation(bytes, mediaType));
+                    }
+                });
+                return router;
+            }
+        });
+        return component;
+    }
+
+    private static int findFreePort() throws Exception {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+}

--- a/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ResourceHandlerBinaryTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ResourceHandlerBinaryTest.java
@@ -1,0 +1,218 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.ServerSocket;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.restlet.Application;
+import org.restlet.Component;
+import org.restlet.Request;
+import org.restlet.Response;
+import org.restlet.Restlet;
+import org.restlet.data.MediaType;
+import org.restlet.data.Protocol;
+import org.restlet.data.Status;
+import org.restlet.representation.ByteArrayRepresentation;
+import org.restlet.routing.Router;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import io.ikanos.Capability;
+import io.ikanos.engine.util.OperationStepExecutor;
+import io.ikanos.spec.IkanosSpec;
+import io.ikanos.spec.exposes.ServerCallSpec;
+import io.ikanos.spec.exposes.mcp.McpServerResourceSpec;
+import io.ikanos.spec.util.VersionHelper;
+
+/**
+ * Tests for the dynamic MCP resource binary read path (capability-binary-content.md §4.5 / §8.3,
+ * Phase 4). A dynamic resource backed by a consumed operation with {@code outputRawFormat: binary}
+ * must return a base64 {@code blob} (BlobResourceContents) instead of UTF-8 text.
+ */
+class ResourceHandlerBinaryTest {
+
+    /** Minimal JPEG header (SOI + APP0/JFIF) followed by EOI. */
+    private static final byte[] JPEG_BYTES = new byte[] {
+            (byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0, 0x00, 0x10,
+            0x4A, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01,
+            0x00, 0x01, 0x00, 0x00, (byte) 0xFF, (byte) 0xD9
+    };
+
+    private String schemaVersion;
+
+    @BeforeEach
+    public void setUp() {
+        schemaVersion = VersionHelper.getSchemaVersion();
+    }
+
+    @Test
+    void readShouldReturnBlobForBinaryDynamicResource() throws Exception {
+        int port = findFreePort();
+        Component server = createBinaryServer(port, JPEG_BYTES, MediaType.IMAGE_JPEG, null);
+        server.start();
+
+        try {
+            Capability capability = capabilityFromYaml(binaryConsumesYaml(port, null));
+            ResourceHandler handler = handlerWith(capability, "image/jpeg", "1MiB");
+
+            List<ResourceHandler.ResourceContent> contents =
+                    handler.read("photos://library/p-1/bytes");
+
+            assertEquals(1, contents.size());
+            ResourceHandler.ResourceContent c = contents.get(0);
+            assertNull(c.text, "binary resource must not carry text");
+            assertEquals(Base64.getEncoder().encodeToString(JPEG_BYTES), c.blob);
+            assertEquals("image/jpeg", c.mimeType);
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Test
+    void readShouldFallBackToUpstreamMediaTypeWhenSpecMimeTypeMissing() throws Exception {
+        int port = findFreePort();
+        Component server = createBinaryServer(port, JPEG_BYTES, MediaType.IMAGE_PNG, null);
+        server.start();
+
+        try {
+            Capability capability = capabilityFromYaml(binaryConsumesYaml(port, null));
+            // No mimeType on the resource spec -> resolved upstream type (image/png) wins.
+            ResourceHandler handler = handlerWith(capability, null, null);
+
+            List<ResourceHandler.ResourceContent> contents =
+                    handler.read("photos://library/p-1/bytes");
+
+            assertEquals("image/png", contents.get(0).mimeType);
+            assertEquals(Base64.getEncoder().encodeToString(JPEG_BYTES), contents.get(0).blob);
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Test
+    void readShouldThrowWhenBinaryResponseExceedsMaxBinarySize() throws Exception {
+        int port = findFreePort();
+        byte[] big = new byte[4096];
+        Component server = createBinaryServer(port, big, MediaType.IMAGE_JPEG, "1KiB");
+        server.start();
+
+        try {
+            Capability capability = capabilityFromYaml(binaryConsumesYaml(port, "1KiB"));
+            ResourceHandler handler = handlerWith(capability, "image/jpeg", null);
+
+            OperationStepExecutor.BinarySizeExceededException ex = assertThrows(
+                    OperationStepExecutor.BinarySizeExceededException.class,
+                    () -> handler.read("photos://library/p-1/bytes"));
+            assertTrue(ex.getMaxBytes() > 0);
+        } finally {
+            server.stop();
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────────────────────
+
+    /** Build a handler with a single dynamic binary resource bound to {@code photos.download}. */
+    private ResourceHandler handlerWith(Capability capability, String mimeType,
+            String unusedMaxBinarySize) {
+        McpServerResourceSpec spec = new McpServerResourceSpec();
+        spec.setName("photo-bytes");
+        spec.setUri("photos://library/{id}/bytes");
+        spec.setCall(new ServerCallSpec("photos.download"));
+        if (mimeType != null) {
+            spec.setMimeType(mimeType);
+        }
+
+        LinkedHashMap<String, McpServerResourceSpec> specMap = new LinkedHashMap<>();
+        specMap.put(spec.getName(), spec);
+        return new ResourceHandler(capability, specMap, "photos");
+    }
+
+    private String binaryConsumesYaml(int port, String maxBinarySize) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("ikanos: \"").append(schemaVersion).append("\"\n");
+        sb.append("capability:\n");
+        sb.append("  exposes:\n");
+        sb.append("  - type: rest\n");
+        sb.append("    address: localhost\n");
+        sb.append("    port: 0\n");
+        sb.append("    namespace: dummy\n");
+        sb.append("    resources:\n");
+        sb.append("      dummy:\n");
+        sb.append("        path: /dummy\n");
+        sb.append("        operations:\n");
+        sb.append("          dummy:\n");
+        sb.append("            method: GET\n");
+        sb.append("  consumes:\n");
+        sb.append("  - namespace: photos\n");
+        sb.append("    type: http\n");
+        sb.append("    baseUri: \"http://localhost:").append(port).append("\"\n");
+        sb.append("    resources:\n");
+        sb.append("      photoBytes:\n");
+        sb.append("        path: /photos/binary\n");
+        sb.append("        operations:\n");
+        sb.append("          download:\n");
+        sb.append("            method: GET\n");
+        sb.append("            outputRawFormat: binary\n");
+        if (maxBinarySize != null) {
+            sb.append("            maxBinarySize: \"").append(maxBinarySize).append("\"\n");
+        }
+        return sb.toString();
+    }
+
+    private static Capability capabilityFromYaml(String yaml) throws Exception {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        IkanosSpec spec = mapper.readValue(yaml, IkanosSpec.class);
+        return new Capability(spec);
+    }
+
+    private static Component createBinaryServer(int port, byte[] bytes, MediaType mediaType,
+            String unused) {
+        Component component = new Component();
+        component.getServers().add(Protocol.HTTP, port);
+        component.getDefaultHost().attach(new Application() {
+            @Override
+            public Restlet createInboundRoot() {
+                Router router = new Router(getContext());
+                router.attach("/photos/binary", new Restlet() {
+                    @Override
+                    public void handle(Request request, Response response) {
+                        response.setStatus(Status.SUCCESS_OK);
+                        response.setEntity(new ByteArrayRepresentation(bytes, mediaType));
+                    }
+                });
+                return router;
+            }
+        });
+        return component;
+    }
+
+    private static int findFreePort() throws Exception {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+}

--- a/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ResourceHandlerStaticBinaryTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ResourceHandlerStaticBinaryTest.java
@@ -16,6 +16,7 @@ package io.ikanos.engine.exposes.mcp;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -25,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import io.ikanos.engine.util.OperationStepExecutor;
 import io.ikanos.spec.exposes.mcp.McpServerResourceSpec;
 
 /**
@@ -116,6 +118,23 @@ public class ResourceHandlerStaticBinaryTest {
 
         assertEquals("image/jpeg", content.get(0).mimeType);
         assertEquals(Base64.getEncoder().encodeToString(raw), content.get(0).blob);
+    }
+
+    @Test
+    public void readShouldEnforceAdapterMaxBinarySizeForStaticFile() throws Exception {
+        // A static binary file larger than the adapter-level cap must be rejected (§4.7). Before the
+        // adapter cap was threaded through, only the 10 MiB engine default applied here.
+        Path assets = tempDir.resolve("big");
+        Files.createDirectories(assets);
+        byte[] raw = new byte[512];
+        Files.write(assets.resolve("big.png"), raw);
+
+        // Adapter cap of 100B is well below the 512B file.
+        ResourceHandler handler = new ResourceHandler(null,
+                Map.of("big", staticResource("big", "files://big", assets)), null, "100B");
+
+        assertThrows(OperationStepExecutor.BinarySizeExceededException.class,
+                () -> handler.read("files://big/big.png"));
     }
 
     // ── isBinaryMime classifier ──────────────────────────────────────────────────────────────────

--- a/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ResourceHandlerStaticBinaryTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ResourceHandlerStaticBinaryTest.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import io.ikanos.spec.exposes.mcp.McpServerResourceSpec;
+
+/**
+ * Phase 5 of the binary-content blueprint (capability-binary-content.md §8.5 / §4.5): static file
+ * resources must return {@code BlobResourceContents} for binary file types instead of reading the
+ * bytes as UTF-8 text (which silently corrupts PNG/PDF/ZIP payloads).
+ */
+public class ResourceHandlerStaticBinaryTest {
+
+    /** Minimal valid PNG signature + IHDR-ish bytes — content is opaque to the handler. */
+    private static final byte[] PNG_BYTES = new byte[] {
+            (byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+            0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+            (byte) 0xFF, 0x00, (byte) 0xC3, 0x28, 0x01, 0x02, 0x03, 0x04
+    };
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    public void readShouldReturnBase64BlobForStaticBinaryFile() throws Exception {
+        Path assets = tempDir.resolve("assets");
+        Files.createDirectories(assets);
+        Files.write(assets.resolve("logo.png"), PNG_BYTES);
+
+        ResourceHandler handler = new ResourceHandler(null,
+                Map.of("assets", staticResource("assets", "files://brand", assets)), null);
+
+        List<ResourceHandler.ResourceContent> content = handler.read("files://brand/logo.png");
+
+        assertEquals(1, content.size());
+        ResourceHandler.ResourceContent c = content.get(0);
+        assertEquals("image/png", c.mimeType);
+        assertNull(c.text, "binary content must not populate the text field");
+        assertEquals(Base64.getEncoder().encodeToString(PNG_BYTES), c.blob);
+    }
+
+    @Test
+    public void readShouldReturnBlobForOctetStreamWhenMimeUnknown() throws Exception {
+        Path assets = tempDir.resolve("bin");
+        Files.createDirectories(assets);
+        byte[] raw = new byte[] { 0x00, 0x01, (byte) 0xFE, (byte) 0xFF, 0x10 };
+        Files.write(assets.resolve("blob.dat"), raw);
+
+        ResourceHandler handler = new ResourceHandler(null,
+                Map.of("bin", staticResource("bin", "files://bin", assets)), null);
+
+        List<ResourceHandler.ResourceContent> content = handler.read("files://bin/blob.dat");
+
+        assertEquals(1, content.size());
+        ResourceHandler.ResourceContent c = content.get(0);
+        assertNull(c.text);
+        assertEquals(Base64.getEncoder().encodeToString(raw), c.blob);
+    }
+
+    @Test
+    public void readShouldKeepTextPathForMarkdown() throws Exception {
+        Path docs = tempDir.resolve("docs");
+        Files.createDirectories(docs);
+        Files.writeString(docs.resolve("guide.md"), "# guide\n", StandardCharsets.UTF_8);
+
+        ResourceHandler handler = new ResourceHandler(null,
+                Map.of("docs", staticResource("docs", "data://docs", docs)), null);
+
+        List<ResourceHandler.ResourceContent> content = handler.read("data://docs/guide.md");
+
+        assertEquals(1, content.size());
+        ResourceHandler.ResourceContent c = content.get(0);
+        assertEquals("text/markdown", c.mimeType);
+        assertEquals("# guide\n", c.text);
+        assertNull(c.blob, "text content must not populate the blob field");
+    }
+
+    @Test
+    public void readShouldHonourExplicitBinaryMimeTypeOverride() throws Exception {
+        // The file extension is text-looking (.bin) but the spec pins image/jpeg, so the handler
+        // must take the binary path based on the declared MIME type.
+        Path assets = tempDir.resolve("img");
+        Files.createDirectories(assets);
+        byte[] raw = new byte[] { 0x01, 0x02, 0x03 };
+        Files.write(assets.resolve("photo.bin"), raw);
+
+        McpServerResourceSpec spec = staticResource("img", "files://img", assets);
+        spec.setMimeType("image/jpeg");
+
+        ResourceHandler handler = new ResourceHandler(null, Map.of("img", spec), null);
+
+        List<ResourceHandler.ResourceContent> content = handler.read("files://img/photo.bin");
+
+        assertEquals("image/jpeg", content.get(0).mimeType);
+        assertEquals(Base64.getEncoder().encodeToString(raw), content.get(0).blob);
+    }
+
+    // ── isBinaryMime classifier ──────────────────────────────────────────────────────────────────
+
+    @Test
+    public void isBinaryMimeShouldTreatTextFamilyAsText() {
+        assertFalse(ResourceHandler.isBinaryMime("text/plain"));
+        assertFalse(ResourceHandler.isBinaryMime("text/markdown"));
+        assertFalse(ResourceHandler.isBinaryMime("application/json"));
+        assertFalse(ResourceHandler.isBinaryMime("application/yaml"));
+        assertFalse(ResourceHandler.isBinaryMime("application/x-yaml"));
+        assertFalse(ResourceHandler.isBinaryMime("application/xml"));
+        assertFalse(ResourceHandler.isBinaryMime("application/javascript"));
+        assertFalse(ResourceHandler.isBinaryMime("text/plain; charset=utf-8"));
+        assertFalse(ResourceHandler.isBinaryMime("application/vnd.api+json"));
+        assertFalse(ResourceHandler.isBinaryMime("application/problem+xml"));
+    }
+
+    @Test
+    public void isBinaryMimeShouldTreatNonTextAsBinary() {
+        assertTrue(ResourceHandler.isBinaryMime("image/png"));
+        assertTrue(ResourceHandler.isBinaryMime("image/jpeg"));
+        assertTrue(ResourceHandler.isBinaryMime("audio/mpeg"));
+        assertTrue(ResourceHandler.isBinaryMime("application/pdf"));
+        assertTrue(ResourceHandler.isBinaryMime("application/zip"));
+        assertTrue(ResourceHandler.isBinaryMime("application/octet-stream"));
+        assertTrue(ResourceHandler.isBinaryMime(null));
+        assertTrue(ResourceHandler.isBinaryMime("   "));
+    }
+
+    private static McpServerResourceSpec staticResource(String name, String uri, Path dir) {
+        McpServerResourceSpec spec = new McpServerResourceSpec();
+        spec.setName(name);
+        spec.setUri(uri);
+        spec.setLocation(dir.toUri().toString());
+        return spec;
+    }
+}

--- a/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ToolHandlerBinaryTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ToolHandlerBinaryTest.java
@@ -194,6 +194,46 @@ public class ToolHandlerBinaryTest {
         }
     }
 
+    @Test
+    public void handleToolCallShouldSkipOutputParametersAndLogForBinaryUpstream() throws Exception {
+        int port = findFreePort();
+        Component upstream = createBinaryServer(port, JPEG_BYTES, MediaType.IMAGE_JPEG);
+        upstream.start();
+
+        java.util.logging.Logger logger = org.restlet.Context.getCurrentLogger();
+        java.util.List<String> messages = new java.util.ArrayList<>();
+        java.util.logging.Handler captor = new java.util.logging.Handler() {
+            @Override public void publish(java.util.logging.LogRecord record) {
+                messages.add(record.getMessage());
+            }
+            @Override public void flush() { }
+            @Override public void close() { }
+        };
+        logger.addHandler(captor);
+
+        try {
+            ToolHandler handler =
+                    handlerFromYaml(binaryToolWithOutputParametersYaml(port));
+            McpSchema.CallToolResult result =
+                    handler.handleToolCall("get-photo", Map.of("id", "p-1"));
+
+            // Mappings are bypassed: the result is the raw image, not a mapped text payload.
+            assertEquals(Boolean.FALSE, result.isError());
+            assertEquals(1, result.content().size());
+            McpSchema.ImageContent image =
+                    assertInstanceOf(McpSchema.ImageContent.class, result.content().get(0));
+            assertEquals("image/jpeg", image.mimeType());
+            assertEquals(Base64.getEncoder().encodeToString(JPEG_BYTES), image.data());
+
+            assertTrue(messages.stream().anyMatch(m ->
+                    m != null && m.contains("Skipping outputParameters mappings for tool 'get-photo'")),
+                    "expected an INFO log that outputParameters were skipped, got: " + messages);
+        } finally {
+            logger.removeHandler(captor);
+            upstream.stop();
+        }
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────────────────────
 
     private ToolHandler handlerFromYaml(String yaml) throws Exception {
@@ -248,7 +288,49 @@ public class ToolHandlerBinaryTest {
                             type: string
                             description: Photo id
                             required: true
+                        outputParameters:
+                          caption:
+                            type: string
+                            mapping: "$.caption"
                 """.formatted(schemaVersion, port, mediaLine, capLine);
+    }
+
+    /** Same as the basic binary tool capability but with outputParameters declared on the tool. */
+    private String binaryToolWithOutputParametersYaml(int port) {
+        return """
+                ikanos: "%s"
+                capability:
+                  consumes:
+                  - namespace: photos
+                    type: http
+                    baseUri: http://localhost:%d
+                    resources:
+                      photoBytes:
+                        path: /photos/binary
+                        operations:
+                          download:
+                            method: GET
+                            outputRawFormat: binary
+                            outputMediaType: "image/jpeg"
+                  exposes:
+                  - type: mcp
+                    transport: http
+                    port: 0
+                    namespace: photos
+                    tools:
+                      get-photo:
+                        description: Get photo bytes
+                        call: photos.download
+                        inputParameters:
+                          id:
+                            type: string
+                            description: Photo id
+                            required: true
+                        outputParameters:
+                          caption:
+                            type: string
+                            mapping: "$.caption"
+                """.formatted(schemaVersion, port);
     }
 
     private static Component createBinaryServer(int port, byte[] bytes, MediaType mediaType) {

--- a/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ToolHandlerBinaryTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ToolHandlerBinaryTest.java
@@ -1,0 +1,279 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.restlet.Application;
+import org.restlet.Component;
+import org.restlet.Request;
+import org.restlet.Response;
+import org.restlet.Restlet;
+import org.restlet.data.MediaType;
+import org.restlet.data.Protocol;
+import org.restlet.data.Status;
+import org.restlet.representation.ByteArrayRepresentation;
+import org.restlet.routing.Router;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import io.ikanos.Capability;
+import io.ikanos.spec.IkanosSpec;
+import io.ikanos.spec.exposes.mcp.McpServerSpec;
+import io.ikanos.spec.util.VersionHelper;
+import io.modelcontextprotocol.spec.McpSchema;
+
+/**
+ * Tests for the MCP tool binary-result branch (capability-binary-content.md §4.4 / §8.2, Phase 3).
+ *
+ * <p>Covers both the pure MIME-driven dispatch ({@link ToolHandler#buildBinaryContent}) and the
+ * end-to-end {@code tools/call} path against a live upstream that returns raw bytes.</p>
+ */
+public class ToolHandlerBinaryTest {
+
+    /** Minimal JPEG header (SOI + APP0/JFIF) followed by EOI. */
+    private static final byte[] JPEG_BYTES = new byte[] {
+            (byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0, 0x00, 0x10,
+            0x4A, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01,
+            0x00, 0x01, 0x00, 0x00, (byte) 0xFF, (byte) 0xD9
+    };
+
+    private String schemaVersion;
+
+    @BeforeEach
+    public void setUp() {
+        schemaVersion = VersionHelper.getSchemaVersion();
+    }
+
+    // ── Unit tests: MIME-driven dispatch ──────────────────────────────────────────────────────
+
+    @Test
+    public void buildBinaryContentShouldReturnImageContentForImageMime() {
+        ToolHandler handler = new ToolHandler(null, Map.of(), "photos");
+        byte[] bytes = {1, 2, 3, 4};
+
+        McpSchema.Content content = handler.buildBinaryContent("get-photo", bytes, "image/jpeg");
+
+        McpSchema.ImageContent image = assertInstanceOf(McpSchema.ImageContent.class, content);
+        assertEquals("image/jpeg", image.mimeType());
+        assertEquals(Base64.getEncoder().encodeToString(bytes), image.data());
+    }
+
+    @Test
+    public void buildBinaryContentShouldReturnAudioContentForAudioMime() {
+        ToolHandler handler = new ToolHandler(null, Map.of(), "sounds");
+        byte[] bytes = {5, 6, 7, 8};
+
+        McpSchema.Content content = handler.buildBinaryContent("get-clip", bytes, "audio/mpeg");
+
+        McpSchema.AudioContent audio = assertInstanceOf(McpSchema.AudioContent.class, content);
+        assertEquals("audio/mpeg", audio.mimeType());
+        assertEquals(Base64.getEncoder().encodeToString(bytes), audio.data());
+    }
+
+    @Test
+    public void buildBinaryContentShouldReturnEmbeddedResourceForOtherMime() {
+        ToolHandler handler = new ToolHandler(null, Map.of(), "docs");
+        byte[] bytes = "%PDF-1.7".getBytes(StandardCharsets.US_ASCII);
+
+        McpSchema.Content content = handler.buildBinaryContent("get-pdf", bytes,
+                "application/pdf");
+
+        McpSchema.EmbeddedResource embedded =
+                assertInstanceOf(McpSchema.EmbeddedResource.class, content);
+        McpSchema.BlobResourceContents blob =
+                assertInstanceOf(McpSchema.BlobResourceContents.class, embedded.resource());
+        assertEquals("application/pdf", blob.mimeType());
+        assertEquals(Base64.getEncoder().encodeToString(bytes), blob.blob());
+        assertTrue(blob.uri().startsWith("ikanos://transient/docs/get-pdf/"),
+                "transient URI should follow the ikanos://transient/{capability}/{tool}/{uuid} pattern");
+    }
+
+    @Test
+    public void buildBinaryContentShouldFallBackToEmbeddedForOctetStream() {
+        ToolHandler handler = new ToolHandler(null, Map.of(), null);
+        byte[] bytes = {0, 1, 2};
+
+        McpSchema.Content content = handler.buildBinaryContent("download", bytes,
+                "application/octet-stream");
+
+        McpSchema.EmbeddedResource embedded =
+                assertInstanceOf(McpSchema.EmbeddedResource.class, content);
+        McpSchema.BlobResourceContents blob =
+                assertInstanceOf(McpSchema.BlobResourceContents.class, embedded.resource());
+        assertTrue(blob.uri().startsWith("ikanos://transient/ikanos/download/"),
+                "missing namespace should fall back to 'ikanos' in the transient URI");
+    }
+
+    // ── End-to-end: tools/call against a live binary upstream ─────────────────────────────────
+
+    @Test
+    public void handleToolCallShouldReturnImageContentForBinaryUpstream() throws Exception {
+        int port = findFreePort();
+        Component upstream = createBinaryServer(port, JPEG_BYTES, MediaType.IMAGE_JPEG);
+        upstream.start();
+
+        try {
+            ToolHandler handler = handlerFromYaml(binaryToolCapabilityYaml(port, null));
+            McpSchema.CallToolResult result =
+                    handler.handleToolCall("get-photo", Map.of("id", "p-1"));
+
+            assertEquals(Boolean.FALSE, result.isError());
+            assertEquals(1, result.content().size());
+            McpSchema.ImageContent image =
+                    assertInstanceOf(McpSchema.ImageContent.class, result.content().get(0));
+            assertEquals("image/jpeg", image.mimeType());
+            assertEquals(Base64.getEncoder().encodeToString(JPEG_BYTES), image.data());
+        } finally {
+            upstream.stop();
+        }
+    }
+
+    @Test
+    public void handleToolCallShouldReturnEmbeddedResourceForPdfUpstream() throws Exception {
+        int port = findFreePort();
+        byte[] pdf = "%PDF-1.7 binary".getBytes(StandardCharsets.US_ASCII);
+        Component upstream =
+                createBinaryServer(port, pdf, MediaType.valueOf("application/pdf"));
+        upstream.start();
+
+        try {
+            ToolHandler handler =
+                    handlerFromYaml(binaryToolCapabilityYaml(port, "application/pdf"));
+            McpSchema.CallToolResult result =
+                    handler.handleToolCall("get-photo", Map.of("id", "p-1"));
+
+            assertEquals(Boolean.FALSE, result.isError());
+            assertInstanceOf(McpSchema.EmbeddedResource.class, result.content().get(0));
+        } finally {
+            upstream.stop();
+        }
+    }
+
+    @Test
+    public void handleToolCallShouldReturnErrorWhenResponseExceedsMaxBinarySize() throws Exception {
+        int port = findFreePort();
+        byte[] big = new byte[4096];
+        Component upstream = createBinaryServer(port, big, MediaType.IMAGE_JPEG);
+        upstream.start();
+
+        try {
+            ToolHandler handler =
+                    handlerFromYaml(binaryToolCapabilityYaml(port, null, "1KiB"));
+            McpSchema.CallToolResult result =
+                    handler.handleToolCall("get-photo", Map.of("id", "p-1"));
+
+            assertEquals(Boolean.TRUE, result.isError());
+            McpSchema.TextContent text =
+                    assertInstanceOf(McpSchema.TextContent.class, result.content().get(0));
+            assertTrue(text.text().contains("maxBinarySize"));
+        } finally {
+            upstream.stop();
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────────────────────
+
+    private ToolHandler handlerFromYaml(String yaml) throws Exception {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        IkanosSpec spec = mapper.readValue(yaml, IkanosSpec.class);
+        Capability capability = new Capability(spec);
+        McpServerSpec mcpSpec = (McpServerSpec) capability.getServerAdapters().stream()
+                .map(a -> a.getSpec())
+                .filter(McpServerSpec.class::isInstance)
+                .findFirst()
+                .orElseThrow();
+        return new ToolHandler(capability, mcpSpec.getTools(), mcpSpec.getNamespace());
+    }
+
+    private String binaryToolCapabilityYaml(int port, String outputMediaType) {
+        return binaryToolCapabilityYaml(port, outputMediaType, null);
+    }
+
+    private String binaryToolCapabilityYaml(int port, String outputMediaType, String maxBinarySize) {
+        String mediaLine = outputMediaType != null
+                ? "\n            outputMediaType: \"" + outputMediaType + "\""
+                : "";
+        String capLine = maxBinarySize != null
+                ? "\n            maxBinarySize: \"" + maxBinarySize + "\""
+                : "";
+        return """
+                ikanos: "%s"
+                capability:
+                  consumes:
+                  - namespace: photos
+                    type: http
+                    baseUri: http://localhost:%d
+                    resources:
+                      photoBytes:
+                        path: /photos/binary
+                        operations:
+                          download:
+                            method: GET
+                            outputRawFormat: binary%s%s
+                  exposes:
+                  - type: mcp
+                    transport: http
+                    port: 0
+                    namespace: photos
+                    tools:
+                      get-photo:
+                        description: Get photo bytes
+                        call: photos.download
+                        inputParameters:
+                          id:
+                            type: string
+                            description: Photo id
+                            required: true
+                """.formatted(schemaVersion, port, mediaLine, capLine);
+    }
+
+    private static Component createBinaryServer(int port, byte[] bytes, MediaType mediaType) {
+        Component component = new Component();
+        component.getServers().add(Protocol.HTTP, port);
+        component.getDefaultHost().attach(new Application() {
+            @Override
+            public Restlet createInboundRoot() {
+                Router router = new Router(getContext());
+                router.attach("/photos/binary", new Restlet() {
+                    @Override
+                    public void handle(Request request, Response response) {
+                        response.setStatus(Status.SUCCESS_OK);
+                        response.setEntity(new ByteArrayRepresentation(bytes, mediaType));
+                    }
+                });
+                return router;
+            }
+        });
+        return component;
+    }
+
+    private static int findFreePort() throws Exception {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+}

--- a/ikanos-engine/src/test/java/io/ikanos/engine/exposes/rest/RestBinaryResponseIntegrationTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/exposes/rest/RestBinaryResponseIntegrationTest.java
@@ -16,6 +16,7 @@ package io.ikanos.engine.exposes.rest;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.ServerSocket;
 
@@ -118,6 +119,42 @@ public class RestBinaryResponseIntegrationTest {
         }
     }
 
+    @Test
+    public void handleShouldSkipOutputParametersAndLogWhenResponseIsBinary() throws Exception {
+        int port = findFreePort();
+        Component upstream = createBinaryServer(port, JPEG_BYTES, MediaType.IMAGE_JPEG);
+        upstream.start();
+
+        java.util.logging.Logger logger = org.restlet.Context.getCurrentLogger();
+        java.util.List<String> messages = new java.util.ArrayList<>();
+        java.util.logging.Handler captor = new java.util.logging.Handler() {
+            @Override public void publish(java.util.logging.LogRecord record) {
+                messages.add(record.getMessage());
+            }
+            @Override public void flush() { }
+            @Override public void close() { }
+        };
+        logger.addHandler(captor);
+
+        try {
+            Capability capability =
+                    capabilityFromYaml(binaryCapabilityWithOutputParametersYaml(port));
+            Response response = invokeGetPhotoImage(capability);
+
+            // Mappings are bypassed: the response is the raw image, not a JSON projection.
+            assertEquals(Status.SUCCESS_OK, response.getStatus());
+            assertEquals("image/jpeg", response.getEntity().getMediaType().getName());
+            assertArrayEquals(JPEG_BYTES, readBytes(response));
+
+            assertTrue(messages.stream().anyMatch(m ->
+                    m != null && m.contains("Skipping outputParameters mappings for REST operation")),
+                    "expected an INFO log that outputParameters were skipped, got: " + messages);
+        } finally {
+            logger.removeHandler(captor);
+            upstream.stop();
+        }
+    }
+
     private Response invokeGetPhotoImage(Capability capability) {
         RestServerSpec serverSpec =
                 (RestServerSpec) capability.getServerAdapters().get(0).getSpec();
@@ -166,6 +203,45 @@ public class RestBinaryResponseIntegrationTest {
                               outputRawFormat: "binary"
                               outputMediaType: "image/jpeg"%s
                 """.formatted(schemaVersion, port, capLine);
+    }
+
+    /** Same as {@link #binaryCapabilityYaml} but declares outputParameters on the REST operation. */
+    private String binaryCapabilityWithOutputParametersYaml(int port) {
+        return """
+                ikanos: "%s"
+                capability:
+                  exposes:
+                    - type: "rest"
+                      address: "localhost"
+                      port: 0
+                      namespace: "photos"
+                      resources:
+                        - path: "/photos/image"
+                          name: "photo-image"
+                          operations:
+                            - method: "GET"
+                              name: "get-photo-image"
+                              call: "photos.download"
+                              responseBinary:
+                                status: 200
+                                mediaType: "image/jpeg"
+                                description: "Original image bytes"
+                              outputParameters:
+                                - caption:
+                                    mapping: "$.caption"
+                  consumes:
+                    - type: "http"
+                      namespace: "photos"
+                      baseUri: "http://localhost:%d"
+                      resources:
+                        - path: "/photos/binary"
+                          name: "photo-bytes"
+                          operations:
+                            - method: "GET"
+                              name: "download"
+                              outputRawFormat: "binary"
+                              outputMediaType: "image/jpeg"
+                """.formatted(schemaVersion, port);
     }
 
     private static byte[] readBytes(Response response) throws Exception {

--- a/ikanos-engine/src/test/java/io/ikanos/engine/exposes/rest/RestBinaryResponseIntegrationTest.java
+++ b/ikanos-engine/src/test/java/io/ikanos/engine/exposes/rest/RestBinaryResponseIntegrationTest.java
@@ -1,0 +1,208 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.rest;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.net.ServerSocket;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.restlet.Application;
+import org.restlet.Component;
+import org.restlet.Request;
+import org.restlet.Response;
+import org.restlet.Restlet;
+import org.restlet.data.MediaType;
+import org.restlet.data.Method;
+import org.restlet.data.Protocol;
+import org.restlet.data.Status;
+import org.restlet.representation.ByteArrayRepresentation;
+import org.restlet.routing.Router;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.ikanos.Capability;
+import io.ikanos.spec.IkanosSpec;
+import io.ikanos.spec.exposes.rest.RestServerSpec;
+import io.ikanos.spec.util.VersionHelper;
+
+/**
+ * Integration tests for the REST binary-response runtime branch (capability-binary-content.md
+ * §7.5, Phase 2). Proves that a REST operation backed by a consumed operation with
+ * {@code outputRawFormat: binary} returns the raw upstream bytes with the resolved
+ * {@code Content-Type}, and that the {@code maxBinarySize} cap is enforced.
+ */
+public class RestBinaryResponseIntegrationTest {
+
+    /** Minimal JPEG header (SOI + APP0/JFIF) followed by EOI — enough to assert byte fidelity. */
+    private static final byte[] JPEG_BYTES = new byte[] {
+            (byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0, 0x00, 0x10,
+            0x4A, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01,
+            0x00, 0x01, 0x00, 0x00, (byte) 0xFF, (byte) 0xD9
+    };
+
+    private String schemaVersion;
+
+    @BeforeEach
+    public void setUp() {
+        schemaVersion = VersionHelper.getSchemaVersion();
+    }
+
+    @Test
+    public void handleShouldReturnRawBytesWithDeclaredMediaTypeWhenConsumedOperationIsBinary()
+            throws Exception {
+        int port = findFreePort();
+        Component upstream = createBinaryServer(port, JPEG_BYTES, MediaType.IMAGE_JPEG);
+        upstream.start();
+
+        try {
+            Capability capability = capabilityFromYaml(binaryCapabilityYaml(port, null));
+            Response response = invokeGetPhotoImage(capability);
+
+            assertEquals(Status.SUCCESS_OK, response.getStatus());
+            assertNotNull(response.getEntity());
+            assertEquals("image/jpeg", response.getEntity().getMediaType().getName());
+            assertArrayEquals(JPEG_BYTES, readBytes(response));
+        } finally {
+            upstream.stop();
+        }
+    }
+
+    @Test
+    public void handleShouldPreferDeclaredOutputMediaTypeOverGenericUpstream() throws Exception {
+        int port = findFreePort();
+        // Upstream lies with octet-stream; the consumed op declares image/jpeg, which must win.
+        Component upstream = createBinaryServer(port, JPEG_BYTES, MediaType.APPLICATION_OCTET_STREAM);
+        upstream.start();
+
+        try {
+            Capability capability = capabilityFromYaml(binaryCapabilityYaml(port, null));
+            Response response = invokeGetPhotoImage(capability);
+
+            assertEquals(Status.SUCCESS_OK, response.getStatus());
+            assertEquals("image/jpeg", response.getEntity().getMediaType().getName());
+        } finally {
+            upstream.stop();
+        }
+    }
+
+    @Test
+    public void handleShouldReturnServerErrorWhenResponseExceedsMaxBinarySize() throws Exception {
+        int port = findFreePort();
+        byte[] big = new byte[4096];
+        Component upstream = createBinaryServer(port, big, MediaType.IMAGE_JPEG);
+        upstream.start();
+
+        try {
+            Capability capability = capabilityFromYaml(binaryCapabilityYaml(port, "1KiB"));
+            Response response = invokeGetPhotoImage(capability);
+
+            assertEquals(Status.SERVER_ERROR_INTERNAL, response.getStatus());
+            assertNotNull(response.getEntity());
+        } finally {
+            upstream.stop();
+        }
+    }
+
+    private Response invokeGetPhotoImage(Capability capability) {
+        RestServerSpec serverSpec =
+                (RestServerSpec) capability.getServerAdapters().get(0).getSpec();
+        ResourceRestlet restlet = new ResourceRestlet(capability, serverSpec,
+                serverSpec.getResources().values().iterator().next());
+
+        Request request = new Request(Method.GET, "http://localhost/photos/image");
+        Response response = new Response(request);
+        restlet.handle(request, response);
+        return response;
+    }
+
+    private String binaryCapabilityYaml(int port, String maxBinarySize) {
+        String capLine = maxBinarySize != null
+                ? "\n              maxBinarySize: \"" + maxBinarySize + "\""
+                : "";
+        return """
+                ikanos: "%s"
+                capability:
+                  exposes:
+                    - type: "rest"
+                      address: "localhost"
+                      port: 0
+                      namespace: "photos"
+                      resources:
+                        - path: "/photos/image"
+                          name: "photo-image"
+                          operations:
+                            - method: "GET"
+                              name: "get-photo-image"
+                              call: "photos.download"
+                              responseBinary:
+                                status: 200
+                                mediaType: "image/jpeg"
+                                description: "Original image bytes"
+                  consumes:
+                    - type: "http"
+                      namespace: "photos"
+                      baseUri: "http://localhost:%d"
+                      resources:
+                        - path: "/photos/binary"
+                          name: "photo-bytes"
+                          operations:
+                            - method: "GET"
+                              name: "download"
+                              outputRawFormat: "binary"
+                              outputMediaType: "image/jpeg"%s
+                """.formatted(schemaVersion, port, capLine);
+    }
+
+    private static byte[] readBytes(Response response) throws Exception {
+        return response.getEntity().getStream().readAllBytes();
+    }
+
+    private static Component createBinaryServer(int port, byte[] bytes, MediaType mediaType)
+            throws Exception {
+        Component component = new Component();
+        component.getServers().add(Protocol.HTTP, port);
+        component.getDefaultHost().attach(new Application() {
+            @Override
+            public Restlet createInboundRoot() {
+                Router router = new Router(getContext());
+                router.attach("/photos/binary", new Restlet() {
+                    @Override
+                    public void handle(Request request, Response response) {
+                        response.setStatus(Status.SUCCESS_OK);
+                        response.setEntity(new ByteArrayRepresentation(bytes, mediaType));
+                    }
+                });
+                return router;
+            }
+        });
+        return component;
+    }
+
+    private static Capability capabilityFromYaml(String yaml) throws Exception {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        IkanosSpec spec = mapper.readValue(yaml, IkanosSpec.class);
+        return new Capability(spec);
+    }
+
+    private static int findFreePort() throws Exception {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+}

--- a/ikanos-spec/src/main/java/io/ikanos/spec/exposes/mcp/McpServerSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/exposes/mcp/McpServerSpec.java
@@ -45,6 +45,9 @@ public class McpServerSpec extends ServerSpec {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private volatile String description;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private volatile String maxBinarySize;
+
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonDeserialize(using = McpServerToolMapDeserializer.class)
     private final Map<String, McpServerToolSpec> tools =
@@ -96,6 +99,19 @@ public class McpServerSpec extends ServerSpec {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    /**
+     * @return the adapter-level {@code maxBinarySize} sized string (e.g. {@code "25MiB"}), or
+     *         {@code null} when none is declared (engine default applies). See
+     *         {@code blueprints/capability-binary-content.md} §4.7 / §8.1.
+     */
+    public String getMaxBinarySize() {
+        return maxBinarySize;
+    }
+
+    public void setMaxBinarySize(String maxBinarySize) {
+        this.maxBinarySize = maxBinarySize;
     }
 
     public Map<String, McpServerToolSpec> getTools() {

--- a/ikanos-spec/src/main/java/io/ikanos/spec/exposes/rest/RestResponseBinarySpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/exposes/rest/RestResponseBinarySpec.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.spec.exposes.rest;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Shorthand for a single successful binary response on a REST operation
+ * ({@code responseBinary}). Normalized into the full {@code responses} structure at spec load.
+ * Mutually exclusive with {@code responses}.
+ *
+ * <p>See {@code blueprints/capability-binary-content.md} §7.2.</p>
+ *
+ * <h2>Thread safety</h2>
+ * Scalar fields are held in {@link AtomicReference} (SonarQube {@code java:S3077}).
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RestResponseBinarySpec {
+
+    /** Default HTTP status code for the binary response when {@code status} is omitted. */
+    public static final int DEFAULT_STATUS = 200;
+
+    private final AtomicReference<Integer> status = new AtomicReference<>();
+
+    private final AtomicReference<String> mediaType = new AtomicReference<>();
+
+    private final AtomicReference<String> description = new AtomicReference<>();
+
+    public RestResponseBinarySpec() {
+        // Jackson
+    }
+
+    /** @return the declared status code, or {@link #DEFAULT_STATUS} (200) when omitted */
+    public int getStatusOrDefault() {
+        Integer s = status.get();
+        return s != null ? s : DEFAULT_STATUS;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Integer getStatus() {
+        return status.get();
+    }
+
+    public void setStatus(Integer status) {
+        this.status.set(status);
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String getMediaType() {
+        return mediaType.get();
+    }
+
+    public void setMediaType(String mediaType) {
+        this.mediaType.set(mediaType);
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String getDescription() {
+        return description.get();
+    }
+
+    public void setDescription(String description) {
+        this.description.set(description);
+    }
+}

--- a/ikanos-spec/src/main/java/io/ikanos/spec/exposes/rest/RestResponseContentSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/exposes/rest/RestResponseContentSpec.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.spec.exposes.rest;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * The payload contract for a single media type within a REST operation's response
+ * ({@code responses.<code>.content.<mediaType>}).
+ *
+ * <p>Either {@code binary: true} (raw bytes, exported as {@code type: string, format: binary}) or
+ * an inline structured {@code schema}. See {@code blueprints/capability-binary-content.md} §7.1 /
+ * §7.4.</p>
+ *
+ * <h2>Thread safety</h2>
+ * Scalar fields are held in {@link AtomicReference} (SonarQube {@code java:S3077}).
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RestResponseContentSpec {
+
+    private final AtomicReference<Boolean> binary = new AtomicReference<>();
+
+    private final AtomicReference<Map<String, Object>> schema = new AtomicReference<>();
+
+    public RestResponseContentSpec() {
+        // Jackson
+    }
+
+    public RestResponseContentSpec(Boolean binary) {
+        this.binary.set(binary);
+    }
+
+    /**
+     * @return {@code true} when this media type returns raw bytes; {@code null}/{@code false}
+     *         otherwise
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Boolean getBinary() {
+        return binary.get();
+    }
+
+    public void setBinary(Boolean binary) {
+        this.binary.set(binary);
+    }
+
+    /** @return {@code true} iff {@link #getBinary()} is non-null and {@code true} */
+    public boolean isBinary() {
+        return Boolean.TRUE.equals(binary.get());
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Map<String, Object> getSchema() {
+        return schema.get();
+    }
+
+    public void setSchema(Map<String, Object> schema) {
+        this.schema.set(schema);
+    }
+}

--- a/ikanos-spec/src/main/java/io/ikanos/spec/exposes/rest/RestResponseSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/exposes/rest/RestResponseSpec.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.spec.exposes.rest;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * A single HTTP status-code entry in a REST operation's response contract
+ * ({@code responses.<code>}). Mirrors the OpenAPI Response Object subset Ikanos exports.
+ *
+ * <p>See {@code blueprints/capability-binary-content.md} §7.1.</p>
+ *
+ * <h2>Thread safety</h2>
+ * The {@code content} map is a synchronized {@link LinkedHashMap} (media-type order preserved)
+ * wrapped in an {@link AtomicReference}; {@code description} is an {@link AtomicReference}
+ * (SonarQube {@code java:S3077}).
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RestResponseSpec {
+
+    private final AtomicReference<String> description = new AtomicReference<>();
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private final AtomicReference<Map<String, RestResponseContentSpec>> content =
+            new AtomicReference<>(Collections.synchronizedMap(new LinkedHashMap<>()));
+
+    public RestResponseSpec() {
+        // Jackson
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String getDescription() {
+        return description.get();
+    }
+
+    public void setDescription(String description) {
+        this.description.set(description);
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, RestResponseContentSpec> getContent() {
+        return content.get();
+    }
+
+    public void setContent(Map<String, RestResponseContentSpec> content) {
+        Map<String, RestResponseContentSpec> snapshot = Collections.synchronizedMap(
+                new LinkedHashMap<>(content != null ? content : Map.of()));
+        this.content.set(snapshot);
+    }
+}

--- a/ikanos-spec/src/main/java/io/ikanos/spec/exposes/rest/RestServerOperationSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/exposes/rest/RestServerOperationSpec.java
@@ -16,6 +16,7 @@ package io.ikanos.spec.exposes.rest;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -50,6 +51,22 @@ public class RestServerOperationSpec extends OperationSpec {
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private final CopyOnWriteArrayList<StepOutputMappingSpec> mappings = new CopyOnWriteArrayList<>();
+
+    /**
+     * Explicit per-status-code response contract, keyed by HTTP status code (e.g. {@code "200"},
+     * {@code "404"}). Drives binary response handling and OpenAPI export. Mutually exclusive with
+     * {@link #responseBinary}. See {@code blueprints/capability-binary-content.md} §7.1.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private final AtomicReference<Map<String, RestResponseSpec>> responses =
+            new AtomicReference<>(Collections.synchronizedMap(new LinkedHashMap<>()));
+
+    /**
+     * Shorthand for a single successful binary response, normalized into {@link #responses} via
+     * {@link #getEffectiveResponses()}. Mutually exclusive with {@link #responses}. See
+     * {@code blueprints/capability-binary-content.md} §7.2.
+     */
+    private final AtomicReference<RestResponseBinarySpec> responseBinary = new AtomicReference<>();
 
     public RestServerOperationSpec() {
         this(null, null, null, null, null, null, null, null, null);
@@ -93,5 +110,80 @@ public class RestServerOperationSpec extends OperationSpec {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getRef() { return ref.get(); }
     public void setRef(String ref) { this.ref.set(ref); }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, RestResponseSpec> getResponses() { return responses.get(); }
+
+    public void setResponses(Map<String, RestResponseSpec> responses) {
+        Map<String, RestResponseSpec> snapshot = Collections.synchronizedMap(
+                new LinkedHashMap<>(responses != null ? responses : Map.of()));
+        this.responses.set(snapshot);
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public RestResponseBinarySpec getResponseBinary() { return responseBinary.get(); }
+
+    public void setResponseBinary(RestResponseBinarySpec responseBinary) {
+        this.responseBinary.set(responseBinary);
+    }
+
+    /**
+     * Resolve the effective response contract, normalizing the {@code responseBinary} shorthand
+     * into the full {@code responses} structure (§7.2). When {@code responses} is declared it is
+     * returned as-is; when only {@code responseBinary} is declared it is expanded into a single
+     * status entry with a {@code binary: true} content for its media type; when neither is declared
+     * an empty map is returned.
+     *
+     * @return the normalized status-code → {@link RestResponseSpec} map; never {@code null}
+     */
+    public Map<String, RestResponseSpec> getEffectiveResponses() {
+        Map<String, RestResponseSpec> declared = responses.get();
+        if (declared != null && !declared.isEmpty()) {
+            return declared;
+        }
+
+        RestResponseBinarySpec shorthand = responseBinary.get();
+        if (shorthand == null || shorthand.getMediaType() == null) {
+            return Map.of();
+        }
+
+        RestResponseSpec responseSpec = new RestResponseSpec();
+        responseSpec.setDescription(shorthand.getDescription());
+        Map<String, RestResponseContentSpec> contentMap = new LinkedHashMap<>();
+        contentMap.put(shorthand.getMediaType(), new RestResponseContentSpec(Boolean.TRUE));
+        responseSpec.setContent(contentMap);
+
+        Map<String, RestResponseSpec> normalized = new LinkedHashMap<>();
+        normalized.put(String.valueOf(shorthand.getStatusOrDefault()), responseSpec);
+        return normalized;
+    }
+
+    /**
+     * Find the first binary media type declared across all status codes in the effective response
+     * contract (§7). Returns the media type string (e.g. {@code "image/jpeg"}) of the first
+     * {@code content} entry whose {@code binary} flag is true, or empty when the operation declares
+     * no binary response.
+     *
+     * @return the declared binary media type, or {@link Optional#empty()} when none is declared
+     */
+    public Optional<String> findBinaryResponseMediaType() {
+        for (RestResponseSpec responseSpec : getEffectiveResponses().values()) {
+            Map<String, RestResponseContentSpec> content = responseSpec.getContent();
+            if (content == null) {
+                continue;
+            }
+            for (Map.Entry<String, RestResponseContentSpec> entry : content.entrySet()) {
+                if (entry.getValue() != null && entry.getValue().isBinary()) {
+                    return Optional.of(entry.getKey());
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    /** @return {@code true} iff the effective response contract declares any binary media type */
+    public boolean hasBinaryResponse() {
+        return findBinaryResponseMediaType().isPresent();
+    }
 }
 

--- a/ikanos-spec/src/main/java/io/ikanos/spec/exposes/rest/RestServerSpec.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/exposes/rest/RestServerSpec.java
@@ -28,6 +28,9 @@ public class RestServerSpec extends ServerSpec {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private volatile String namespace;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private volatile String maxBinarySize;
+
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonDeserialize(using = RestServerResourceMapDeserializer.class)
     private final Map<String, RestServerResourceSpec> resources =
@@ -44,6 +47,14 @@ public class RestServerSpec extends ServerSpec {
 
     public String getNamespace() { return namespace; }
     public void setNamespace(String namespace) { this.namespace = namespace; }
+
+    /**
+     * @return the adapter-level {@code maxBinarySize} sized string (e.g. {@code "25MiB"}), or
+     *         {@code null} when none is declared (engine default applies). See
+     *         {@code blueprints/capability-binary-content.md} §4.7.
+     */
+    public String getMaxBinarySize() { return maxBinarySize; }
+    public void setMaxBinarySize(String maxBinarySize) { this.maxBinarySize = maxBinarySize; }
 
     public Map<String, RestServerResourceSpec> getResources() { return resources; }
 

--- a/ikanos-spec/src/main/java/io/ikanos/spec/openapi/OasExportBuilder.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/openapi/OasExportBuilder.java
@@ -257,7 +257,12 @@ public class OasExportBuilder {
 
         // Responses
         ApiResponses responses = new ApiResponses();
-        if (opSpec.getOutputParameters() != null && !opSpec.getOutputParameters().isEmpty()) {
+        if (opSpec.hasBinaryResponse()) {
+            // Binary REST response contract (capability-binary-content.md §7.4): emit each declared
+            // status code with its media types, mapping `binary: true` to
+            // `schema: { type: string, format: binary }` and preserving inline structured schemas.
+            buildBinaryResponses(opSpec, responses);
+        } else if (opSpec.getOutputParameters() != null && !opSpec.getOutputParameters().isEmpty()) {
             Schema<?> responseSchema = buildOutputSchema(opSpec.getOutputParameters());
             responses.addApiResponse("200", new ApiResponse()
                     .description("Successful response")
@@ -270,6 +275,64 @@ public class OasExportBuilder {
         operation.setResponses(responses);
 
         return operation;
+    }
+
+    /**
+     * Populate {@code responses} from a REST operation's declared response contract, mapping each
+     * {@code content.<mediaType>.binary: true} to an OpenAPI {@code type: string, format: binary}
+     * schema and copying any inline structured {@code schema} verbatim. Declared media types are
+     * preserved exactly and binary responses are never collapsed to {@code application/json}
+     * (§7.4).
+     */
+    void buildBinaryResponses(RestServerOperationSpec opSpec, ApiResponses responses) {
+        for (Map.Entry<String, io.ikanos.spec.exposes.rest.RestResponseSpec> statusEntry
+                : opSpec.getEffectiveResponses().entrySet()) {
+            io.ikanos.spec.exposes.rest.RestResponseSpec responseSpec = statusEntry.getValue();
+            ApiResponse apiResponse = new ApiResponse();
+            apiResponse.setDescription(responseSpec.getDescription() != null
+                    ? responseSpec.getDescription() : "Successful response");
+
+            Map<String, io.ikanos.spec.exposes.rest.RestResponseContentSpec> contentMap =
+                    responseSpec.getContent();
+            if (contentMap != null && !contentMap.isEmpty()) {
+                Content content = new Content();
+                for (Map.Entry<String, io.ikanos.spec.exposes.rest.RestResponseContentSpec>
+                        mediaEntry : contentMap.entrySet()) {
+                    io.ikanos.spec.exposes.rest.RestResponseContentSpec contentSpec =
+                            mediaEntry.getValue();
+                    Schema<?> schema;
+                    if (contentSpec != null && contentSpec.isBinary()) {
+                        schema = new Schema<>().type("string").format("binary");
+                    } else if (contentSpec != null && contentSpec.getSchema() != null) {
+                        schema = mapInlineSchema(contentSpec.getSchema());
+                    } else {
+                        schema = new Schema<>();
+                    }
+                    content.addMediaType(mediaEntry.getKey(), new MediaType().schema(schema));
+                }
+                apiResponse.setContent(content);
+            }
+
+            responses.addApiResponse(statusEntry.getKey(), apiResponse);
+        }
+    }
+
+    /**
+     * Best-effort mapping of an inline JSON-schema map (from a non-binary {@code content.<mediaType>
+     * .schema}) into a Swagger {@link Schema}. Only the {@code type} keyword is interpreted; the map
+     * is otherwise copied as the schema's extensions are out of scope for this blueprint phase.
+     */
+    Schema<?> mapInlineSchema(Map<String, Object> inline) {
+        Schema<?> schema = new Schema<>();
+        Object type = inline.get("type");
+        if (type instanceof String typeStr) {
+            schema.setType(typeStr);
+        }
+        Object format = inline.get("format");
+        if (format instanceof String formatStr) {
+            schema.setFormat(formatStr);
+        }
+        return schema;
     }
 
     Schema<?> buildInputSchema(InputParameterSpec inputParam) {

--- a/ikanos-spec/src/main/java/io/ikanos/spec/openapi/OasExportBuilder.java
+++ b/ikanos-spec/src/main/java/io/ikanos/spec/openapi/OasExportBuilder.java
@@ -318,9 +318,10 @@ public class OasExportBuilder {
     }
 
     /**
-     * Best-effort mapping of an inline JSON-schema map (from a non-binary {@code content.<mediaType>
-     * .schema}) into a Swagger {@link Schema}. Only the {@code type} keyword is interpreted; the map
-     * is otherwise copied as the schema's extensions are out of scope for this blueprint phase.
+     * Best-effort mapping of an inline JSON-schema map (from a non-binary
+     * {@code content.<mediaType>.schema}) into a Swagger {@link Schema}. Only the {@code type} and
+     * {@code format} keywords are interpreted; all other keywords are ignored, as richer schema
+     * mapping is out of scope for this blueprint phase.
      */
     Schema<?> mapInlineSchema(Map<String, Object> inline) {
         Schema<?> schema = new Schema<>();

--- a/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
+++ b/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
@@ -1037,6 +1037,10 @@
           "$ref": "#/$defs/Authentication",
           "description": "Authentication required on incoming requests to this REST adapter. Protects all resources and operations under this adapter. Supports `basic`, `apikey`, `bearer`, `digest`, and `oauth2` (JWT/introspection)."
         },
+        "maxBinarySize": {
+          "$ref": "#/$defs/BinarySize",
+          "description": "Maximum allowed binary response size before buffering. Accepts sizes like '512KiB', '10MiB', '1GiB'. Default: 10MiB. Can be overridden per consumed operation via `maxBinarySize`."
+        },
         "resources": {
           "type": "object",
           "propertyNames": {

--- a/ikanos-spec/src/test/java/io/ikanos/spec/exposes/rest/RestServerOperationSpecBinaryTest.java
+++ b/ikanos-spec/src/test/java/io/ikanos/spec/exposes/rest/RestServerOperationSpecBinaryTest.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.spec.exposes.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+/**
+ * Unit tests for the REST binary response contract on {@link RestServerOperationSpec}
+ * ({@code responses} / {@code responseBinary}) — Phase 2 of the binary-content blueprint
+ * (capability-binary-content.md §7).
+ */
+public class RestServerOperationSpecBinaryTest {
+
+    private ObjectMapper mapper;
+
+    @BeforeEach
+    public void setUp() {
+        mapper = new ObjectMapper(new YAMLFactory());
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+    @Test
+    public void deserializeShouldBindResponsesContract() throws Exception {
+        String yaml = """
+            method: "GET"
+            name: "get-image"
+            responses:
+              '200':
+                description: "Original image bytes"
+                content:
+                  image/jpeg:
+                    binary: true
+            """;
+
+        RestServerOperationSpec op = mapper.readValue(yaml, RestServerOperationSpec.class);
+
+        RestResponseSpec resp = op.getResponses().get("200");
+        assertEquals("Original image bytes", resp.getDescription());
+        assertTrue(resp.getContent().get("image/jpeg").isBinary());
+    }
+
+    @Test
+    public void deserializeShouldBindResponseBinaryShorthand() throws Exception {
+        String yaml = """
+            method: "GET"
+            name: "get-pdf"
+            responseBinary:
+              status: 200
+              mediaType: "application/pdf"
+              description: "Signed contract PDF"
+            """;
+
+        RestServerOperationSpec op = mapper.readValue(yaml, RestServerOperationSpec.class);
+
+        assertEquals("application/pdf", op.getResponseBinary().getMediaType());
+        assertEquals(200, op.getResponseBinary().getStatusOrDefault());
+    }
+
+    @Test
+    public void responseBinaryShouldDefaultStatusTo200() {
+        RestResponseBinarySpec shorthand = new RestResponseBinarySpec();
+        shorthand.setMediaType("image/png");
+        assertEquals(200, shorthand.getStatusOrDefault());
+    }
+
+    @Test
+    public void getEffectiveResponsesShouldNormalizeShorthandIntoResponses() throws Exception {
+        String yaml = """
+            method: "GET"
+            name: "get-pdf"
+            responseBinary:
+              mediaType: "application/pdf"
+              description: "Signed contract PDF"
+            """;
+
+        RestServerOperationSpec op = mapper.readValue(yaml, RestServerOperationSpec.class);
+
+        Map<String, RestResponseSpec> normalized = op.getEffectiveResponses();
+        RestResponseSpec resp = normalized.get("200");
+        assertEquals("Signed contract PDF", resp.getDescription());
+        assertTrue(resp.getContent().get("application/pdf").isBinary());
+    }
+
+    @Test
+    public void findBinaryResponseMediaTypeShouldReturnDeclaredType() throws Exception {
+        String yaml = """
+            method: "GET"
+            name: "get-image"
+            responses:
+              '200':
+                content:
+                  image/jpeg:
+                    binary: true
+            """;
+
+        RestServerOperationSpec op = mapper.readValue(yaml, RestServerOperationSpec.class);
+
+        assertEquals(Optional.of("image/jpeg"), op.findBinaryResponseMediaType());
+        assertTrue(op.hasBinaryResponse());
+    }
+
+    @Test
+    public void hasBinaryResponseShouldBeFalseWhenNoContractDeclared() {
+        RestServerOperationSpec op = new RestServerOperationSpec();
+        op.setMethod("GET");
+        op.setName("list");
+
+        assertFalse(op.hasBinaryResponse());
+        assertTrue(op.getEffectiveResponses().isEmpty());
+    }
+
+    @Test
+    public void hasBinaryResponseShouldBeFalseForNonBinaryContent() throws Exception {
+        String yaml = """
+            method: "GET"
+            name: "get-issue"
+            responses:
+              '200':
+                content:
+                  application/json:
+                    schema:
+                      type: object
+            """;
+
+        RestServerOperationSpec op = mapper.readValue(yaml, RestServerOperationSpec.class);
+
+        assertFalse(op.hasBinaryResponse());
+    }
+}

--- a/ikanos-spec/src/test/java/io/ikanos/spec/openapi/OasExportBuilderTest.java
+++ b/ikanos-spec/src/test/java/io/ikanos/spec/openapi/OasExportBuilderTest.java
@@ -13,7 +13,11 @@
  */
 package io.ikanos.spec.openapi;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;
@@ -799,6 +803,79 @@ public class OasExportBuilderTest {
 
         assertEquals("query", result.getOpenApi().getPaths().get("/data")
                 .getGet().getParameters().get(0).getIn());
+    }
+
+    // ── Binary response contracts (capability-binary-content.md §7.4) ──
+
+    @Test
+    void buildShouldExportBinaryResponseAsStringFormatBinary() {
+        IkanosSpec spec = minimalSpec("Test", null);
+        RestServerSpec rest = getRestServer(spec);
+
+        RestServerResourceSpec resource = new RestServerResourceSpec();
+        resource.setPath("/photos/{id}/image");
+        resource.setName("photo-image");
+        RestServerOperationSpec op = new RestServerOperationSpec();
+        op.setMethod("GET");
+        op.setName("get-image");
+
+        io.ikanos.spec.exposes.rest.RestResponseContentSpec content =
+                new io.ikanos.spec.exposes.rest.RestResponseContentSpec(Boolean.TRUE);
+        io.ikanos.spec.exposes.rest.RestResponseSpec resp =
+                new io.ikanos.spec.exposes.rest.RestResponseSpec();
+        resp.setDescription("Original image bytes");
+        resp.setContent(Map.of("image/jpeg", content));
+        op.setResponses(Map.of("200", resp));
+
+        resource.setOperations(Map.of(op.getName(), op));
+        addResource(rest, resource);
+
+        OasExportResult result = builder.build(spec, null);
+
+        Operation operation =
+                result.getOpenApi().getPaths().get("/photos/{id}/image").getGet();
+        var apiResponse = operation.getResponses().get("200");
+        assertNotNull(apiResponse);
+        assertEquals("Original image bytes", apiResponse.getDescription());
+        var media = apiResponse.getContent().get("image/jpeg");
+        assertNotNull(media, "binary media type must be preserved exactly");
+        assertEquals("string", media.getSchema().getType());
+        assertEquals("binary", media.getSchema().getFormat());
+        assertNull(operation.getResponses().get("200").getContent().get("application/json"),
+                "binary responses must not be collapsed to application/json");
+    }
+
+    @Test
+    void buildShouldExportBinaryResponseFromResponseBinaryShorthand() {
+        IkanosSpec spec = minimalSpec("Test", null);
+        RestServerSpec rest = getRestServer(spec);
+
+        RestServerResourceSpec resource = new RestServerResourceSpec();
+        resource.setPath("/contracts/{id}/pdf");
+        resource.setName("contract-pdf");
+        RestServerOperationSpec op = new RestServerOperationSpec();
+        op.setMethod("GET");
+        op.setName("get-pdf");
+
+        io.ikanos.spec.exposes.rest.RestResponseBinarySpec shorthand =
+                new io.ikanos.spec.exposes.rest.RestResponseBinarySpec();
+        shorthand.setMediaType("application/pdf");
+        shorthand.setDescription("Signed contract PDF");
+        op.setResponseBinary(shorthand);
+
+        resource.setOperations(Map.of(op.getName(), op));
+        addResource(rest, resource);
+
+        OasExportResult result = builder.build(spec, null);
+
+        Operation operation =
+                result.getOpenApi().getPaths().get("/contracts/{id}/pdf").getGet();
+        var apiResponse = operation.getResponses().get("200");
+        assertNotNull(apiResponse, "responseBinary defaults to status 200");
+        var media = apiResponse.getContent().get("application/pdf");
+        assertNotNull(media);
+        assertEquals("string", media.getSchema().getType());
+        assertEquals("binary", media.getSchema().getFormat());
     }
 
     // ── Utility methods ──


### PR DESCRIPTION
## Summary

Implements **binary content handling across an Ikanos capability** per the blueprint
[`capability-binary-content.md`](https://github.com/naftiko/blueprints/blob/main/capability-binary-content.md)
(v1.0.0-beta1). A consumed HTTP operation can declare `outputRawFormat: binary`, and the
engine then propagates the raw bytes — base64-encoded where required — through REST and MCP
exposures instead of UTF-8 decoding (which silently corrupts PNG/PDF/ZIP/audio payloads).

Phases 0 and 1 (spec/schema additions + the `OperationStepExecutor` binary core) already
landed on `main` via #597. **This PR delivers phases 2–6**, the adapter-level wiring and the
merge-gate test matrix.

Refs #583

## What's included (blueprint phases 2–6)

| Phase | Area | Highlights |
|-------|------|------------|
| **2** | REST runtime + OAS export | `ResourceRestlet` returns raw bytes with the resolved `Content-Type` for binary ops; `responses` / `responseBinary` contracts; `OasExportBuilder` exports `type: string, format: binary`. |
| **3** | MCP tool results | `ToolHandler.buildBinaryContent` MIME dispatch: `image/*` → `ImageContent`, `audio/*` → `AudioContent`, else → `EmbeddedResource` with an `ikanos://transient/...` blob URI. |
| **4** | MCP dynamic resources | `ResourceHandler.readDynamic` returns `BlobResourceContents` (base64) for binary upstream calls; new `ResourceContent.binary(...)` factory. |
| **5** | MCP static resources | `ResourceHandler.readStatic` is now MIME-aware (`isBinaryMime`): binary files return a base64 blob instead of corrupted UTF-8 text. Closes a silent-correctness bug. |
| **6** | Integration test matrix (§11.3) | Merge gate. Closes remaining gaps: 1 MiB JPEG round-trip over **stdio**, and `outputParameters`-skipped assertions for binary REST + MCP responses. |

## Commits

- `c29dad9a` — feat(rest): make binary outputs first-class & documentable (phase 2)
- `990c0131` — feat(mcp): emit binary tool results via MIME dispatch (phase 3)
- `550f35c4` — feat(mcp): emit BlobResourceContents for binary dynamic resources (phase 4)
- `b3f2a2f1` — fix(mcp): return BlobResourceContents for binary static resources (phase 5)
- `48266ebf` — test(mcp,rest): complete binary-content integration test matrix (phase 6)

## Behavior & compatibility

- **Strictly additive / opt-in.** No existing text/JSON path changes. Binary is engaged only
  when a consumed op declares `outputRawFormat: binary`.
- **Silent-bug fix (phase 5):** static binary resources (PNG/PDF/…) that were previously read
  as UTF-8 now return correct bytes. Documented as a fix, not a breaking change.
- **`maxBinarySize` guard** (engine default 10 MiB): oversized payloads return a tool
  `isError: true` (MCP) or a `500` / JSON-RPC error (REST/resource) rather than OOM-ing.
- **Mappings bypassed for binary:** `outputParameters` are skipped with an INFO log, since they
  are meaningless for opaque bytes.

## Testing

Full binary-content matrix is green: **64 spec tests + 54 engine tests, 0 failures**, including
`RestBinaryResponseIntegrationTest`, `ToolHandlerBinaryTest`, `ResourceHandlerBinaryTest`,
`ResourceHandlerStaticBinaryTest`, `McpBinaryStdioIntegrationTest`, `OasExportBuilderTest`,
`BinaryContentSchemaValidationTest`, `HttpClientOperationSpecBinaryTest`,
`RestServerOperationSpecBinaryTest`, `BinarySizeTest`, and `HandlingContextBinaryTest`.

## Out of scope (deferred)

- **Phase 7** (docs/cookbook) — Shipyard/docs follow-up.
- **Phase 8** (stretch) — `outputContentType` escape hatch, `multipart` responses.
- **Aggregate-flow binary inheritance** (§11.3 items 13–16) — the `AggregateFlowSpec` runtime
  has no `outputRawFormat`/`binary` fields yet, so those rows are intentionally not implemented.
