### PR TITLE
chore: sync Ikanos version

### DIFF
--- a/ikanos-cli/src/test/resources/control/control-capability.yaml
+++ b/ikanos-cli/src/test/resources/control/control-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../../../ikanos-spec/src/main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 info:
   display: "CLI Control Port Test Capability"
   description: "Test capability for CLI runtime startup"

--- a/ikanos-cli/src/test/resources/native-regression/serve-http.ikanos.yaml
+++ b/ikanos-cli/src/test/resources/native-regression/serve-http.ikanos.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 info:
   display: Native Regression — HTTP Connector
   description: >

--- a/ikanos-cli/src/test/resources/native-regression/serve-rest-mock.ikanos.yaml
+++ b/ikanos-cli/src/test/resources/native-regression/serve-rest-mock.ikanos.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 info:
   display: Native Regression — Minimal REST Mock
   description: >

--- a/ikanos-docs/tutorial/shared/legacy-consumes.yaml
+++ b/ikanos-docs/tutorial/shared/legacy-consumes.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 consumes:
 - namespace: legacy
   type: http

--- a/ikanos-docs/tutorial/shared/registry-consumes.yaml
+++ b/ikanos-docs/tutorial/shared/registry-consumes.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 consumes:
 - namespace: registry
   type: http

--- a/ikanos-docs/tutorial/shared/step11-registry-consumes.yml
+++ b/ikanos-docs/tutorial/shared/step11-registry-consumes.yml
@@ -1,5 +1,5 @@
 # shared/registry-consumes.yaml (final — added get-voyage + cargo resource)
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 consumes:
 - namespace: registry
   type: http

--- a/ikanos-docs/tutorial/shared/step5-registry-consumes.yaml
+++ b/ikanos-docs/tutorial/shared/step5-registry-consumes.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 consumes:
 - namespace: registry
   type: http

--- a/ikanos-docs/tutorial/shared/step6-registry-consumes.yaml
+++ b/ikanos-docs/tutorial/shared/step6-registry-consumes.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 consumes:
 - namespace: registry
   type: http

--- a/ikanos-docs/tutorial/shared/step7-registry-consumes.yml
+++ b/ikanos-docs/tutorial/shared/step7-registry-consumes.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 consumes:
 - namespace: registry
   type: http

--- a/ikanos-docs/tutorial/step-1-shipyard-mock.yml
+++ b/ikanos-docs/tutorial/step-1-shipyard-mock.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 capability:
   exposes:

--- a/ikanos-docs/tutorial/step-10-shipyard-rest-adapter.yml
+++ b/ikanos-docs/tutorial/step-10-shipyard-rest-adapter.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-11-shipyard-fleet-manifest.yml
+++ b/ikanos-docs/tutorial/step-11-shipyard-fleet-manifest.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 info:
   display: "Shipyard Fleet Management"

--- a/ikanos-docs/tutorial/step-2-shipyard-wiring.yml
+++ b/ikanos-docs/tutorial/step-2-shipyard-wiring.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 capability:
   consumes:

--- a/ikanos-docs/tutorial/step-3-shipyard-auth.yml
+++ b/ikanos-docs/tutorial/step-3-shipyard-auth.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-4-shipyard-output-shaping.yml
+++ b/ikanos-docs/tutorial/step-4-shipyard-output-shaping.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-5-shipyard-multi-source.yml
+++ b/ikanos-docs/tutorial/step-5-shipyard-multi-source.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-6-shipyard-write-operations.yml
+++ b/ikanos-docs/tutorial/step-6-shipyard-write-operations.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-7-shipyard-orchestrated-lookup.yml
+++ b/ikanos-docs/tutorial/step-7-shipyard-orchestrated-lookup.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-8-shipyard-skill-groups.yml
+++ b/ikanos-docs/tutorial/step-8-shipyard-skill-groups.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-docs/tutorial/step-9-shipyard-aggregates.yml
+++ b/ikanos-docs/tutorial/step-9-shipyard-aggregates.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-basic.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-basic.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 info:
   display: Aggregate Basic Test
   description: Test capability for aggregate function ref resolution

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-hints-override.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-hints-override.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 info:
   display: Aggregate Hints Override Test
   description: Test capability for semantics-to-hints derivation with override

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-invalid-ref.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-invalid-ref.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 info:
   display: "Aggregate Invalid Ref Test"
   description: "Test capability with an unknown aggregate ref"

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-shared-mock.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-shared-mock.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 info:
   display: Aggregate Shared Mock Test
   description: Shared aggregate mock function consumed by MCP and REST refs

