### PR TITLE
fix: disable dependabot for non-security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     labels:
       - dependencies
     groups:
@@ -17,6 +17,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     groups:
       all-actions:
         patterns:


### PR DESCRIPTION
## Related Issue

partially closes https://github.com/naftiko/ikanos/issues/665

---

## What does this PR do?

patching the dependabot.yaml in order to restrict Dependabots to security updates only now.

---

## Tests

<!-- Describe tests added or modified. If none, explain why. -->

---

## Documentation

<!-- If this PR modifies github actions for example -->

- [ ] Update Notion documentation
- [ ] Ensure our internal technical documentation (specs, user docs, test docs) reflects the current implementation (no drift)

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main`
- [ ] Small and focused — one concern per PR
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

