### PR TITLE
feat(e2e): testing e2e exposes oauth and bearer authentification

### DIFF
--- a/.github/e2e/resources/docker-compose.yml
+++ b/.github/e2e/resources/docker-compose.yml
@@ -1,0 +1,45 @@
+# Infrastructure-only compose for E2E tests.
+# Ikanos itself is NOT started here — it is launched per-feature by the
+# workflow orchestrator (e2e-feature-tests.yml) so each feature's capability
+# file can be injected cleanly without rebuilding the image.
+
+services:
+  microcks:
+    image: quay.io/microcks/microcks-uber:latest
+    container_name: e2e-microcks
+    ports:
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8080/api/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 18   # up to 90s
+    networks:
+      - e2e
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.1
+    container_name: e2e-keycloak
+    ports:
+      - "8180:8080"
+    # Throwaway credentials for an ephemeral container that exists only for the
+    # duration of a CI run and is never reachable from outside the runner.
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+    # Imports the E2E realm on first startup (e2e-test realm with a
+    # service-account client whose client_secret is "test-secret").
+    command: start-dev --import-realm
+    volumes:
+      - ./keycloak/realm-e2e.json:/opt/keycloak/data/import/realm-e2e.json
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8080/realms/e2e-test"]
+      interval: 5s
+      timeout: 5s
+      retries: 24   # up to 120s
+    networks:
+      - e2e
+
+networks:
+  e2e:
+    driver: bridge