--- a/ikanos-engine/src/test/resources/aggregates/aggregate-step-with-namespace.yaml
+++ b/ikanos-engine/src/test/resources/aggregates/aggregate-step-with-namespace.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 info:
   display: Aggregate Step Namespace Test
   description: Test capability for namespace-qualified references in aggregate function

--- a/ikanos-engine/src/test/resources/baseuri-trailing-slash-capability.yaml
+++ b/ikanos-engine/src/test/resources/baseuri-trailing-slash-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 info:
   display: "BaseUri Trailing Slash Regression Test"
   description: "Capability intentionally using a trailing-slash baseUri to test strict validation"

--- a/ikanos-engine/src/test/resources/control/control-capability.yaml
+++ b/ikanos-engine/src/test/resources/control/control-capability.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../../../ikanos-spec/src/main/resources/schemas/ikanos-schema.json
 ---
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 info:
   display: "Control Port Test Capability"
   description: "Test capability for Control Server Adapter deserialization and wiring"

--- a/ikanos-engine/src/test/resources/control/control-observability-disabled.yaml
+++ b/ikanos-engine/src/test/resources/control/control-observability-disabled.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 info:
   display: "Control Port — Observability Disabled"
   description: "Test fixture: observability.enabled=false should suppress /metrics and /traces"

--- a/ikanos-engine/src/test/resources/control/control-scripting-capability.yaml
+++ b/ikanos-engine/src/test/resources/control/control-scripting-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 info:
   display: "Control Port Scripting Test"
   description: "Test capability for scripting governance on the Control Port"

--- a/ikanos-engine/src/test/resources/embedding/embedding-capability.yaml
+++ b/ikanos-engine/src/test/resources/embedding/embedding-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 info:
   display: Embedding Test
   description: Test capability for step handler registry integration

--- a/ikanos-engine/src/test/resources/formats/avro-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/avro-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 info:
   display: Avro Test Capability
   description: Test capability for Avro message decoding from API responses

--- a/ikanos-engine/src/test/resources/formats/csv-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/csv-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 info:
   display: CSV Test Capability
   description: Test capability for CSV parsing from API responses

--- a/ikanos-engine/src/test/resources/formats/html-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/html-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 info:
   display: "HTML Test Capability"
   description: "Test capability for HTML table parsing"

--- a/ikanos-engine/src/test/resources/formats/markdown-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/markdown-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 info:
   display: "Markdown Test Capability"
   description: "Test capability for Markdown parsing"

--- a/ikanos-engine/src/test/resources/formats/proto-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/proto-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 info:
   display: Protobuf Test Capability
   description: Test capability for Protobuf message decoding from API responses

--- a/ikanos-engine/src/test/resources/formats/xml-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/xml-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 info:
   display: XML Test Capability
   description: Test capability for XML parsing from API responses

--- a/ikanos-engine/src/test/resources/formats/yaml-capability.yaml
+++ b/ikanos-engine/src/test/resources/formats/yaml-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 info:
   display: YAML Test Capability
   description: Test capability for YAML parsing from API responses

--- a/ikanos-engine/src/test/resources/http/http-body-capability.yaml
+++ b/ikanos-engine/src/test/resources/http/http-body-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 capability:
   exposes:
   - type: rest

--- a/ikanos-engine/src/test/resources/http/http-forward-value-capability.yaml
+++ b/ikanos-engine/src/test/resources/http/http-forward-value-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 info:
   display: HTTP Forward with Value Field Test
   description: Test capability for forward spec with value field supporting Mustache

--- a/ikanos-engine/src/test/resources/http/http-header-query-capability.yaml
+++ b/ikanos-engine/src/test/resources/http/http-header-query-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 capability:
   exposes:
   - type: rest

