### PR TITLE
feat: rename naftiko-golden-repo references to golden-repo-naftiko

### DIFF
--- a/.github/instructions/agents-shared.instructions.md
+++ b/.github/instructions/agents-shared.instructions.md
@@ -6,7 +6,7 @@ name: "agents-shared skill discovery"
 
 The transversal skills served to this repository — `pr-review`, `bugfix`, and
 `ikanos-capability` — are **not** committed here. They are versioned once in the
-[`naftiko-golden-repo`](https://github.com/naftiko/naftiko-golden-repo) golden repo and served
+[`golden-repo-naftiko`](https://github.com/naftiko/golden-repo-naftiko) golden repo and served
 read-only by the `agents-shared` Ikanos capability (Skill Server, `type: skill`).
 
 ## How to use a skill
@@ -42,7 +42,7 @@ read-only by the `agents-shared` Ikanos capability (Skill Server, `type: skill`)
 
 ## If the Skill Server is not running
 
-The capability runs from a local checkout of `naftiko-golden-repo` via `ikanos serve` — see
+The capability runs from a local checkout of `golden-repo-naftiko` via `ikanos serve` — see
 `agents-shared/README.md` in that repo for setup (including the absolute `location:`
 rewrite) and for a `gh api` fallback that needs no server. Ask the user to start the
 server or fetch the skill via the fallback; do not copy the skill into version control.
@@ -50,4 +50,4 @@ server or fetch the skill via the fallback; do not copy the skill into version c
 ## Rules
 
 - The synced copies under `.agents/skills/` are **git-ignored** — never commit them.
-- Never edit a synced copy; improvements go to `naftiko-golden-repo` (issue-first).
+- Never edit a synced copy; improvements go to `golden-repo-naftiko` (issue-first).

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ dependency-reduced-pom.xml
 
 # On-demand synced skill copies (never commit) — the transversal skills served by the
 # agents-shared capability (pr-review, bugfix, ikanos-capability) are versioned once in the
-# naftiko-golden-repo golden repo and fetched on demand via
+# golden-repo-naftiko golden repo and fetched on demand via
 # .github/instructions/agents-shared.instructions.md. Never commit these synced copies.
 .agents/skills/pr-review/
 .agents/skills/bugfix/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,7 +150,7 @@ Example: a PR-review agent writes findings to `/memories/repo/pr-review-<PR>.md`
 
 ## Code Style
 
-**Java** — follows Google Style. Configure VS Code with `Language Support for Java by Red Hat` and apply settings from [naftiko/naftiko-golden-repo — java](https://github.com/naftiko/naftiko-golden-repo/tree/main/java).
+**Java** — follows Google Style. Configure VS Code with `Language Support for Java by Red Hat` and apply settings from [naftiko/golden-repo-naftiko — java](https://github.com/naftiko/golden-repo-naftiko/tree/main/java).
 
 **Method visibility** — prefer package-private (no modifier) over `private` for methods that implement non-trivial logic. This allows direct unit testing from the same package without reflection. Reserve `private` for truly internal helpers that are trivially covered by public API tests (e.g. one-liner formatters, simple getters).
 
@@ -234,7 +234,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow. Key rules:
 - When creating issues or PRs with multiline bodies via `gh`, **never construct the body as a string in the terminal** — PowerShell here-strings and multiline variable assignments hang or corrupt content. Always write the body to a temp `.md` file using the file creation tool (outside the terminal), then pass it via `--body-file "/path/to/file.md"` (see also *Working on Windows → Terminal & file I/O*)
 - When asked to review a PR, load and follow the `pr-review` skill via the `agents-shared`
   capability — see `.github/instructions/agents-shared.instructions.md` for the discovery
-  and sync procedure. The skill is served from `naftiko-golden-repo/agents-shared` (naftiko/shipyard#23).
+  and sync procedure. The skill is served from `golden-repo-naftiko/agents-shared` (naftiko/shipyard#23).
 - When asked to fix a bug, investigate an issue, or address PR review feedback, load and follow the `bugfix` skill via the `agents-shared` capability — see `.github/instructions/agents-shared.instructions.md` for the discovery and sync procedure — before doing anything else. It targets **Java/Maven** repositories (its build/test core assumes `mvn`); fixing a bash script or CI workflow that lives inside such a repo is in scope, but non-Java/Maven application code (C++, TypeScript, …) is not. It does **not** hardcode the repository name — it derives `<owner/repo>` from the working directory, so it is reusable across Java/Maven repos
 - When resuming after a context compaction (conversation summary), always re-read any active skill's `SKILL.md` before continuing — compaction erases step formalism, workflow constraints, and all details defined in the skill
 - When editing documentation, skill, or instruction files (`.md`, `SKILL.md`, `AGENTS.md`), re-read the **entire file** after applying edits and before committing — to catch terminology drift, broken cross-references, and inconsistencies between sections that targeted edits cannot detect


### PR DESCRIPTION
## Related Issue

Tracked by naftiko/golden-repo-naftiko#44 (repo rename).

---

## What does this PR do?

The golden repo was renamed on GitHub from `naftiko-golden-repo` to `golden-repo-naftiko`. This PR updates the functional references to the old name so agent-facing guidance points to the correct repository.

Updated (6 occurrences across 3 files):
- `AGENTS.md` — Java standards link and the served-skill pointer.
- `.github/instructions/agents-shared.instructions.md` — skill-discovery source, local-checkout note, and the issue-first rule.
- `.gitignore` — comment referencing the golden repo.

Name-only edits; no behavior change.

---

## Tests

None — documentation/instruction-only change. No source, schema, or fixtures touched.

---

## Documentation

<!-- If this PR modifies github actions for example -->

- [ ] Update Notion documentation
- [x] Ensure our internal technical documentation (specs, user docs, test docs) reflects the current implementation (no drift)

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow Conventional Commits
