### PR TITLE
fix: use logback's appender list in tests instead of java.util.loggin…

### DIFF
--- a/modules/ikanos-engine/pom.xml
+++ b/modules/ikanos-engine/pom.xml
@@ -186,6 +186,9 @@
                 <configuration>
                     <systemPropertyVariables>
                         <microcks.image>${microcks.image}</microcks.image>
+                        <org.restlet.engine.loggerFacadeClass>
+                            org.restlet.ext.slf4j.Slf4jLoggerFacade
+                        </org.restlet.engine.loggerFacadeClass>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ToolHandlerBinaryTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ToolHandlerBinaryTest.java
@@ -13,37 +13,31 @@
  */
 package io.ikanos.engine.exposes.mcp;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.net.ServerSocket;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-import java.util.Map;
-
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.ikanos.Capability;
+import io.ikanos.spec.IkanosSpec;
+import io.ikanos.spec.exposes.mcp.McpServerSpec;
+import io.ikanos.spec.util.VersionHelper;
+import io.modelcontextprotocol.spec.McpSchema;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.restlet.Application;
-import org.restlet.Component;
-import org.restlet.Request;
-import org.restlet.Response;
-import org.restlet.Restlet;
+import org.restlet.*;
 import org.restlet.data.MediaType;
 import org.restlet.data.Protocol;
 import org.restlet.data.Status;
 import org.restlet.representation.ByteArrayRepresentation;
 import org.restlet.routing.Router;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
 
-import io.ikanos.Capability;
-import io.ikanos.spec.IkanosSpec;
-import io.ikanos.spec.exposes.mcp.McpServerSpec;
-import io.ikanos.spec.util.VersionHelper;
-import io.modelcontextprotocol.spec.McpSchema;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for the MCP tool binary-result branch (capability-binary-content.md §4.4 / §8.2, Phase 3).
@@ -200,16 +194,10 @@ public class ToolHandlerBinaryTest {
         Component upstream = createBinaryServer(port, JPEG_BYTES, MediaType.IMAGE_JPEG);
         upstream.start();
 
-        java.util.logging.Logger logger = org.restlet.Context.getCurrentLogger();
-        java.util.List<String> messages = new java.util.ArrayList<>();
-        java.util.logging.Handler captor = new java.util.logging.Handler() {
-            @Override public void publish(java.util.logging.LogRecord record) {
-                messages.add(record.getMessage());
-            }
-            @Override public void flush() { }
-            @Override public void close() { }
-        };
-        logger.addHandler(captor);
+        ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) ((org.restlet.ext.slf4j.Slf4jLogger) org.restlet.Context.getCurrentLogger()).getSlf4jLogger();
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
 
         try {
             ToolHandler handler =
@@ -225,12 +213,13 @@ public class ToolHandlerBinaryTest {
             assertEquals("image/jpeg", image.mimeType());
             assertEquals(Base64.getEncoder().encodeToString(JPEG_BYTES), image.data());
 
-            assertTrue(messages.stream().anyMatch(m ->
-                    m != null && m.contains("Skipping outputParameters mappings for tool 'get-photo'")),
-                    "expected an INFO log that outputParameters were skipped, got: " + messages);
+            assertTrue(appender.list.stream().anyMatch(m ->
+                    m != null && m.getFormattedMessage().contains("Skipping outputParameters mappings for tool 'get-photo'")),
+                    "expected an INFO log that outputParameters were skipped, got: " + appender.list.stream().map(ILoggingEvent::getFormattedMessage).toList());
         } finally {
-            logger.removeHandler(captor);
             upstream.stop();
+            logger.detachAppender(appender);
+            appender.stop();
         }
     }
 

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/rest/RestBinaryResponseIntegrationTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/rest/RestBinaryResponseIntegrationTest.java
@@ -13,26 +13,8 @@
  */
 package io.ikanos.engine.exposes.rest;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.net.ServerSocket;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.restlet.Application;
