### PR TITLE
Test commit

### DIFF
--- a/modules/ikanos-engine/pom.xml
+++ b/modules/ikanos-engine/pom.xml
@@ -186,6 +186,9 @@
                 <configuration>
                     <systemPropertyVariables>
                         <microcks.image>${microcks.image}</microcks.image>
+                        <org.restlet.engine.loggerFacadeClass>
+                            org.restlet.ext.slf4j.Slf4jLoggerFacade
+                        </org.restlet.engine.loggerFacadeClass>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ToolHandlerBinaryTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ToolHandlerBinaryTest.java
@@ -22,6 +22,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.restlet.Application;
@@ -200,16 +203,11 @@ public class ToolHandlerBinaryTest {
         Component upstream = createBinaryServer(port, JPEG_BYTES, MediaType.IMAGE_JPEG);
         upstream.start();
 
-        java.util.logging.Logger logger = org.restlet.Context.getCurrentLogger();
-        java.util.List<String> messages = new java.util.ArrayList<>();
-        java.util.logging.Handler captor = new java.util.logging.Handler() {
-            @Override public void publish(java.util.logging.LogRecord record) {
-                messages.add(record.getMessage());
-            }
-            @Override public void flush() { }
-            @Override public void close() { }
-        };
-        logger.addHandler(captor);
+        ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) ((org.restlet.ext.slf4j.Slf4jLogger) org.restlet.Context.getCurrentLogger()).getSlf4jLogger();
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        logger.setLevel(Level.INFO);
 
         try {
             ToolHandler handler =
@@ -225,11 +223,10 @@ public class ToolHandlerBinaryTest {
             assertEquals("image/jpeg", image.mimeType());
             assertEquals(Base64.getEncoder().encodeToString(JPEG_BYTES), image.data());
 
-            assertTrue(messages.stream().anyMatch(m ->
-                    m != null && m.contains("Skipping outputParameters mappings for tool 'get-photo'")),
-                    "expected an INFO log that outputParameters were skipped, got: " + messages);
+            assertTrue(appender.list.stream().anyMatch(m ->
+                    m != null && m.getFormattedMessage().contains("Skipping outputParameters mappings for tool 'get-photo'")),
+                    "expected an INFO log that outputParameters were skipped, got: " + appender.list.stream().map(ILoggingEvent::getFormattedMessage).toList());
         } finally {
-            logger.removeHandler(captor);
             upstream.stop();
         }
     }

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/rest/RestBinaryResponseIntegrationTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/rest/RestBinaryResponseIntegrationTest.java
@@ -20,6 +20,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.ServerSocket;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.restlet.Application;
@@ -40,6 +43,8 @@ import io.ikanos.Capability;
 import io.ikanos.spec.IkanosSpec;
 import io.ikanos.spec.exposes.rest.RestServerSpec;
 import io.ikanos.spec.util.VersionHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Integration tests for the REST binary-response runtime branch (capability-binary-content.md
@@ -55,6 +60,7 @@ public class RestBinaryResponseIntegrationTest {
             0x4A, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01,
             0x00, 0x01, 0x00, 0x00, (byte) 0xFF, (byte) 0xD9
     };
+    private static final Logger log = LoggerFactory.getLogger(RestBinaryResponseIntegrationTest.class);
 
     private String schemaVersion;
 
@@ -125,16 +131,11 @@ public class RestBinaryResponseIntegrationTest {
         Component upstream = createBinaryServer(port, JPEG_BYTES, MediaType.IMAGE_JPEG);
         upstream.start();
 
-        java.util.logging.Logger logger = org.restlet.Context.getCurrentLogger();
-        java.util.List<String> messages = new java.util.ArrayList<>();
-        java.util.logging.Handler captor = new java.util.logging.Handler() {
-            @Override public void publish(java.util.logging.LogRecord record) {
-                messages.add(record.getMessage());
-            }
-            @Override public void flush() { }
-            @Override public void close() { }
-        };
-        logger.addHandler(captor);
+        ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) ((org.restlet.ext.slf4j.Slf4jLogger) org.restlet.Context.getCurrentLogger()).getSlf4jLogger();
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        logger.setLevel(Level.INFO);
 
         try {
             Capability capability =
@@ -146,11 +147,10 @@ public class RestBinaryResponseIntegrationTest {
             assertEquals("image/jpeg", response.getEntity().getMediaType().getName());
             assertArrayEquals(JPEG_BYTES, readBytes(response));
 
-            assertTrue(messages.stream().anyMatch(m ->
-                    m != null && m.contains("Skipping outputParameters mappings for REST operation")),
-                    "expected an INFO log that outputParameters were skipped, got: " + messages);
+            assertTrue(appender.list.stream().anyMatch(m ->
+                    m != null && m.getMessage().contains("Skipping outputParameters mappings for REST operation")),
+                    "expected an INFO log that outputParameters were skipped, got: " + appender.list.stream().map(ILoggingEvent::getFormattedMessage).toList());
         } finally {
-            logger.removeHandler(captor);
             upstream.stop();
         }
     }


### PR DESCRIPTION
## Related Issue

Closes https://github.com/naftiko/ikanos/issues/670

---

## What does this PR do?

1. Fixes 2 tests that assert against the list of logged records by using a log handler. The issue is that we use org.restlet.ext.slf4j.Slf4jLogger, which extends java.util.logging.Logger. We add a handler by calling java.util.logging.Logger::addHandler. Handlers are not getting called because org.restlet.ext.slf4j.Slf4jLogger overrides the java.util.logging.Logger::log without calling the handlers.
2. Add the 'org.restlet.engine.loggerFacadeClass=org.restlet.ext.slf4j.Slf4jLoggerFacade' so that tests behave the same locally and in CI pipelines

---

## Tests

ToolHandlerBinaryTest::handleToolCallShouldSkipOutputParametersAndLogForBinaryUpstream and RestBinaryResponseIntegrationTest::handleShouldSkipOutputParametersAndLogWhenResponseIsBinary now test against the appender of the underlying logback logger.

---

## Documentation

<!-- If this PR modifies github actions for example -->

- [ ] Update Notion documentation
- [ ] Ensure our internal technical documentation (specs, user docs, test docs) reflects the current implementation (no drift)

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main`
- [ ] Small and focused — one concern per PR
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

<!-- If this PR was created or assisted by an AI agent, provide metadata below (YAML) -->

```yaml
# agent_name:
# llm:
# tool:
# confidence:          # low | medium | high
# source_event:
# discovery_method:    # runtime_observation | code_review | test_failure | user_report
# review_focus:        # e.g. ClassName.java:line-range
```