--- a/ikanos-engine/src/test/resources/imports/aggregates/shared.aggregates.yml
+++ b/ikanos-engine/src/test/resources/imports/aggregates/shared.aggregates.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 aggregates:
   - namespace: "forecast"
     display: "Forecast Domain"

--- a/ikanos-engine/src/test/resources/imports/binds/shared.binds.yml
+++ b/ikanos-engine/src/test/resources/imports/binds/shared.binds.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 binds:
   - namespace: "weather-secrets"
     description: "Weather API credentials"

--- a/ikanos-engine/src/test/resources/imports/consumes/shared-clients.yml
+++ b/ikanos-engine/src/test/resources/imports/consumes/shared-clients.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 consumes:
   - namespace: "weather-http"
     type: "http"

--- a/ikanos-engine/src/test/resources/imports/consumes/shared.consumes.yml
+++ b/ikanos-engine/src/test/resources/imports/consumes/shared.consumes.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 consumes:
   - type: "http"
     namespace: "weather-api"

--- a/ikanos-engine/src/test/resources/imports/exposes/shared-servers.yml
+++ b/ikanos-engine/src/test/resources/imports/exposes/shared-servers.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 exposes:
   - namespace: "weather-rest"
     type: "rest"

--- a/ikanos-engine/src/test/resources/imports/exposes/shared.exposes.yml
+++ b/ikanos-engine/src/test/resources/imports/exposes/shared.exposes.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 exposes:
   - type: "rest"
     namespace: "weather-rest"

--- a/ikanos-engine/src/test/resources/imports/invalid/empty-section.consumes.yml
+++ b/ikanos-engine/src/test/resources/imports/invalid/empty-section.consumes.yml
@@ -1,2 +1,2 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 consumes: []

--- a/ikanos-engine/src/test/resources/mcp/mcp-capability.yaml
+++ b/ikanos-engine/src/test/resources/mcp/mcp-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 info:
   display: MCP Test Capability
   description: Test capability for MCP Server Adapter deserialization and wiring

--- a/ikanos-engine/src/test/resources/mcp/mcp-hints-capability.yaml
+++ b/ikanos-engine/src/test/resources/mcp/mcp-hints-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 info:
   display: MCP Hints Test Capability
   description: Test capability for MCP tool hints (ToolAnnotations) support

--- a/ikanos-engine/src/test/resources/mcp/mcp-resources-prompts-capability.yaml
+++ b/ikanos-engine/src/test/resources/mcp/mcp-resources-prompts-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 info:
   display: MCP Resources & Prompts Test Capability
   description: Test capability for MCP Server Adapter resources and prompts support

--- a/ikanos-engine/src/test/resources/mcp/mcp-stdio-capability.yaml
+++ b/ikanos-engine/src/test/resources/mcp/mcp-stdio-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 info:
   display: MCP Stdio Test Capability
   description: Test capability for MCP Server Adapter with stdio transport

--- a/ikanos-engine/src/test/resources/mcp/mcp-step-with-namespace-capability.yaml
+++ b/ikanos-engine/src/test/resources/mcp/mcp-step-with-namespace-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 capability:
   consumes:
   - namespace: registry

--- a/ikanos-engine/src/test/resources/mcp/mcp-tool-handler-with-mustache-capability.yaml
+++ b/ikanos-engine/src/test/resources/mcp/mcp-tool-handler-with-mustache-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 capability:
   consumes:
   - namespace: registry

--- a/ikanos-engine/src/test/resources/nested-object-output-capability.yaml
+++ b/ikanos-engine/src/test/resources/nested-object-output-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 info:
   display: Nested Object Output Capability
   description: Test fixture for verifying that output mappings correctly resolve nested

--- a/ikanos-engine/src/test/resources/observability/observability-capability.yaml
+++ b/ikanos-engine/src/test/resources/observability/observability-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 info:
   display: "Observability Test Capability"
   description: "Test capability for observability spec deserialization"

--- a/ikanos-engine/src/test/resources/observability/observability-disabled.yaml
+++ b/ikanos-engine/src/test/resources/observability/observability-disabled.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 info:
   display: "Observability Disabled Capability"
   description: "Test capability with observability disabled"