-import org.restlet.Component;
-import org.restlet.Request;
-import org.restlet.Response;
-import org.restlet.Restlet;
-import org.restlet.data.MediaType;
-import org.restlet.data.Method;
-import org.restlet.data.Protocol;
-import org.restlet.data.Status;
-import org.restlet.representation.ByteArrayRepresentation;
-import org.restlet.routing.Router;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -40,6 +22,19 @@ import io.ikanos.Capability;
 import io.ikanos.spec.IkanosSpec;
 import io.ikanos.spec.exposes.rest.RestServerSpec;
 import io.ikanos.spec.util.VersionHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.restlet.*;
+import org.restlet.data.MediaType;
+import org.restlet.data.Method;
+import org.restlet.data.Protocol;
+import org.restlet.data.Status;
+import org.restlet.representation.ByteArrayRepresentation;
+import org.restlet.routing.Router;
+
+import java.net.ServerSocket;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Integration tests for the REST binary-response runtime branch (capability-binary-content.md
@@ -125,16 +120,10 @@ public class RestBinaryResponseIntegrationTest {
         Component upstream = createBinaryServer(port, JPEG_BYTES, MediaType.IMAGE_JPEG);
         upstream.start();
 
-        java.util.logging.Logger logger = org.restlet.Context.getCurrentLogger();
-        java.util.List<String> messages = new java.util.ArrayList<>();
-        java.util.logging.Handler captor = new java.util.logging.Handler() {
-            @Override public void publish(java.util.logging.LogRecord record) {
-                messages.add(record.getMessage());
-            }
-            @Override public void flush() { }
-            @Override public void close() { }
-        };
-        logger.addHandler(captor);
+        ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) ((org.restlet.ext.slf4j.Slf4jLogger) org.restlet.Context.getCurrentLogger()).getSlf4jLogger();
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
 
         try {
             Capability capability =
@@ -146,12 +135,13 @@ public class RestBinaryResponseIntegrationTest {
             assertEquals("image/jpeg", response.getEntity().getMediaType().getName());
             assertArrayEquals(JPEG_BYTES, readBytes(response));
 
-            assertTrue(messages.stream().anyMatch(m ->
-                    m != null && m.contains("Skipping outputParameters mappings for REST operation")),
-                    "expected an INFO log that outputParameters were skipped, got: " + messages);
+            assertTrue(appender.list.stream().anyMatch(m ->
+                    m != null && m.getMessage().contains("Skipping outputParameters mappings for REST operation")),
+                    "expected an INFO log that outputParameters were skipped, got: " + appender.list.stream().map(ILoggingEvent::getFormattedMessage).toList());
         } finally {
-            logger.removeHandler(captor);
             upstream.stop();
+            logger.detachAppender(appender);
+            appender.stop();
         }
     }
 


### PR DESCRIPTION
## Related Issue

Closes https://github.com/naftiko/ikanos/issues/670

---

## What does this PR do?

1. Fixes 2 tests that assert against the list of logged records by using a log handler. The issue is that we use org.restlet.ext.slf4j.Slf4jLogger, which extends java.util.logging.Logger. We add a handler by calling java.util.logging.Logger::addHandler. Handlers are not getting called because org.restlet.ext.slf4j.Slf4jLogger overrides the java.util.logging.Logger::log without calling the handlers.
2. Add the 'org.restlet.engine.loggerFacadeClass=org.restlet.ext.slf4j.Slf4jLoggerFacade' so that tests behave the same locally and in CI pipelines

---

## Tests

ToolHandlerBinaryTest::handleToolCallShouldSkipOutputParametersAndLogForBinaryUpstream and RestBinaryResponseIntegrationTest::handleShouldSkipOutputParametersAndLogWhenResponseIsBinary now test against the appender of the underlying logback logger.

---

## Documentation

<!-- If this PR modifies github actions for example -->

- [ ] Update Notion documentation
- [ ] Ensure our internal technical documentation (specs, user docs, test docs) reflects the current implementation (no drift)

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

<!-- If this PR was created or assisted by an AI agent, provide metadata below (YAML) -->

```yaml
# agent_name:
# llm:
# tool:
# confidence:          # low | medium | high
# source_event:
# discovery_method:    # runtime_observation | code_review | test_failure | user_report
# review_focus:        # e.g. ClassName.java:line-range
```