--- a/.github/e2e/resources/features/_lib/helpers.sh
+++ b/.github/e2e/resources/features/_lib/helpers.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# helpers.sh — shared utilities sourced by every feature run.sh
+#
+# Expected env vars set by the workflow before sourcing:
+#   IKANOS_IMAGE      ghcr.io/naftiko/ikanos:latest
+#   IKANOS_CONTAINER  container name (unique per feature run)
+#   SECRETS_DIR       absolute path to .github/e2e/resources/shared
+#   KC_CLIENT_SECRET  Keycloak client secret (default: test-secret)
+#   MCP_SERVER_TOKEN  static fallback bearer token
+
+# ── Counters (accumulated across tests within one run.sh) ─────────────────────
+PASSED=0
+FAILED=0
+SKIPPED=0
+
+# ── Container lifecycle ────────────────────────────────────────────────────────
+cleanup_ikanos() {
+  docker stop "$IKANOS_CONTAINER" 2>/dev/null || true
+  docker rm   "$IKANOS_CONTAINER" 2>/dev/null || true
+}
+
+# start_ikanos CAPABILITY_FILE
+# Starts the Ikanos container. All exposed ports are reachable on the host
+# immediately via --network host — no -p mapping needed.
+# Follow with one assert_ready call per exposed surface.
+start_ikanos() {
+  local CAP_FILE="$1"
+  cleanup_ikanos
+  docker run -d \
+    --name "$IKANOS_CONTAINER" \
+    --network host \
+    -v "${CAP_FILE}:/app/test.capability.yaml" \
+    -v "${SECRETS_DIR}:/app/shared" \
+    "$IKANOS_IMAGE" \
+    serve /app/test.capability.yaml
+}
+
+# ── Internal readiness pollers (use assert_ready, not these directly) ──────────
+_wait_for_mcp() {
+  local PORT="$1"
+  local TOKEN="$2"
+  echo "  Waiting for MCP server on port $PORT..."
+  for j in $(seq 1 30); do
+    RESP=$(curl -s "http://localhost:$PORT" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer $TOKEN" \
+      -d '{"jsonrpc":"2.0","id":0,"method":"tools/list","params":{}}' \
+      2>/dev/null || true)
+    if echo "$RESP" | jq -e '.result.tools' > /dev/null 2>&1; then
+      echo "  MCP server is ready on port $PORT"; return 0
+    fi
+    sleep 2
+  done
+  echo "  MCP server on port $PORT did not become ready in time"; return 1
+}
+
+_wait_for_rest() {
+  local PORT="$1"
+  # NOT named PATH: that would shadow the shell's command-lookup path for the
+  # whole dynamic scope of this function, leaving curl and sleep below resolvable
+  # only through bash's command hash.
+  local ENDPOINT_PATH="${2:-/}"
+  echo "  Waiting for REST server on port $PORT..."
+  for j in $(seq 1 30); do
+    if curl -sf "http://localhost:$PORT$ENDPOINT_PATH" > /dev/null 2>&1; then
+      echo "  REST server is ready on port $PORT"; return 0
+    fi
+    sleep 2
+  done
+  echo "  REST server on port $PORT did not become ready in time"; return 1
+}
+
+# ── Startup ────────────────────────────────────────────────────────────────────
+
+# assert_ready TYPE PORT [TOKEN_OR_PATH]
+# Waits for one exposed port to be ready, exits 1 with docker logs on timeout.
+# Call once per exposed surface after start_ikanos.
+#
+#   TYPE  mcp   → polls tools/list with the bearer TOKEN (3rd arg)
+#         rest  → polls GET PORT/PATH (3rd arg, default "/")
+#
+# Examples:
+#   assert_ready mcp  3001 "$TOKEN"
+#   assert_ready rest 3001
+#   assert_ready rest 3001 "/health"
+assert_ready() {
+  local TYPE="$1"
+  local PORT="$2"
+  local ARG="${3:-}"
+
+  local OK=false
+  case "$TYPE" in
+    mcp)  _wait_for_mcp  "$PORT" "$ARG"      && OK=true ;;
+    rest) _wait_for_rest "$PORT" "${ARG:-/}" && OK=true ;;
+    *)    echo "  assert_ready: unknown type '$TYPE' (use mcp or rest)"; exit 1 ;;
+  esac
+
+  if [ "$OK" != "true" ]; then
+    echo "  FAIL: $TYPE port $PORT did not become ready"
+    docker logs "$IKANOS_CONTAINER"
+    cleanup_ikanos
+    exit 1
+  fi
+}
+
+# ── OAuth2 token minting ───────────────────────────────────────────────────────
+mint_token() {
+  curl -sf \
+    -d "grant_type=client_credentials" \
+    -d "client_id=ikanos-e2e" \
+    -d "client_secret=${KC_CLIENT_SECRET}" \
+    "http://localhost:8180/realms/e2e-test/protocol/openid-connect/token" \
+    | jq -r '.access_token'
+}
+
+# ── Test runners ───────────────────────────────────────────────────────────────
+
+# run_mcp_test NAME TOOL PORT ARGS VALID_TOKEN [JQ_VALIDATIONS...]
+# Calls tools/call, runs jq validations, increments PASSED/FAILED.
+run_mcp_test() {
+  local NAME="$1" TOOL="$2" PORT="$3" ARGS="$4" TOKEN="$5"
+  shift 5
+  local VALIDATIONS=("$@")
+
+  echo ""
+  echo "  Test: $NAME  (type: mcp, tool: $TOOL, port: $PORT)"
+
+  # `|| true` is required: run.sh scripts set -e, and a transient curl failure
+  # (connection refused, reset) would otherwise abort the whole script from
+  # inside this assignment, losing the run instead of counting one failed test.
+  local RESPONSE IS_ERROR DATA
+  RESPONSE=$(curl -s "http://localhost:$PORT" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $TOKEN" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"$TOOL\",\"arguments\":$ARGS}}" || true)
+
+  IS_ERROR=$(echo "$RESPONSE" | jq -r '.result.isError // false')
+  DATA=$(echo "$RESPONSE" | jq -r '.result.content[0].text // empty')
+
+  if [ "$IS_ERROR" = "true" ]; then
+    echo "  FAIL ✗ — tool returned an error: $DATA"
+    FAILED=$((FAILED + 1)); return
+  fi
+
+  if echo "$DATA" | head -c 1 | grep -q "<"; then
+    DATA=$(echo "$DATA" | jq -R .)
+  fi
+
+  if ! echo "$DATA" | jq . > /dev/null 2>&1; then
+    echo "  FAIL ✗ — invalid JSON. Raw: $RESPONSE"
+    FAILED=$((FAILED + 1)); return
+  fi
+
+  local RULE TEST_PASSED=true
+  for RULE in "${VALIDATIONS[@]}"; do
+    if ! echo "$DATA" | jq -e "$RULE" > /dev/null 2>&1; then
+      echo "  FAIL ✗ — validation failed: $RULE"
+      echo "    Data: $(echo "$DATA" | jq -c .)"
+      TEST_PASSED=false; break
+    fi
+  done
+
+  if [ "$TEST_PASSED" = "true" ]; then
+    echo "  PASS ✓ — $NAME"
+    PASSED=$((PASSED + 1))
+  else
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+# run_auth_test NAME TOOL PORT ARGS TOKEN EXPECTED_HTTP_STATUS
+# Sends a raw MCP request and asserts on HTTP status code only.
+run_auth_test() {
+  local NAME="$1" TOOL="$2" PORT="$3" ARGS="$4" TOKEN="$5" EXPECTED_STATUS="$6"
+
+  echo ""
+  echo "  Test: $NAME  (type: auth, tool: $TOOL, port: $PORT, expected: HTTP $EXPECTED_STATUS)"
+
+  # See run_mcp_test for why `|| true` is required here.
+  local HTTP_STATUS
+  HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    "http://localhost:$PORT" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $TOKEN" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"$TOOL\",\"arguments\":$ARGS}}" || true)
+
+  if [ "$HTTP_STATUS" = "$EXPECTED_STATUS" ]; then
+    echo "  PASS ✓ — $NAME (HTTP $HTTP_STATUS)"
+    PASSED=$((PASSED + 1))
+  else
+    echo "  FAIL ✗ — expected HTTP $EXPECTED_STATUS, got $HTTP_STATUS"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+# run_rest_test NAME METHOD PORT PATH BODY TOKEN EXPECTED_STATUS [JQ_VALIDATIONS...]
+# Makes a raw REST call, checks HTTP status, then optionally runs jq on the response body.
+# Pass "" for BODY on GET requests. Pass "" for TOKEN to send no Authorization header.
+run_rest_test() {
+  local NAME="$1" METHOD="$2" PORT="$3" ENDPOINT="$4" BODY="$5" TOKEN="$6" EXPECTED_STATUS="$7"
+  shift 7
+  local VALIDATIONS=("$@")
+
+  echo ""
+  echo "  Test: $NAME  (type: rest, $METHOD http://localhost:$PORT$ENDPOINT, expected: HTTP $EXPECTED_STATUS)"
+
+  local CURL_ARGS=(-s -o /tmp/rest_body -w "%{http_code}"
+    -X "$METHOD"
+    -H "Content-Type: application/json"
+    "http://localhost:$PORT$ENDPOINT")
+
+  # Written as `if` rather than `[ -n "$X" ] && ...`: as a top-level statement
+  # that form evaluates to 1 whenever the variable is empty, which under the
+  # `set -e` used by every run.sh aborts the script — on exactly the empty
+  # TOKEN and empty BODY this helper documents as supported.
+  if [ -n "$TOKEN" ]; then CURL_ARGS+=(-H "Authorization: Bearer $TOKEN"); fi
+  if [ -n "$BODY"  ]; then CURL_ARGS+=(-d "$BODY"); fi
+
+  # See run_mcp_test for why `|| true` is required here.
+  local HTTP_STATUS
+  HTTP_STATUS=$(curl "${CURL_ARGS[@]}" || true)
+  local DATA
+  DATA=$(cat /tmp/rest_body 2>/dev/null || true)
+
+  if [ "$HTTP_STATUS" != "$EXPECTED_STATUS" ]; then
+    echo "  FAIL ✗ — expected HTTP $EXPECTED_STATUS, got $HTTP_STATUS"
+    echo "    Body: $DATA"
+    FAILED=$((FAILED + 1)); return
+  fi
+
+  if [ "${#VALIDATIONS[@]}" -eq 0 ]; then
+    echo "  PASS ✓ — $NAME (HTTP $HTTP_STATUS)"
+    PASSED=$((PASSED + 1)); return
+  fi
+
+  if echo "$DATA" | head -c 1 | grep -q "<"; then
+    DATA=$(echo "$DATA" | jq -R .)
+  fi
+
+  local RULE TEST_PASSED=true
+  for RULE in "${VALIDATIONS[@]}"; do
+    if ! echo "$DATA" | jq -e "$RULE" > /dev/null 2>&1; then
+      echo "  FAIL ✗ — validation failed: $RULE"
+      echo "    Data: $(echo "$DATA" | jq -c .)"
+      TEST_PASSED=false; break
+    fi
+  done
+
+  if [ "$TEST_PASSED" = "true" ]; then
+    echo "  PASS ✓ — $NAME (HTTP $HTTP_STATUS)"
+    PASSED=$((PASSED + 1))
+  else
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+# ── Summary ────────────────────────────────────────────────────────────────────
+print_summary() {
+  echo ""
+  echo "  passed: $PASSED | failed: $FAILED | skipped: $SKIPPED"
+}

--- a/.github/e2e/resources/features/exposed-oauth2/capability.yml
+++ b/.github/e2e/resources/features/exposed-oauth2/capability.yml
@@ -1,0 +1,158 @@
+ikanos: "1.0.0-beta3"
+
+binds:
+- namespace: "registry-env"
+  description: "Maritime Registry API credentials and config."
+  location: "file:///app/shared/secrets.yaml"
+  keys:
+    REGISTRY_TOKEN: "registry-bearer-token"
+    REGISTRY_VERSION: "registry-api-version"
+- namespace: "bearer-env"
+  description: "Static bearer token for the MCP bearer-auth surface."
+  location: "file:///app/shared/secrets.yaml"
+  keys:
+    MCP_BEARER_TOKEN: "mcp-server-token"
+
+capability:
+  consumes:
+  - namespace: registry
+    type: http
+    baseUri: "http://localhost:8080/rest/naftiko-shipyard-maritime-registry-api/1.0.0-alpha2"
+    authentication:
+      type: bearer
+      token: "{{REGISTRY_TOKEN}}"
+    inputParameters:
+      Registry-Version:
+        in: header
+        value: "{{REGISTRY_VERSION}}"
+    resources:
+      ships:
+        path: "/ships"
+        operations:
+          list-ships:
+            method: GET
+            inputParameters:
+              status:
+                in: query
+      ship:
+        path: "/ships/{{imo_number}}"
+        operations:
+          get-ship:
+            method: GET
+            inputParameters:
+              imo_number:
+                in: path
+  exposes:
+  - type: mcp
+    address: "0.0.0.0"
+    port: 3001
+    namespace: shipyard-tools
+    # Real OAuth2.1 resource server: validates incoming JWTs via Keycloak JWKS.
+    # The engine auto-discovers the jwks_uri from:
+    #   http://localhost:8180/realms/e2e-test/.well-known/oauth-authorization-server
+    # `resource` is used as the expected `aud` claim in every JWT.
+    # NOTE: http:// is intentional for CI — the lint rule ikanos-oauth2-https-authserver
+    # only runs on modules/ikanos-docs/tutorial/** and does not cover .github/e2e/.
+    authentication:
+      type: oauth2
+      authorizationServerUri: "http://localhost:8180/realms/e2e-test"
+      resource: "http://ikanos-e2e"
+    description: "Shipyard MCP tools for fleet management"
+    tools:
+      list-ships:
+        description: "List ships in the shipyard, optionally filtered by status"
+        inputParameters:
+          status:
+            type: string
+            required: false
+            description: "Filter by operational status"
+        call: registry.list-ships
+        with:
+          status: shipyard-tools.status
+        outputParameters:
+        - type: array
+          mapping: "$."
+          items:
+            type: object
+            properties:
+              imo:
+                type: string
+                mapping: "$.imo_number"
+              name:
+                type: string
+                mapping: "$.vessel_name"
+              type:
+                type: string
+                mapping: "$.vessel_type"
+              flag:
+                type: string
+                mapping: "$.flag_code"
+              status:
+                type: string
+                mapping: "$.operational_status"
+      get-ship:
+        description: "Retrieve a ship's details by IMO number"
+        inputParameters:
+          imo:
+            type: string
+            required: true
+            description: "IMO number of the ship"
+        call: registry.get-ship
+        with:
+          imo_number: shipyard-tools.imo
+        outputParameters:
+        - type: object
+          properties:
+            imo:
+              type: string
+              mapping: "$.imo_number"
+            name:
+              type: string
+              mapping: "$.vessel_name"
+            type:
+              type: string
+              mapping: "$.vessel_type"
+            flag:
+              type: string
+              mapping: "$.flag_code"
+            status:
+              type: string
+              mapping: "$.operational_status"
+
+  # Second expose: same tools, static bearer token, port 3002.
+  # Tests that type: bearer authentication (401 on wrong token) works
+  # independently from the OAuth2/JWKS surface on port 3001.
+  - type: mcp
+    address: "0.0.0.0"
+    port: 3002
+    namespace: shipyard-tools-bearer
+    authentication:
+      type: bearer
+      token: "{{MCP_BEARER_TOKEN}}"
+    description: "Shipyard MCP tools — bearer-auth surface"
+    tools:
+      list-ships:
+        description: "List ships in the shipyard, optionally filtered by status"
+        inputParameters:
+          status:
+            type: string
+            required: false
+            description: "Filter by operational status"
+        call: registry.list-ships
+        with:
+          status: shipyard-tools-bearer.status
+        outputParameters:
+        - type: array
+          mapping: "$."
+          items:
+            type: object
+            properties:
+              imo:
+                type: string
+                mapping: "$.imo_number"
+              name:
+                type: string
+                mapping: "$.vessel_name"
+              status:
+                type: string
+                mapping: "$.operational_status"

--- a/.github/e2e/resources/features/exposed-oauth2/run.sh
+++ b/.github/e2e/resources/features/exposed-oauth2/run.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# run.sh — E2E tests for the exposed-oauth2 feature
+#
+# Called by the workflow with these env vars already set:
+#   IKANOS_IMAGE, IKANOS_CONTAINER, SECRETS_DIR, KC_CLIENT_SECRET, MCP_SERVER_TOKEN
+#
+# The workflow starts ikanos before calling this script and stops it after.
+# Exit code: 0 = all passed, 1 = at least one failure
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../_lib/helpers.sh
+source "$SCRIPT_DIR/../_lib/helpers.sh"
+
+OAUTH2_PORT=3001
+BEARER_PORT=3002
+
+echo "================================================================"
+echo "Feature: exposed-oauth2 (OAuth2.1 on :$OAUTH2_PORT + bearer on :$BEARER_PORT)"
+echo "================================================================"
+
+# ── 1. Obtain credentials ─────────────────────────────────────────────────────
+# OAuth2 port: two independent Keycloak JWTs
+VALID_TOKEN=$(mint_token)
+if [ -z "$VALID_TOKEN" ] || [ "$VALID_TOKEN" = "null" ]; then
+  echo "  FAIL: could not mint OAuth2.1 token from Keycloak"
+  exit 1
+fi
+echo "  VALID_TOKEN minted (Keycloak)"
+
+REFRESHED_TOKEN=$(mint_token)
+echo "  REFRESHED_TOKEN minted (independent JWT)"
+
+# Bearer port: static token. The workflow has already written it into
+# secrets.yaml before starting the container — do NOT write it here. Ikanos
+# resolves file:// binds once, synchronously, at capability construction
+# (BindingResolver.resolve), so a write issued after start_ikanos only lands in
+# time by luck of JVM startup being slower than sed.
+STATIC_TOKEN="${MCP_SERVER_TOKEN}"
+
+# ── 2. Wait for readiness ─────────────────────────────────────────────────────
+assert_ready mcp "$OAUTH2_PORT" "$VALID_TOKEN"
+assert_ready mcp "$BEARER_PORT" "$STATIC_TOKEN"
+
+# ── OAuth2.1 surface (port 3001) — JWKS validation ───────────────────────────
+run_mcp_test "oauth2-list-ships" "list-ships" "$OAUTH2_PORT" "{}" "$VALID_TOKEN" \
+  'type == "array"' \
+  'length > 0' \
+  '.[0] | has("imo")' \
+  '.[0] | has("name")' \
+  '.[0] | has("status")'
+
+run_mcp_test "oauth2-list-ships-filter-active" "list-ships" "$OAUTH2_PORT" '{"status":"active"}' "$VALID_TOKEN" \
+  'type == "array"' \
+  'length > 0' \
+  'all(.[]; .status == "active")'
+
+run_mcp_test "oauth2-get-ship" "get-ship" "$OAUTH2_PORT" '{"imo":"IMO-9321483"}' "$VALID_TOKEN" \
+  'type == "object"' \
+  'has("imo")' 'has("name")' 'has("type")' 'has("flag")' 'has("status")' \
+  '.imo == "IMO-9321483"'
+
+run_auth_test "oauth2-valid-token-200"     "list-ships" "$OAUTH2_PORT" "{}" "$VALID_TOKEN"               200
+run_auth_test "oauth2-refreshed-token-200" "list-ships" "$OAUTH2_PORT" "{}" "$REFRESHED_TOKEN"           200
+run_auth_test "oauth2-invalid-token-401"   "list-ships" "$OAUTH2_PORT" "{}" "this-is-not-a-valid-token"  401
+
+# ── Bearer surface (port 3002) — static token validation ─────────────────────
+run_auth_test "bearer-valid-token-200"   "list-ships" "$BEARER_PORT" "{}" "$STATIC_TOKEN"             200
+run_auth_test "bearer-invalid-token-401" "list-ships" "$BEARER_PORT" "{}" "this-is-not-a-valid-token"  401
+
+print_summary
+
+[ "$FAILED" -gt 0 ] && exit 1 || exit 0

--- a/.github/e2e/resources/keycloak/realm-e2e.json
+++ b/.github/e2e/resources/keycloak/realm-e2e.json
@@ -1,0 +1,44 @@
+{
+  "realm": "e2e-test",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "clients": [
+    {
+      "clientId": "ikanos-e2e",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "test-secret",
+      "serviceAccountsEnabled": true,
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "attributes": {
+        "access.token.lifespan": "300"
+      },
+      "protocolMappers": [
+        {
+          "name": "ikanos-e2e-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.custom.audience": "http://ikanos-e2e",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "clientId": "ikanos-resource-server",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "bearerOnly": true
+    }
+  ],
+  "roles": {
+    "realm": [],
+    "client": {}
+  }
+}

--- a/.github/e2e/resources/shared/secrets.yaml
+++ b/.github/e2e/resources/shared/secrets.yaml
@@ -1,0 +1,4 @@
+registry-bearer-token: "dummy-token"
+registry-api-version: "1.0.0-alpha2"
+dockyard-api-key: "dummy-dockyard-key"
+mcp-server-token: "placeholder"

--- a/.github/workflows/e2e-feature-tests.yml
+++ b/.github/workflows/e2e-feature-tests.yml
@@ -1,0 +1,151 @@
+name: E2E Feature Tests
+
+# ── Trigger decision ──────────────────────────────────────────────────────────
+# workflow_dispatch  → manual run on any branch (useful for pre-release checks)
+# workflow_call      → called by nightly-orchestrator or other parent workflows
+# schedule           → nightly at 02:00 UTC against the default branch
+#
+# Deliberately NOT on push/PR — this suite spins up a full Docker stack
+# (Microcks + Keycloak + Ikanos container) and can take several minutes.
+# Fast feedback on PRs is handled by validate-tuto-examples.yml; this suite
+# is the deeper, daily quality gate.
+on:
+  workflow_dispatch:
+  workflow_call:
+  schedule:
+    - cron: '0 2 * * *'
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  feature-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      # ── Checkout ─────────────────────────────────────────────────────────────
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # ── Tooling ──────────────────────────────────────────────────────────────
+      # jq is pre-installed on ubuntu-latest; no extra tooling needed.
+      # run.sh scripts use only bash, curl, jq, and docker.
+
+      # ── Start infrastructure (Microcks + Keycloak) ───────────────────────────
+      - name: Start infrastructure stack
+        run: |
+          docker compose \
+            -f .github/e2e/resources/docker-compose.yml \
+            up -d microcks keycloak
+        env:
+          COMPOSE_PROJECT_NAME: ikanos-e2e
+
+      - name: Wait for Microcks
+        run: |
+          echo "Waiting for Microcks..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8080/api/health > /dev/null; then
+              echo "Microcks is up"; break
+            fi
+            echo "  attempt $i/30 – retrying in 5s..."; sleep 5
+            [ "$i" -eq 30 ] && { docker compose -f .github/e2e/resources/docker-compose.yml logs microcks; exit 1; }
+          done
+
+      - name: Wait for Keycloak
+        run: |
+          echo "Waiting for Keycloak..."
+          for i in $(seq 1 36); do
+            if curl -sf http://localhost:8180/realms/e2e-test > /dev/null; then
+              echo "Keycloak is up"; break
+            fi
+            echo "  attempt $i/36 – retrying in 5s..."; sleep 5
+            [ "$i" -eq 36 ] && { docker compose -f .github/e2e/resources/docker-compose.yml logs keycloak; exit 1; }
+          done
+
+      - name: Import OpenAPI specs into Microcks
+        run: |
+          for file in modules/ikanos-engine/src/test/resources/openapi/*.yaml; do
+            echo "Importing $file"
+            curl -sf -X POST "http://localhost:8080/api/artifact/upload" \
+              -F "file=@$file" || { echo "Failed to import $file"; exit 1; }
+          done
+
+      # ── Pull Ikanos image ─────────────────────────────────────────────────────
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull Ikanos image
+        run: docker pull ghcr.io/naftiko/ikanos:latest
+
+      # ── Main loop ─────────────────────────────────────────────────────────────
+      # Each feature lives in its own subdirectory under features/.
+      # The directory contains:
+      #   capability.yml  — Ikanos capability config
+      #   run.sh          — tests only (start/stop is handled by this loop)
+      # The workflow starts ikanos, calls run.sh, then stops ikanos.
+      - name: Run E2E tests for each feature
+        env:
+          IKANOS_IMAGE: ghcr.io/naftiko/ikanos:latest
+          IKANOS_CONTAINER: ikanos-e2e-run
+          SECRETS_DIR: ${{ github.workspace }}/.github/e2e/resources/shared
+          KC_CLIENT_SECRET: ${{ secrets.KC_E2E_CLIENT_SECRET || 'test-secret' }}
+          MCP_SERVER_TOKEN: ${{ secrets.MCP_SERVER_TOKEN || 'sk-mcp-YYYYYYYYYYYY' }}
+        run: |
+          # shellcheck source=.github/e2e/resources/features/_lib/helpers.sh
+          source ".github/e2e/resources/features/_lib/helpers.sh"
+
+          FEATURES_DIR="${GITHUB_WORKSPACE}/.github/e2e/resources/features"
+          TOTAL_PASSED=0
+          TOTAL_FAILED=0
+
+          # ── Inject the bearer token once, before any container starts ─────────
+          # Ikanos resolves file:// binds once, synchronously, at capability
+          # construction (BindingResolver.resolve) — there is no re-read and no
+          # hot reload. A run.sh writing this file after start_ikanos would be
+          # racing the JVM, so the write has to happen here instead.
+          sed -i "s|mcp-server-token: .*|mcp-server-token: ${MCP_SERVER_TOKEN}|" \
+            "${SECRETS_DIR}/secrets.yaml"
+          grep -q "mcp-server-token: ${MCP_SERVER_TOKEN}" "${SECRETS_DIR}/secrets.yaml" \
+            || { echo "Failed to inject MCP_SERVER_TOKEN into secrets.yaml"; exit 1; }
+
+          for FEATURE_DIR in "$FEATURES_DIR"/*/; do
+            FEATURE_DIR="${FEATURE_DIR%/}"   # strip trailing slash from glob
+            [ -f "$FEATURE_DIR/run.sh" ] || continue
+            CAPABILITY_FILE="$FEATURE_DIR/capability.yml"
+            echo ""
+
+            # ── Start ikanos for this feature ──────────────────────────────────
+            start_ikanos "$CAPABILITY_FILE"
+
+            # ── Run the feature's test script (tests only) ─────────────────────
+            if bash "$FEATURE_DIR/run.sh"; then
+              TOTAL_PASSED=$((TOTAL_PASSED + 1))
+            else
+              TOTAL_FAILED=$((TOTAL_FAILED + 1))
+            fi
+
+            # ── Teardown: stop ikanos ──────────────────────────────────────────
+            cleanup_ikanos
+          done
+
+          echo ""
+          echo "================================================================"
+          echo "E2E overall — features passed: $TOTAL_PASSED | failed: $TOTAL_FAILED"
+          echo "================================================================"
+          [ "$TOTAL_FAILED" -gt 0 ] && exit 1 || true
+
+      # ── Teardown ──────────────────────────────────────────────────────────────
+      - name: Teardown infrastructure stack
+        if: always()
+        run: |
+          docker compose \
+            -f .github/e2e/resources/docker-compose.yml \
+            down --volumes --remove-orphans 2>/dev/null || true
+          docker rm -f ikanos-e2e-run 2>/dev/null || true
+        env:
+          COMPOSE_PROJECT_NAME: ikanos-e2e


### PR DESCRIPTION
## Related Issue

Closes https://github.com/naftiko/ikanos/issues/612

---

## What does this PR do?

Adds a full E2E test for feature-level testing of Ikanos capabilities. Infrastructure (Microcks + Keycloak) runs as a Docker Compose stack; Ikanos itself is started per feature by the workflow.

**The exposed-oauth2 feature (first test suite)**

1. Auth type: oauth2 real JWKS validation via Keycloak => list-ships, filter, get-ship, valid token ×2 (independent JWTs), invalid token (OAuth2.1 uses genuine JWKS auto-discovery (/.well-known/oauth-authorization-server) no static token comparison, any valid Keycloak JWT is accepted)
3. Auth type: bearer static token => valid token, invalid token

---

## Tests

https://github.com/naftiko/ikanos/actions/runs/30618053923

---

## Documentation

<!-- If this PR modifies github actions for example -->

- [ ] Update Notion documentation
- [ ] Ensure our internal technical documentation (specs, user docs, test docs) reflects the current implementation (no drift)

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main`
- [ ] Small and focused — one concern per PR
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

<!-- If this PR was created or assisted by an AI agent, provide metadata below (YAML) -->

```yaml
# agent_name:
# llm:
# tool:
# confidence:          # low | medium | high
# source_event:
# discovery_method:    # runtime_observation | code_review | test_failure | user_report
# review_focus:        # e.g. ClassName.java:line-range
```