--- a/ikanos-engine/src/test/resources/register.capability.yml
+++ b/ikanos-engine/src/test/resources/register.capability.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 info:
   display: "register"
   description: "Business description of your capability"

--- a/ikanos-engine/src/test/resources/skill-capability.yaml
+++ b/ikanos-engine/src/test/resources/skill-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 info:
   display: Skill Test Capability
   description: Test capability for Skill Server Adapter deserialization and wiring

--- a/ikanos-engine/src/test/resources/tutorial/shared/legacy-consumes.yaml
+++ b/ikanos-engine/src/test/resources/tutorial/shared/legacy-consumes.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 consumes:
 - namespace: legacy
   type: http

--- a/ikanos-engine/src/test/resources/tutorial/shared/registry-consumes.yaml
+++ b/ikanos-engine/src/test/resources/tutorial/shared/registry-consumes.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 consumes:
 - namespace: registry
   type: http

--- a/ikanos-engine/src/test/resources/tutorial/shared/step11-registry-consumes.yml
+++ b/ikanos-engine/src/test/resources/tutorial/shared/step11-registry-consumes.yml
@@ -1,5 +1,5 @@
 # shared/registry-consumes.yaml (final — added get-voyage + cargo resource)
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 consumes:
 - namespace: registry
   type: http

--- a/ikanos-engine/src/test/resources/tutorial/shared/step5-registry-consumes.yaml
+++ b/ikanos-engine/src/test/resources/tutorial/shared/step5-registry-consumes.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 consumes:
 - namespace: registry
   type: http

--- a/ikanos-engine/src/test/resources/tutorial/shared/step6-registry-consumes.yaml
+++ b/ikanos-engine/src/test/resources/tutorial/shared/step6-registry-consumes.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 consumes:
 - namespace: registry
   type: http

--- a/ikanos-engine/src/test/resources/tutorial/shared/step7-registry-consumes.yml
+++ b/ikanos-engine/src/test/resources/tutorial/shared/step7-registry-consumes.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 consumes:
 - namespace: registry
   type: http

--- a/ikanos-engine/src/test/resources/tutorial/step-1-shipyard-mock.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-1-shipyard-mock.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 capability:
   exposes:

--- a/ikanos-engine/src/test/resources/tutorial/step-10-shipyard-rest-adapter.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-10-shipyard-rest-adapter.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-11-shipyard-fleet-manifest.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-11-shipyard-fleet-manifest.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 info:
   display: "Shipyard Fleet Management"

--- a/ikanos-engine/src/test/resources/tutorial/step-2-shipyard-wiring.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-2-shipyard-wiring.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 capability:
   consumes:

--- a/ikanos-engine/src/test/resources/tutorial/step-3-shipyard-auth.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-3-shipyard-auth.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-4-shipyard-output-shaping.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-4-shipyard-output-shaping.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-5-shipyard-multi-source.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-5-shipyard-multi-source.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-6-shipyard-write-operations.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-6-shipyard-write-operations.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-7-shipyard-orchestrated-lookup.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-7-shipyard-orchestrated-lookup.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-8-shipyard-skill-groups.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-8-shipyard-skill-groups.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-engine/src/test/resources/tutorial/step-9-shipyard-aggregates.yml
+++ b/ikanos-engine/src/test/resources/tutorial/step-9-shipyard-aggregates.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-spec/src/main/resources/schemas/examples/capability-binary-content.yml
+++ b/ikanos-spec/src/main/resources/schemas/examples/capability-binary-content.yml
@@ -14,7 +14,7 @@
 #   - exposes rest: responses contract + responseBinary shorthand
 #   - exposes mcp: adapter-level maxBinarySize, resource `binary: true`
 # Runtime byte handling lands in Phases 1+.
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 info:
   display: "Photo library (binary content example)"

--- a/ikanos-spec/src/main/resources/schemas/examples/reverse-tunnel-ziti.yml
+++ b/ikanos-spec/src/main/resources/schemas/examples/reverse-tunnel-ziti.yml
@@ -8,7 +8,7 @@
 # At Phase 1 the engine does NOT yet wire the tunnel — this YAML validates
 # against the schema and the Polychro rules only. End-to-end execution lands
 # in Phases 2+ (embedded Ziti integration).
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 info:
   display: "CRM reverse-tunnel example"

