### PR TITLE
fix: handle the 204 no content responses

### DIFF
--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/ToolHandler.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/ToolHandler.java
@@ -15,6 +15,7 @@ package io.ikanos.engine.exposes.mcp;
 
 import java.io.IOException;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,6 +34,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Scope;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.restlet.representation.EmptyRepresentation;
 
 /**
  * Handles MCP tool calls by delegating to consumed HTTP operations.
@@ -274,8 +276,12 @@ public class ToolHandler {
         // Check for error status
         int statusCode = found.clientResponse.getStatus().getCode();
         boolean isError = statusCode >= 400;
+        boolean hasBody = found.clientResponse.getEntity() != null && !(found.clientResponse.getEntity() instanceof EmptyRepresentation);
 
-        if (found.clientResponse.getEntity() == null) {
+        if (!isError && !hasBody) {
+            return new McpSchema.CallToolResult(Collections.emptyList(),
+                    false, null, null);
+        } else if (!hasBody) {
             return new McpSchema.CallToolResult(
                     List.of(new McpSchema.TextContent(
                             "No response entity received (HTTP " + statusCode + " "

--- a/modules/ikanos-engine/src/test/java/io/ikanos/tutorial/AbstractShipyardMcpClientIntegrationTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/tutorial/AbstractShipyardMcpClientIntegrationTest.java
@@ -13,6 +13,7 @@
  */
 package io.ikanos.tutorial;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -28,6 +29,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import io.github.microcks.testcontainers.MicrocksContainer;
 import org.junit.jupiter.api.AfterAll;
@@ -204,6 +206,14 @@ abstract class AbstractShipyardMcpClientIntegrationTest {
      * JSON payload from {@code result.content[0].text}.
      */
     protected JsonNode callTool(HttpClient http, String sessionId, String body) throws Exception {
+        return doCallTool(http, sessionId, body, true).orElseThrow();
+    }
+
+    protected Optional<JsonNode> callTool(HttpClient http, String sessionId, String body, boolean contentExpected) throws Exception {
+        return doCallTool(http, sessionId, body, contentExpected);
+    }
+
+    private Optional<JsonNode> doCallTool(HttpClient http, String sessionId, String body, boolean contentExpected) throws IOException, InterruptedException {
         HttpResponse<String> response = http.send(buildPost(body, sessionId), string());
         assertEquals(200, response.statusCode());
 
@@ -214,9 +224,11 @@ abstract class AbstractShipyardMcpClientIntegrationTest {
                 "Tool must not return an error. Raw response: " + envelope.toPrettyString());
 
         JsonNode content = callResult.path("content");
-        assertTrue(content.isArray() && !content.isEmpty(), "result.content must be non-empty");
+        assertThat(content.isArray()).overridingErrorMessage(() -> "Expecting result.content to be an array").isTrue();
+        assertThat(content.isEmpty()).overridingErrorMessage(() -> "Expecting result.content to be %s, actual content: %s".formatted(contentExpected ?
+                "non-empty" : "empty", content.toPrettyString())).isEqualTo(!contentExpected);
 
-        return json.readTree(content.get(0).path("text").asText());
+        return contentExpected ? Optional.of(json.readTree(content.get(0).path("text").asText())) : Optional.empty();
     }
 
     protected HttpRequest buildPost(String body) {

--- a/modules/ikanos-engine/src/test/java/io/ikanos/tutorial/Step6ShipyardMcpClientIntegrationTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/tutorial/Step6ShipyardMcpClientIntegrationTest.java
@@ -13,11 +13,13 @@
  */
 package io.ikanos.tutorial;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.http.HttpClient;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -59,11 +61,12 @@ public class Step6ShipyardMcpClientIntegrationTest
 
         JsonNode tools = callToolsList(http, sessionId);
 
-        assertEquals(4, tools.size(), "step-6 exposes exactly four tools");
+        assertEquals(5, tools.size(), "step-6 exposes exactly five tools");
         assertEquals("list-ships",          tools.get(0).path("name").asText());
         assertEquals("get-ship",            tools.get(1).path("name").asText());
         assertEquals("list-legacy-vessels", tools.get(2).path("name").asText());
         assertEquals("create-voyage",       tools.get(3).path("name").asText());
+        assertEquals("refresh-crew",       tools.get(4).path("name").asText());
     }
 
     @Test
@@ -157,5 +160,23 @@ public class Step6ShipyardMcpClientIntegrationTest
         assertTrue(voyage.path("crewIds").size() > 0, "crewIds must not be empty");
         assertTrue(voyage.path("cargoIds").isArray(), "cargoIds must be an array");
         assertFalse(voyage.path("status").asText().isBlank(), "status must not be blank");
+    }
+
+    @Test
+    void refreshCrewShouldReturnEmptyResult() throws Exception {
+        // Given
+        HttpClient http = HttpClient.newHttpClient();
+        String sessionId = initialize(http);
+
+        // When
+        Optional<JsonNode> result = callTool(http, sessionId, """
+                {"jsonrpc":"2.0","id":4,"method":"tools/call",
+                 "params":{"name":"refresh-crew","arguments":{
+                   "imo_number":"IMO-9876543"
+                 }}}
+                """, false);
+
+        // Then
+        assertThat(result).isEmpty();
     }
 }

