### PR TITLE
feat: synchronize schema version to the shipyard tutorial yaml files

### DIFF
--- a/.github/workflows/synchronize-schema-version-in-other-repos.yml
+++ b/.github/workflows/synchronize-schema-version-in-other-repos.yml
@@ -75,3 +75,69 @@ jobs:
             Updated files:
             - `templates/skeletons/capabilities/*.ikanos.yml`
           delete-branch: true
+
+  sync-shipyard-schema-version:
+    runs-on: ubuntu-latest
+    if: github.ref_name == 'main'
+
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_SYNC_IKANOS_VERSION_ID }}
+          private-key: ${{ secrets.APP_SYNC_IKANOS_VERSION_PRIVATE_KEY }}
+          owner: naftiko
+          repositories: shipyard
+
+      - name: Checkout ikanos
+        uses: actions/checkout@v4
+        with:
+          path: ikanos
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Checkout shipyard
+        uses: actions/checkout@v4
+        with:
+          repository: naftiko/shipyard
+          token: ${{ steps.app-token.outputs.token }}
+          path: shipyard
+
+      - name: Sync Ikanos schema version to shipyard
+        id: sync
+        run: |
+          VERSION=$(python3 ikanos/scripts/sync-schema-version-to-shipyard.py \
+            --schema ikanos/ikanos-spec/src/main/resources/schemas/ikanos-schema.json \
+            --target shipyard/shipyard-front/src/assets/tutorials/yaml)
+          echo "value=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Check for changes
+        id: git-check
+        working-directory: shipyard
+        run: |
+          if git diff --quiet; then
+            echo "changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Pull Request
+        if: steps.git-check.outputs.changes == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          path: shipyard
+          base: main
+          branch: "chore/sync-ikanos-schema-version"
+          commit-message: "chore: sync Ikanos schema version to ${{ steps.sync.outputs.value }}"
+          title: "chore: sync Ikanos schema version to ${{ steps.sync.outputs.value }}"
+          body: |
+            Automated sync from [ikanos@${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}).
+
+            Updated files:
+            - `shipyard-front/src/assets/tutorials/yaml/**/*.yml`
+          delete-branch: true

--- a/scripts/sync-schema-version-to-shipyard.py
+++ b/scripts/sync-schema-version-to-shipyard.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""
+Script to synchronize the Ikanos schema version from ikanos-schema.json into Shipyard YAML files.
+"""
+
+import argparse
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).parent))
+from ikanos_version import extract_version_from_schema, update_yaml_version
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Sync Ikanos schema version to Shipyard YAML files")
+    parser.add_argument("--schema", required=True, help="Path to ikanos-schema.json")
+    parser.add_argument("--target", required=True, help="Path to the shipyard directory to search recursively for YAML files")
+    args = parser.parse_args()
+
+    version = extract_version_from_schema(args.schema)
+
+    target = Path(args.target)
+    files = list(target.rglob("*.yml")) + list(target.rglob("*.yaml"))
+
+    if not files:
+        print(f"⚠ No .yml/.yaml files found under {target}", file=sys.stderr)
+    else:
+        for file in files:
+            if update_yaml_version(file, version):
+                print(f"   ✓ {file}", file=sys.stderr)
+            else:
+                print(f"   - {file} (no change)", file=sys.stderr)
+
+    # Output clean version for workflow capture
+    print(version)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Related Issue

No related issue

---

## What does this PR do?

Add a job in the existing GitHub action to sync the schema version (when modified) to the shipyard tutorials yaml files (in addition to warden)

---

## Tests

<!-- Describe tests added or modified. If none, explain why. -->

---

## Documentation

<!-- If this PR modifies github actions for example -->

- [ ] Update Notion documentation
- [ ] Ensure our internal technical documentation (specs, user docs, test docs) reflects the current implementation (no drift)

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main`
- [ ] Small and focused — one concern per PR
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

<!-- If this PR was created or assisted by an AI agent, provide metadata below (YAML) -->

```yaml
# agent_name:
# llm:
# tool:
# confidence:          # low | medium | high
# source_event:
# discovery_method:    # runtime_observation | code_review | test_failure | user_report
# review_focus:        # e.g. ClassName.java:line-range
```
