### PR TITLE
chore: rename internal blueprint vocabulary to design doc (issue naftiko/blueprints#6)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ If you still want to run the full pre-PR checks locally, install [Trivy](https:/
 
 The primary development environment is Windows with PowerShell. These rules are
 **environment hazards** that apply to *any* file you touch — Java, YAML capabilities,
-JSON schemas, blueprints, Markdown, anything — not just code. They are hard rules.
+JSON schemas, design docs, Markdown, anything — not just code. They are hard rules.
 
 ### Terminal & file I/O (PowerShell)
 
@@ -77,7 +77,7 @@ JSON schemas, blueprints, Markdown, anything — not just code. They are hard ru
 encoding (CP850 / Windows-1252), **not** UTF-8 — every multi-byte character (`—`, `→`,
 accented letters, emojis like 🔴🟡🔵) is mangled into mojibake (`ÔÇö`, `├ö├ç├Â`) **before**
 it is written. Adding `-Encoding utf8NoBOM` does **not** help: it re-encodes an
-already-corrupted string. This corrupts capability YAML, schema JSON, blueprints, and docs
+already-corrupted string. This corrupts capability YAML, schema JSON, design docs, and docs
 just as easily as source code.
 
 **Do — to materialise a Git blob, ref, or any file content into a file:**


### PR DESCRIPTION
## Related Issue

Tracked by naftiko/blueprints#6 (rename blueprints repo and vocabulary to design-docs).

---

## What does this PR do?

Renames the remaining internal "blueprint" vocabulary in `AGENTS.md` to "design doc", per
naftiko/blueprints#6. This is a selective rename: only internal design-doc vocabulary is
touched — the Shipyard product concept and this repo's own `src/main/resources/blueprints/`
directory (a different, unrelated concept: Ikanos capability import bindings) are untouched.

Updated (2 occurrences in 1 file):
- `AGENTS.md` — the generic "environment hazards apply to any file" example in the Windows
  PowerShell/UTF-8 section ("JSON schemas, blueprints, Markdown" → "JSON schemas, design
  docs, Markdown").

This repo does not consume the `blueprint-itd-sync`/`design-itd-sync` skill, so
`.github/instructions/agents-shared.instructions.md` needed no change.

Name-only edits; no behavior change.

---

## Tests

None — documentation-only change. No source, schema, or fixtures touched.

---

## Documentation

- [ ] Update Notion documentation
- [x] Ensure our internal technical documentation (specs, user docs, test docs) reflects the current implementation (no drift)

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow Conventional Commits

---

## Agent Context (optional)

```yaml
# agent_name: GitHub Copilot
# llm: Naftiko - Claude Sonnet 5
# tool: agent mode
# confidence: high
# source_event: naftiko/blueprints#6
# discovery_method: user_report
# review_focus: AGENTS.md
```