--- a/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
+++ b/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ikanos.io/schemas/v1.0.0-beta1/ikanos.json",
+  "$id": "https://ikanos.io/schemas/v1.0.0-beta2/ikanos.json",
   "name": "Ikanos Specification",
   "description": "Ikanos Capability Specification \u2014 describes a capability document (adapter + metadata) or a standalone shared file (consumes / exposes / aggregates / binds). A valid document must declare `ikanos` + exactly one of `capability`, `consumes`, `exposes`, `aggregates`, or `binds`. All adapter logic lives under `capability`; shared section definitions live at root.",
   "type": "object",
@@ -8,7 +8,7 @@
     "ikanos": {
       "type": "string",
       "description": "Ikanos specification version. Must be `1.0.0-beta1`. Signals schema compatibility \u2014 always the first key in a capability file.",
-      "const": "1.0.0-beta1"
+      "const": "1.0.0-beta2"
     },
     "info": {
       "$ref": "#/$defs/Info",

--- a/ikanos-spec/src/test/resources/capabilities/capability-spurious-name.yml
+++ b/ikanos-spec/src/test/resources/capabilities/capability-spurious-name.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-spec/src/test/resources/capabilities/capability-valid.yml
+++ b/ikanos-spec/src/test/resources/capabilities/capability-valid.yml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 binds:
 - namespace: "registry-env"

--- a/ikanos-spec/src/test/resources/imports/aggregate-duplicate-function-name.yaml
+++ b/ikanos-spec/src/test/resources/imports/aggregate-duplicate-function-name.yaml
@@ -1,6 +1,6 @@
 # Aggregate with two functions sharing the same name.
 # Should trigger: ikanos-aggregates-unique-function-name
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 capability:
   aggregates:

--- a/ikanos-spec/src/test/resources/imports/aggregates-namespace-missing.yaml
+++ b/ikanos-spec/src/test/resources/imports/aggregates-namespace-missing.yaml
@@ -1,6 +1,6 @@
 # Standalone source file with an `aggregates` entry that lacks `namespace`.
 # Should trigger: ikanos-aggregates-namespace-required
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 aggregates:
   - label: Weather Service

--- a/ikanos-spec/src/test/resources/imports/capability-aggregates-namespace-missing.yaml
+++ b/ikanos-spec/src/test/resources/imports/capability-aggregates-namespace-missing.yaml
@@ -1,7 +1,7 @@
 # Capability with an inline `aggregates` entry (declares `functions`) that lacks `namespace`.
 # Tests the new `$.capability.aggregates[?(@.functions)]` JSONPath in the rule.
 # Should trigger: ikanos-aggregates-namespace-required
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 capability:
   aggregates:

--- a/ikanos-spec/src/test/resources/imports/capability-exposes-namespace-missing.yaml
+++ b/ikanos-spec/src/test/resources/imports/capability-exposes-namespace-missing.yaml
@@ -1,7 +1,7 @@
 # Capability with an inline `exposes` entry (declares `type`) that lacks `namespace`.
 # Tests the new `$.capability.exposes[?(@.type)]` JSONPath in the rule.
 # Should trigger: ikanos-exposes-namespace-required
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 capability:
   exposes:

--- a/ikanos-spec/src/test/resources/imports/exposes-namespace-missing.yaml
+++ b/ikanos-spec/src/test/resources/imports/exposes-namespace-missing.yaml
@@ -1,6 +1,6 @@
 # Standalone source file with an `exposes` entry that lacks `namespace`.
 # Should trigger: ikanos-exposes-namespace-required
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 exposes:
   - type: rest

--- a/ikanos-spec/src/test/resources/imports/import-duplicate-alias.yaml
+++ b/ikanos-spec/src/test/resources/imports/import-duplicate-alias.yaml
@@ -4,7 +4,7 @@
 # Both entries resolve to effective namespace "weather":
 #   - entry 0: `import: weather` (no `as`)
 #   - entry 1: `import: forecast`, `as: weather`
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 capability:
   consumes:

--- a/ikanos-spec/src/test/resources/imports/import-from-self.yaml
+++ b/ikanos-spec/src/test/resources/imports/import-from-self.yaml
@@ -1,6 +1,6 @@
 # Capability with an import `from` pointing to the current directory (bare dot).
 # Should trigger: ikanos-import-from-not-self
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 capability:
   consumes:

--- a/ikanos-spec/src/test/resources/imports/import-missing-fields.yaml
+++ b/ikanos-spec/src/test/resources/imports/import-missing-fields.yaml
@@ -3,7 +3,7 @@
 # Should trigger:
 #   - ikanos-import-from-required  (entry 0 has `from` but no `import`)
 #   - ikanos-import-import-required (entry 1 has `import` but no `from` and no `type`)
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 capability:
   consumes:

--- a/ikanos-spec/src/test/resources/imports/standalone-with-imports.yaml
+++ b/ikanos-spec/src/test/resources/imports/standalone-with-imports.yaml
@@ -1,6 +1,6 @@
 # Standalone source file (no `capability` key) that contains an import entry.
 # Should trigger: ikanos-standalone-no-imports
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 exposes:
   - namespace: weather

--- a/ikanos-spec/src/test/resources/rules/spectral-semantics-consistent.yaml
+++ b/ikanos-spec/src/test/resources/rules/spectral-semantics-consistent.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 capability:
   aggregates:
   - display: Weather Service

--- a/ikanos-spec/src/test/resources/rules/spectral-semantics-inconsistent.yaml
+++ b/ikanos-spec/src/test/resources/rules/spectral-semantics-inconsistent.yaml
@@ -1,4 +1,4 @@
-ikanos: 1.0.0-beta1
+ikanos: 1.0.0-beta2
 capability:
   aggregates:
   - display: Weather Service

--- a/ikanos-spec/src/test/resources/rules/spectral-tunnel-fallback-direct-public.yaml
+++ b/ikanos-spec/src/test/resources/rules/spectral-tunnel-fallback-direct-public.yaml
@@ -3,7 +3,7 @@
 #
 # The tunnel uses fallback: direct against a non-loopback baseUri
 # (https://crm.internal). The warn rule must report a violation.
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 info:
   display: "Reverse tunnel — direct fallback on non-loopback baseUri"

--- a/ikanos-spec/src/test/resources/rules/spectral-tunnel-identity-bound.yaml
+++ b/ikanos-spec/src/test/resources/rules/spectral-tunnel-identity-bound.yaml
@@ -4,7 +4,7 @@
 # The tunnel.identity references the "secrets.ZITI_IDENTITY" key, and "secrets"
 # is declared in binds with a matching key. The custom function must accept this
 # document silently.
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 info:
   display: "Reverse tunnel — bound identity reference"

--- a/ikanos-spec/src/test/resources/rules/spectral-tunnel-identity-unbound.yaml
+++ b/ikanos-spec/src/test/resources/rules/spectral-tunnel-identity-unbound.yaml
@@ -4,7 +4,7 @@
 # The tunnel.identity references a Mustache namespace ("secrets") that is NOT
 # declared in binds/capability.binds. The custom function tunnel-identity-binds-ref
 # must report a violation.
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 
 info:
   display: "Reverse tunnel — unbound identity reference"

--- a/ikanos-spec/src/test/resources/skill-capability.yaml
+++ b/ikanos-spec/src/test/resources/skill-capability.yaml
@@ -1,4 +1,4 @@
-ikanos: "1.0.0-beta1"
+ikanos: "1.0.0-beta2"
 info:
   display: "Skill Test Capability"
   description: "Test capability for Skill Server Adapter deserialization and wiring"


### PR DESCRIPTION
## No related issue

---

## What does this PR do?

Automatically synchronizes the Ikanos version across the repository:
- Updates `ikanos` version in YAML files
- Updates `const` in JSON schema
- Updates `$id` schema URL

Source of truth: `pom.xml`

---

## Tests

No additional tests required.
This change is limited to version synchronization and does not impact runtime behavior.

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main`
- [ ] Small and focused — one concern per PR
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)