--- a/modules/ikanos-engine/src/test/resources/openapi/naftiko-shipyard-maritime-registry-api.yaml
+++ b/modules/ikanos-engine/src/test/resources/openapi/naftiko-shipyard-maritime-registry-api.yaml
@@ -183,6 +183,49 @@ paths:
                     error: "not_found"
                     message: "Ship with IMO number IMO-0000000 not found"
 
+  /ships/{imo_number}/crew:
+    post:
+      tags:
+        - Refresh crew
+      operationId: refresh-crew
+      summary: Refresh a ship's crew
+      description: >-
+        Refreshes the crew of a ship.
+      x-microcks-operation:
+        dispatcher: URI_PARTS
+        dispatcherRules: imo_number
+      parameters:
+        - name: imo_number
+          in: path
+          required: true
+          description: IMO number of the ship
+          schema:
+            type: string
+          examples:
+            "/imo_number=IMO-9321483":
+              value: "IMO-9321483"
+            "/imo_number=IMO-9456781":
+              value: "IMO-9456781"
+            "/imo_number=IMO-9876543":
+              value: "IMO-9876543"
+        - $ref: '#/components/parameters/RegistryVersion'
+      responses:
+        '204':
+          description: Crew refreshed successfully.
+          x-microcks-refs:
+            - "/imo_number=IMO-9876543"
+        '400':
+          description: Invalid vessel request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalidShip:
+                  value:
+                    error: "bad_request"
+                    message: "vessel_type must be one of: cargo, tanker, bulk_carrier, container, passenger"
+
   /voyages:
     post:
       tags:
@@ -539,6 +582,7 @@ components:
           example:
             - "CREW-001"
             - "CREW-003"
+
 
     CreateVoyageRequest:
       type: object

--- a/modules/ikanos-engine/src/test/resources/tutorial/shared/step6-registry-consumes.yaml
+++ b/modules/ikanos-engine/src/test/resources/tutorial/shared/step6-registry-consumes.yaml
@@ -20,6 +20,14 @@ consumes:
           inputParameters:
             status:
               in: query
+    ships-crew:
+      path: /ships/{{imo_number}}/crew
+      operations:
+        refresh-crew:
+          method: POST
+          inputParameters:
+            imo_number:
+              in: path
     ship:
       path: /ships/{{imo_number}}
       operations:

--- a/modules/ikanos-engine/src/test/resources/tutorial/step-6-shipyard-write-operations.yml
+++ b/modules/ikanos-engine/src/test/resources/tutorial/step-6-shipyard-write-operations.yml
@@ -212,5 +212,20 @@ capability:
             status:
               type: string
               mapping: "$.status"
+      refresh-crew:
+        description: "Refresh a ship's crew"
+        inputParameters:
+          imo_number:
+            type: string
+            required: true
+            description: "IMO identification number"
+        call: registry.refresh-crew
+        with:
+          imo_number: shipyard-tools.imo_number
+        hints:
+          readOnly: false
+          destructive: false
+          idempotent: false
+          openWorld: true
 
 


### PR DESCRIPTION
## Related Issue

Closes https://github.com/naftiko/ikanos/issues/685

---

## What does this PR do?

Handle the 204 No Content response in ikanos-engine

---

## Tests

Step6ShipyardMcpClientIntegrationTest::createShipShouldReturnEmptyResult was added to test the new behavior.

---

## Documentation

<!-- If this PR modifies github actions for example -->

- [ ] Update Notion documentation
- [ ] Ensure our internal technical documentation (specs, user docs, test docs) reflects the current implementation (no drift)

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main`
- [ ] Small and focused — one concern per PR
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

<!-- If this PR was created or assisted by an AI agent, provide metadata below (YAML) -->

```yaml
# agent_name:
# llm:
# tool:
# confidence:          # low | medium | high
# source_event:
# discovery_method:    # runtime_observation | code_review | test_failure | user_report
# review_focus:        # e.g. ClassName.java:line-range
```
