### PR TITLE
chore: migrate to MCP version 20260728

### DIFF
--- a/.github/workflows/validate-tuto-examples.yml
+++ b/.github/workflows/validate-tuto-examples.yml
@@ -131,11 +131,17 @@ jobs:
               RESPONSE=$(curl -s http://localhost:$PORT \
                 -H "Content-Type: application/json" \
                 -H "Authorization: Bearer $MCP_SERVER_TOKEN" \
+                -H "MCP-Protocol-Version: 2026-07-28" \
+                -H "Mcp-Method: tools/list" \
                 -d '{
                   "jsonrpc":"2.0",
                   "id":1,
                   "method":"tools/list",
-                  "params":{}
+                  "params": {
+                    "_meta": {
+                      "io.modelcontextprotocol/protocolVersion": "2026-07-28"
+                    }
+                  }
                 }' || true)
 
               if echo "$RESPONSE" | jq -e '.result.tools' > /dev/null 2>&1; then
@@ -177,13 +183,19 @@ jobs:
             RESPONSE=$(curl -s http://localhost:$PORT \
               -H "Content-Type: application/json" \
               -H "Authorization: Bearer $MCP_SERVER_TOKEN" \
+              -H "MCP-Protocol-Version: 2026-07-28" \
+              -H "Mcp-Method: tools/call" \
+              -H "Mcp-Name: $TOOL" \
               -d "{
                 \"jsonrpc\": \"2.0\",
                 \"id\": 1,
                 \"method\": \"tools/call\",
                 \"params\": {
                   \"name\": \"$TOOL\",
-                  \"arguments\": $ARGS
+                  \"arguments\": $ARGS,
+                  \"_meta\": {
+                      \"io.modelcontextprotocol/protocolVersion\": \"2026-07-28\"
+                  }
                 }
               }")
 

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/McpOAuth2Restlet.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/McpOAuth2Restlet.java
@@ -31,7 +31,7 @@ import io.ikanos.spec.consumes.http.OAuth2AuthenticationSpec;
 
 /**
  * MCP-specific OAuth 2.1 Restlet that extends {@link OAuth2AuthenticationRestlet} with
- * MCP 2025-11-25 protocol behavior:
+ * MCP protocol behavior:
  * <ul>
  *   <li>Auto-serves Protected Resource Metadata (RFC 9728) at the well-known path</li>
  *   <li>Includes {@code resource_metadata} URL in {@code WWW-Authenticate} headers</li>

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/McpServerAdapter.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/McpServerAdapter.java
@@ -13,18 +13,6 @@
  */
 package io.ikanos.engine.exposes.mcp;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.logging.Level;
-import org.restlet.Context;
-import org.restlet.Restlet;
-import org.restlet.routing.Router;
-import io.modelcontextprotocol.spec.McpSchema;
 import io.ikanos.Capability;
 import io.ikanos.engine.aggregates.AggregateFlow;
 import io.ikanos.engine.exposes.ServerAdapter;
@@ -33,6 +21,18 @@ import io.ikanos.spec.consumes.http.OAuth2AuthenticationSpec;
 import io.ikanos.spec.exposes.mcp.McpServerSpec;
 import io.ikanos.spec.exposes.mcp.McpServerToolSpec;
 import io.ikanos.spec.exposes.mcp.McpToolHintsSpec;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.restlet.Context;
+import org.restlet.Restlet;
+import org.restlet.routing.Router;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
 
 /**
  * MCP Server Adapter implementation.
@@ -107,16 +107,9 @@ public class McpServerAdapter extends ServerAdapter {
      */
     private void initHttpTransport(McpServerSpec serverSpec) {
         ProtocolDispatcher dispatcher = new ProtocolDispatcher(this);
-        Map<String, Boolean> activeSessions = new ConcurrentHashMap<>();
 
         Context context = new Context();
         context.getAttributes().put("dispatcher", dispatcher);
-        context.getAttributes().put("activeSessions", activeSessions);
-        if (getCapability().getSpec().getInfo() != null
-                && getCapability().getSpec().getInfo().getDisplay() != null) {
-            context.getAttributes().put("capabilityName",
-                    getCapability().getSpec().getInfo().getDisplay());
-        }
 
         Router router = new Router(context);
         router.attachDefault(McpServerResource.class);

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/McpServerResource.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/McpServerResource.java
@@ -1,11 +1,11 @@
 /**
  * Copyright 2025-2026 Naftiko
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -13,9 +13,16 @@
  */
 package io.ikanos.engine.exposes.mcp;
 
-import java.util.Map;
-import java.util.UUID;
-import java.util.logging.Level;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.ikanos.engine.exposes.mcp.handler.McpCallHandler;
+import io.ikanos.engine.exposes.mcp.model.DispatchResult;
+import io.ikanos.engine.exposes.mcp.model.JsonRpcCodeMapper;
+import io.ikanos.engine.exposes.mcp.model.JsonRpcError;
+import io.ikanos.engine.exposes.mcp.model.McpHeader;
+import org.restlet.data.Header;
 import org.restlet.data.MediaType;
 import org.restlet.data.Status;
 import org.restlet.representation.Representation;
@@ -24,133 +31,154 @@ import org.restlet.resource.Delete;
 import org.restlet.resource.Get;
 import org.restlet.resource.Post;
 import org.restlet.resource.ServerResource;
-import io.ikanos.engine.observability.OtelRestletBridge;
-import io.ikanos.engine.observability.TelemetryBootstrap;
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.context.Scope;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.restlet.util.Series;
+
+import java.util.Optional;
+import java.util.logging.Level;
+
+import static io.ikanos.engine.exposes.mcp.model.JsonRpcError.HEADER_MISMATCH;
+import static io.ikanos.engine.exposes.mcp.model.JsonRpcError.INTERNAL_ERROR;
+import static io.ikanos.engine.exposes.mcp.model.JsonRpcError.PARSE_ERROR;
+import static io.ikanos.engine.util.JsonRpcResponseBuilder.buildJsonRpcError;
 
 /**
  * Restlet ServerResource implementing the MCP Streamable HTTP transport protocol.
- * 
+ *
  * Handles a single endpoint supporting:
  * <ul>
  * <li>POST: JSON-RPC requests (initialize, tools/list, tools/call)</li>
  * <li>GET: SSE stream for server-initiated messages (returns 405 - not supported)</li>
- * <li>DELETE: Session termination</li>
+ * <li>DELETE: returns 405 - not supported, kept for backwards compatibility</li>
  * </ul>
- * 
+ *
  * Delegates protocol dispatch to {@link ProtocolDispatcher} and adds HTTP-specific concerns:
  * session management, HTTP status codes, content types.
  */
 public class McpServerResource extends ServerResource {
-
-    private static final String HEADER_MCP_SESSION_ID = "Mcp-Session-Id";
 
     @Post("json")
     public Representation handlePost(Representation entity) {
         ProtocolDispatcher dispatcher = getDispatcher();
         ObjectMapper mapper = dispatcher.getMapper();
 
-        // Extract W3C trace context from incoming HTTP headers so downstream
-        // spans (tools/call) are linked to the caller's trace.
-        io.opentelemetry.context.Context extractedContext =
-                OtelRestletBridge.extractContext(getRequest());
-
-        try (Scope ignored = extractedContext.makeCurrent()) {
-            return dispatchWithTraceContext(dispatcher, mapper, entity, extractedContext);
-        }
-    }
-
-    private Representation dispatchWithTraceContext(ProtocolDispatcher dispatcher,
-            ObjectMapper mapper, Representation entity,
-            io.opentelemetry.context.Context extractedContext) {
         try {
             String body = (entity != null) ? entity.getText() : null;
 
             if (body == null || body.isBlank()) {
                 getLogger().log(Level.WARNING,
                         "Error processing request. Missing or empty body");
-                ObjectNode error = dispatcher.buildJsonRpcError(null, -32700,
+                ObjectNode error = buildJsonRpcError(null, PARSE_ERROR.getCode(),
                         "Parse error: empty body");
+                setStatusCode(PARSE_ERROR);
                 return toJsonRepresentation(mapper, error);
             }
 
             JsonNode root = mapper.readTree(body);
-            String rpcMethod = root.path("method").asText("");
-
-            // Handle initialize specially — create the session
-            if ("initialize".equals(rpcMethod)) {
-                String sessionId = UUID.randomUUID().toString();
-                getActiveSessions().put(sessionId, true);
-                getResponse().getHeaders().set(HEADER_MCP_SESSION_ID, sessionId);
+            Series<Header> headers = getRequest().getHeaders();
+            Optional<String> error = validateHeaders(headers, root);
+            if (error.isPresent()) {
+                setStatusCode(HEADER_MISMATCH);
+                return toJsonRepresentation(mapper, buildJsonRpcError(root.get("id"), HEADER_MISMATCH.getCode(), error.get()));
             }
 
-            // Handle notifications/initialized — return 202 with no body
-            if ("notifications/initialized".equals(rpcMethod)) {
+            // Extract W3C trace context (params._meta takes precedence over the inbound HTTP
+            // traceparent header — see McpMetaTraceContextBridge), create the SERVER span,
+            // populate MDC, and delegate to the shared protocol dispatcher.
+            DispatchResult result = dispatcher.dispatchWithTracing(root, getRequest());
+            if (result.isOnError()) {
+                setStatusCode(result.rpcError());
+            }
+
+            if (result.responseBody() != null) {
+                return toJsonRepresentation(mapper, result.responseBody());
+            } else {
+                // Notification — no response body
                 setStatus(Status.SUCCESS_ACCEPTED);
                 return new StringRepresentation("");
             }
-
-            // Create a SERVER span for the inbound MCP request
-            String capabilityName = (String) getContext().getAttributes().get("capabilityName");
-            Span span = TelemetryBootstrap.get().startServerSpan("mcp", rpcMethod,
-                    extractedContext, null, capabilityName);
-            try (Scope scope = span.makeCurrent()) {
-                TelemetryBootstrap.populateMdc(span);
-                // Delegate to the shared protocol dispatcher
-                ObjectNode result = dispatcher.dispatch(root);
-
-                if (result != null) {
-                    return toJsonRepresentation(mapper, result);
-                } else {
-                    // Notification — no response body
-                    setStatus(Status.SUCCESS_ACCEPTED);
-                    return new StringRepresentation("");
-                }
-            } catch (Exception e) {
-                TelemetryBootstrap.recordError(span, e);
-                throw e;
-            } finally {
-                TelemetryBootstrap.clearMdc();
-                TelemetryBootstrap.endSpan(span);
-            }
-
         } catch (JsonProcessingException e) {
             getLogger().log(Level.SEVERE, "Error processing request", e);
-            ObjectNode error = dispatcher.buildJsonRpcError(null, -32700,
+            setStatusCode(PARSE_ERROR);
+            ObjectNode error = buildJsonRpcError(null, PARSE_ERROR.getCode(),
                     "Parse error: " + e.getMessage());
             try {
                 return toJsonRepresentation(mapper, error);
             } catch (Exception ex) {
-                setStatus(Status.SERVER_ERROR_INTERNAL);
+                setStatusCode(INTERNAL_ERROR);
                 return new StringRepresentation("Internal server error", MediaType.TEXT_PLAIN);
             }
         } catch (Exception e) {
             getLogger().log(Level.SEVERE, "Error processing request", e);
-            ObjectNode error = dispatcher.buildJsonRpcError(null, -32603,
+            setStatusCode(INTERNAL_ERROR);
+            ObjectNode error = buildJsonRpcError(null, INTERNAL_ERROR.getCode(),
                     "Internal error: " + e.getMessage());
             try {
                 return toJsonRepresentation(mapper, error);
             } catch (Exception ex) {
-                setStatus(Status.SERVER_ERROR_INTERNAL);
                 return new StringRepresentation("Internal server error", MediaType.TEXT_PLAIN);
             }
         }
     }
 
+    /**
+     * Sets the HTTP status based on the JsonRpc error.
+     * @param rpcError the {@link JsonRpcError}.
+     */
+    private void setStatusCode(JsonRpcError rpcError) {
+        int httpStatus = JsonRpcCodeMapper.getHttpStatusCodeOfJsonRpcCode(rpcError);
+        if (httpStatus != -1) {
+            setStatus(Status.valueOf(httpStatus));
+        }
+    }
+
+    private Optional<String> validateHeaders(Series<Header> headers, JsonNode requestBody) {
+        // 1. Validate the presence of the mandatory headers
+        // The Mcp-Method is required on all requests and allows us to get the mandatory headers for the relevant method
+        String mcpMethod = McpHeader.MCP_METHOD.getHeaderValue(headers);
+        Optional<String> error = validateHeader(McpHeader.MCP_METHOD, mcpMethod, headers, requestBody);
+        if (error.isPresent()) {
+            return error;
+        }
+
+        McpCallHandler methodHandler = getDispatcher().getMethodHandler(mcpMethod);
+        if (methodHandler != null) { // The absence of a handler will be handled by the dispatcher
+            for (var header : methodHandler.getRequiredHeaders()) {
+                try {
+                    Optional<String> header1 = validateHeader(header, mcpMethod, headers, requestBody);
+                    if (header1.isPresent()) {
+                        return header1;
+                    }
+                } catch (IllegalArgumentException ignored) {
+                    return Optional.of("The value of the header %s contains invalid characters".formatted(header.getHeaderName()));
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private Optional<String> validateHeader(McpHeader header,
+                                            String mcpMethod,
+                                            Series<Header> headers,
+                                            JsonNode requestBody) {
+        String headerValue = header.getHeaderValue(headers);
+        if (headerValue == null) {
+            return Optional.of("Missing mandatory header: " + header.getHeaderName());
+        } else {
+            String bodyValue = header.extractValueFromRequestBody(mcpMethod, requestBody);
+            if (!headerValue.equals(bodyValue)) {
+                return Optional.of("Header mismatch: %s header value '%s' does not match body value '%s'".formatted(header.getHeaderName(),
+                        headerValue, bodyValue));
+            }
+        }
+
+        return Optional.empty();
+    }
+
     @Delete
     public Representation handleDelete() {
-        String sessionId =
-                getRequest().getHeaders().getFirstValue(HEADER_MCP_SESSION_ID);
-        if (sessionId != null) {
-            getActiveSessions().remove(sessionId);
-        }
-        setStatus(Status.SUCCESS_OK);
-        return emptyOkRepresentation();
+        setStatus(Status.CLIENT_ERROR_METHOD_NOT_ALLOWED);
+        return new StringRepresentation("DELETE not supported", MediaType.TEXT_PLAIN);
     }
 
     @Get
@@ -159,28 +187,8 @@ public class McpServerResource extends ServerResource {
         return new StringRepresentation("GET not supported", MediaType.TEXT_PLAIN);
     }
 
-    /**
-     * Returns a representation that Restlet treats as available (preventing auto-204 adjustment)
-     * while carrying no meaningful content. This preserves HTTP 200 for DELETE responses,
-     * matching the original Jetty transport behavior.
-     */
-    private Representation emptyOkRepresentation() {
-        StringRepresentation repr = new StringRepresentation("", MediaType.APPLICATION_JSON) {
-            @Override
-            public boolean isAvailable() {
-                return true;
-            }
-        };
-        return repr;
-    }
-
     private ProtocolDispatcher getDispatcher() {
         return (ProtocolDispatcher) getContext().getAttributes().get("dispatcher");
-    }
-
-    @SuppressWarnings("unchecked")
-    private Map<String, Boolean> getActiveSessions() {
-        return (Map<String, Boolean>) getContext().getAttributes().get("activeSessions");
     }
 
     private Representation toJsonRepresentation(ObjectMapper mapper, ObjectNode body)

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/ProtocolDispatcher.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/ProtocolDispatcher.java
@@ -1,11 +1,11 @@
 /**
  * Copyright 2025-2026 Naftiko
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -13,439 +13,181 @@
  */
 package io.ikanos.engine.exposes.mcp;
 
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Level;
-import org.restlet.Context;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.modelcontextprotocol.spec.McpSchema;
-import io.ikanos.spec.exposes.mcp.McpPromptArgumentSpec;
-import io.ikanos.spec.exposes.mcp.McpServerPromptSpec;
-import io.ikanos.spec.exposes.mcp.McpServerResourceSpec;
+import io.ikanos.engine.exposes.mcp.handler.McpCallHandler;
+import io.ikanos.engine.exposes.mcp.handler.McpCallHandlersFactory;
+import io.ikanos.engine.exposes.mcp.model.DispatchResult;
+import io.ikanos.engine.exposes.mcp.model.HandlerFailureResult;
+import io.ikanos.engine.exposes.mcp.model.HandlerSuccessResult;
+import io.ikanos.engine.exposes.mcp.model.HandlerResult;
+import io.ikanos.engine.exposes.mcp.processor.DispatchPostProcessor;
+import io.ikanos.engine.exposes.mcp.processor.DispatchPreProcessor;
+import io.ikanos.engine.observability.McpMetaTraceContextBridge;
+import io.ikanos.engine.observability.TelemetryBootstrap;
+import io.ikanos.exception.ProcessorException;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import org.restlet.Request;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+
+import static io.ikanos.engine.exposes.mcp.model.JsonRpcError.INTERNAL_ERROR;
+import static io.ikanos.engine.exposes.mcp.model.JsonRpcError.INVALID_REQUEST;
+import static io.ikanos.engine.exposes.mcp.model.JsonRpcError.METHOD_NOT_FOUND;
+import static io.ikanos.engine.util.JsonRpcResponseBuilder.buildJsonRpcError;
+import static org.restlet.Context.getCurrentLogger;
 
 /**
  * Transport-agnostic MCP JSON-RPC protocol dispatcher.
- * 
- * Handles MCP protocol methods (initialize, tools/list, tools/call, resources/list,
+ *
+ * Handles MCP protocol methods (tools/list, tools/call, resources/list,
  * resources/read, resources/templates/list, prompts/list, prompts/get, ping)
  * and produces JSON-RPC response envelopes. Used by both the Streamable HTTP
  * handler and the stdio handler.
  */
 public class ProtocolDispatcher {
 
-    static final String JSONRPC_VERSION = "2.0";
-    static final String MCP_PROTOCOL_VERSION = "2025-11-25";
+    public static final String JSONRPC_VERSION = "2.0";
+    public static final String MCP_PROTOCOL_VERSION = "2026-07-28";
 
-    private final McpServerAdapter adapter;
     private final ObjectMapper mapper;
+    private final Map<String, McpCallHandler> mcpHandlers = new HashMap<>();
+    private final String capabilityName;
 
     public ProtocolDispatcher(McpServerAdapter adapter) {
-        this.adapter = adapter;
         this.mapper = new ObjectMapper();
+        this.capabilityName = resolveCapabilityName(adapter);
+        for (McpCallHandler handler : McpCallHandlersFactory.createAll(adapter)) {
+            mcpHandlers.put(handler.getMethodName(), handler);
+        }
     }
 
     /**
-     * Dispatch a JSON-RPC request and return the response envelope.
-     * 
-     * @param request the parsed JSON-RPC request
-     * @return the JSON-RPC response envelope, or {@code null} for notifications
+     * Resolves the capability's display name, or {@code null} when absent. Used to tag the
+     * SERVER span created by each transport (Streamable HTTP reads it from the Restlet
+     * {@code Context} attributes instead; stdio has no such context, so it reads it here).
      */
-    public ObjectNode dispatch(JsonNode request) {
+    private static String resolveCapabilityName(McpServerAdapter adapter) {
+        if (adapter.getCapability().getSpec().getInfo() != null
+                && adapter.getCapability().getSpec().getInfo().getDisplay() != null) {
+            return adapter.getCapability().getSpec().getInfo().getDisplay();
+        }
+        return null;
+    }
+
+    /**
+     * Dispatch a JSON-RPC request and return the dispatch result.
+     *
+     * @param request the parsed JSON-RPC request.
+     * @return the JSON-RPC response envelope + rpcError wrapped in a {@link DispatchResult}.
+     */
+    public DispatchResult dispatch(JsonNode request) {
         if (request == null) {
-            return buildJsonRpcError(null, -32600, "Invalid Request: request body is missing");
+            return new DispatchResult(buildJsonRpcError(null, INVALID_REQUEST.getCode(),
+                    "Invalid Request: request body is missing"), INVALID_REQUEST);
         }
 
         try {
-            String jsonrpc = request.path("jsonrpc").asText("");
             JsonNode idNode = request.get("id");
             String rpcMethod = request.path("method").asText("");
-            JsonNode params = request.get("params");
 
-            if (!JSONRPC_VERSION.equals(jsonrpc)) {
-                return buildJsonRpcError(idNode, -32600,
-                        "Invalid Request: jsonrpc must be '2.0'");
-            }
-
-            switch (rpcMethod) {
-                case "initialize":
-                    return handleInitialize(idNode);
-
-                case "notifications/initialized":
-                    // Notification — no response
-                    return null;
-
-                case "tools/list":
-                    return handleToolsList(idNode);
-
-                case "tools/call":
-                    return handleToolsCall(idNode, params);
-
-                case "resources/list":
-                    return handleResourcesList(idNode);
-
-                case "resources/read":
-                    return handleResourcesRead(idNode, params);
-
-                case "resources/templates/list":
-                    return handleResourcesTemplatesList(idNode);
-
-                case "prompts/list":
-                    return handlePromptsList(idNode);
-
-                case "prompts/get":
-                    return handlePromptsGet(idNode, params);
-
-                case "ping":
-                    return buildJsonRpcResult(idNode, mapper.createObjectNode());
-
-                default:
-                    return buildJsonRpcError(idNode, -32601,
-                            "Method not found: " + rpcMethod);
-            }
-        } catch (Exception e) {
-            Context.getCurrentLogger().log(Level.SEVERE, "Error processing request", e);
-            return buildJsonRpcError(null, -32603, "Internal error: " + e.getMessage());
-        }
-    }
-
-    /**
-     * Handle MCP initialize request.
-     */
-    private ObjectNode handleInitialize(JsonNode id) {
-        ObjectNode result = mapper.createObjectNode();
-        result.put("protocolVersion", MCP_PROTOCOL_VERSION);
-
-        // Conditionally advertise capabilities based on what is declared in the spec
-        ObjectNode capabilities = mapper.createObjectNode();
-        capabilities.putObject("tools");
-        if (!adapter.getMcpServerSpec().getResources().isEmpty()) {
-            capabilities.putObject("resources");
-        }
-        if (!adapter.getMcpServerSpec().getPrompts().isEmpty()) {
-            capabilities.putObject("prompts");
-        }
-        result.set("capabilities", capabilities);
-
-        // Server info
-        ObjectNode serverInfo = mapper.createObjectNode();
-        serverInfo.put("name", adapter.getMcpServerSpec().getNamespace());
-        serverInfo.put("version", "1.0.0");
-        result.set("serverInfo", serverInfo);
-
-        // Instructions from the spec description
-        if (adapter.getMcpServerSpec().getDescription() != null) {
-            result.put("instructions", adapter.getMcpServerSpec().getDescription());
-        }
-
-        return buildJsonRpcResult(id, result);
-    }
-
-    /**
-     * Handle tools/list request.
-     */
-    private ObjectNode handleToolsList(JsonNode id) {
-        ObjectNode result = mapper.createObjectNode();
-        ArrayNode toolsArray = result.putArray("tools");
-        Map<String, String> labels = adapter.getToolLabels();
-
-        for (McpSchema.Tool tool : adapter.getTools()) {
-            ObjectNode toolNode = mapper.createObjectNode();
-            toolNode.put("name", tool.name());
-
-            String title = labels.get(tool.name());
-            if (title != null) {
-                toolNode.put("title", title);
-            }
-
-            if (tool.description() != null) {
-                toolNode.put("description", tool.description());
-            }
-
-            if (tool.inputSchema() != null) {
-                toolNode.set("inputSchema", mapper.valueToTree(tool.inputSchema()));
-            }
-
-            if (tool.annotations() != null) {
-                ObjectNode annotationsNode = mapper.createObjectNode();
-                McpSchema.ToolAnnotations ann = tool.annotations();
-                if (ann.title() != null) {
-                    annotationsNode.put("title", ann.title());
+            McpCallHandler callHandler = mcpHandlers.get(rpcMethod);
+            if (callHandler != null) {
+                for (DispatchPreProcessor preProcessor : callHandler.getPreProcessors()) {
+                    preProcessor.apply(request);
                 }
-                if (ann.readOnlyHint() != null) {
-                    annotationsNode.put("readOnlyHint", ann.readOnlyHint());
-                }
-                if (ann.destructiveHint() != null) {
-                    annotationsNode.put("destructiveHint", ann.destructiveHint());
-                }
-                if (ann.idempotentHint() != null) {
-                    annotationsNode.put("idempotentHint", ann.idempotentHint());
-                }
-                if (ann.openWorldHint() != null) {
-                    annotationsNode.put("openWorldHint", ann.openWorldHint());
-                }
-                if (!annotationsNode.isEmpty()) {
-                    toolNode.set("annotations", annotationsNode);
-                }
-            }
 
-            toolsArray.add(toolNode);
-        }
+                HandlerResult result = callHandler.handle(request);
 
-        return buildJsonRpcResult(id, result);
-    }
-
-    /**
-     * Handle tools/call request.
-     */
-    @SuppressWarnings("unchecked")
-    private ObjectNode handleToolsCall(JsonNode id, JsonNode params) {
-        if (params == null) {
-            return buildJsonRpcError(id, -32602, "Invalid params: missing params");
-        }
-
-        String toolName = params.path("name").asText("");
-        JsonNode argumentsNode = params.get("arguments");
-
-        try {
-            Map<String, Object> arguments = argumentsNode != null
-                    ? mapper.treeToValue(argumentsNode, Map.class)
-                    : new ConcurrentHashMap<>();
-            McpSchema.CallToolResult toolResult =
-                    adapter.getToolHandler().handleToolCall(toolName, arguments);
-            ObjectNode result = mapper.valueToTree(toolResult);
-            return buildJsonRpcResult(id, result);
-        } catch (IllegalArgumentException e) {
-            Context.getCurrentLogger().log(Level.SEVERE, "Error handling tools call", e);
-            return buildJsonRpcError(id, -32602, "Invalid params: " + e.getMessage());
-        } catch (Exception e) {
-            Context.getCurrentLogger().log(Level.SEVERE, "Error handling tools call", e);
-            // Tool execution error — return as a tool result with isError=true
-            ObjectNode result = mapper.createObjectNode();
-            ArrayNode content = result.putArray("content");
-            ObjectNode textContent = content.addObject();
-            textContent.put("type", "text");
-            textContent.put("text", "Error: " + e.getMessage());
-            result.put("isError", true);
-            return buildJsonRpcResult(id, result);
-        }
-    }
-
-    /**
-     * Handle resources/list request.
-     */
-    private ObjectNode handleResourcesList(JsonNode id) {
-        ObjectNode result = mapper.createObjectNode();
-        ArrayNode resourcesArray = result.putArray("resources");
-
-        for (Map<String, String> entry : adapter.getResourceHandler().listAll()) {
-            ObjectNode node = mapper.createObjectNode();
-            node.put("uri", entry.get("uri"));
-            node.put("name", entry.get("name"));
-            String title = entry.get("display");
-            if (title != null) {
-                node.put("title", title);
-            }
-            String description = entry.get("description");
-            if (description != null) {
-                node.put("description", description);
-            }
-            String mimeType = entry.get("mimeType");
-            if (mimeType != null) {
-                node.put("mimeType", mimeType);
-            }
-            resourcesArray.add(node);
-        }
-
-        return buildJsonRpcResult(id, result);
-    }
-
-    /**
-     * Handle resources/read request.
-     */
-    private ObjectNode handleResourcesRead(JsonNode id, JsonNode params) {
-        if (params == null) {
-            return buildJsonRpcError(id, -32602, "Invalid params: missing params");
-        }
-        String uri = params.path("uri").asText("");
-        if (uri.isEmpty()) {
-            return buildJsonRpcError(id, -32602, "Invalid params: uri is required");
-        }
-
-        try {
-            List<ResourceHandler.ResourceContent> contents =
-                    adapter.getResourceHandler().read(uri);
-            ObjectNode result = mapper.createObjectNode();
-            ArrayNode contentsArray = result.putArray("contents");
-            for (ResourceHandler.ResourceContent c : contents) {
-                ObjectNode contentNode = mapper.createObjectNode();
-                contentNode.put("uri", c.uri);
-                if (c.mimeType != null) {
-                    contentNode.put("mimeType", c.mimeType);
-                }
-                if (c.blob != null) {
-                    contentNode.put("blob", c.blob);
-                } else {
-                    contentNode.put("text", c.text != null ? c.text : "");
-                }
-                contentsArray.add(contentNode);
-            }
-            return buildJsonRpcResult(id, result);
-        } catch (IllegalArgumentException e) {
-            Context.getCurrentLogger().log(Level.SEVERE, "Error handling resources/read", e);
-            return buildJsonRpcError(id, -32602, "Invalid params: " + e.getMessage());
-        } catch (Exception e) {
-            Context.getCurrentLogger().log(Level.SEVERE, "Error handling resources/read", e);
-            return buildJsonRpcError(id, -32603, "Internal error: " + e.getMessage());
-        }
-    }
-
-    /**
-     * Handle resources/templates/list request.
-     */
-    private ObjectNode handleResourcesTemplatesList(JsonNode id) {
-        ObjectNode result = mapper.createObjectNode();
-        ArrayNode templatesArray = result.putArray("resourceTemplates");
-
-        for (McpServerResourceSpec spec : adapter.getResourceHandler().listTemplates()) {
-            ObjectNode node = mapper.createObjectNode();
-            node.put("uriTemplate", spec.getUri());
-            node.put("name", spec.getName());
-            if (spec.getDisplay() != null) {
-                node.put("title", spec.getDisplay());
-            }
-            if (spec.getDescription() != null) {
-                node.put("description", spec.getDescription());
-            }
-            if (spec.getMimeType() != null) {
-                node.put("mimeType", spec.getMimeType());
-            }
-            templatesArray.add(node);
-        }
-
-        return buildJsonRpcResult(id, result);
-    }
-
-    /**
-     * Handle prompts/list request.
-     */
-    private ObjectNode handlePromptsList(JsonNode id) {
-        ObjectNode result = mapper.createObjectNode();
-        ArrayNode promptsArray = result.putArray("prompts");
-
-        for (McpServerPromptSpec spec : adapter.getPromptHandler().listAll()) {
-            ObjectNode promptNode = mapper.createObjectNode();
-            promptNode.put("name", spec.getName());
-            if (spec.getDisplay() != null) {
-                promptNode.put("title", spec.getDisplay());
-            }
-            if (spec.getDescription() != null) {
-                promptNode.put("description", spec.getDescription());
-            }
-            if (!spec.getArguments().isEmpty()) {
-                ArrayNode argsArray = promptNode.putArray("arguments");
-                for (McpPromptArgumentSpec arg : spec.getArguments().values()) {
-                    ObjectNode argNode = mapper.createObjectNode();
-                    argNode.put("name", arg.getName());
-                    if (arg.getDisplay() != null) {
-                        argNode.put("title", arg.getDisplay());
+                switch (result) {
+                    case HandlerFailureResult failureResult -> {
+                        // In case of failure, the response's body is already complete, we simply return it
+                        return new DispatchResult(failureResult.body(), failureResult.rpcError());
                     }
-                    if (arg.getDescription() != null) {
-                        argNode.put("description", arg.getDescription());
+                    case HandlerSuccessResult successResult -> {
+                        ObjectNode rpcResponse = mapper.createObjectNode();
+                        rpcResponse.put("jsonrpc", JSONRPC_VERSION);
+
+                        if (idNode != null) {
+                            rpcResponse.set("id", idNode);
+                        }
+                        rpcResponse.set("result", successResult.result());
+
+                        for (DispatchPostProcessor postProcessor : callHandler.getPostProcessors()) {
+                            postProcessor.apply(rpcResponse);
+                        }
+
+                        return new DispatchResult(rpcResponse);
                     }
-                    argNode.put("required", arg.isRequired());
-                    argsArray.add(argNode);
                 }
+            } else {
+                return new DispatchResult(buildJsonRpcError(idNode, METHOD_NOT_FOUND.getCode(),
+                        "Method not found: " + rpcMethod), METHOD_NOT_FOUND);
             }
-            promptsArray.add(promptNode);
-        }
-
-        return buildJsonRpcResult(id, result);
-    }
-
-    /**
-     * Handle prompts/get request — render a prompt with the provided arguments.
-     */
-    @SuppressWarnings("unchecked")
-    private ObjectNode handlePromptsGet(JsonNode id, JsonNode params) {
-        if (params == null) {
-            return buildJsonRpcError(id, -32602, "Invalid params: missing params");
-        }
-        String name = params.path("name").asText("");
-        if (name.isEmpty()) {
-            return buildJsonRpcError(id, -32602, "Invalid params: name is required");
-        }
-
-        try {
-            JsonNode argumentsNode = params.get("arguments");
-            Map<String, Object> arguments = argumentsNode != null
-                    ? mapper.treeToValue(argumentsNode, Map.class)
-                    : new java.util.HashMap<>();
-
-            List<PromptHandler.RenderedMessage> messages =
-                    adapter.getPromptHandler().render(name, arguments);
-
-            ObjectNode result = mapper.createObjectNode();
-            ArrayNode messagesArray = result.putArray("messages");
-            for (PromptHandler.RenderedMessage msg : messages) {
-                ObjectNode msgNode = mapper.createObjectNode();
-                msgNode.put("role", msg.role);
-                ObjectNode contentNode = msgNode.putObject("content");
-                contentNode.put("type", "text");
-                contentNode.put("text", msg.text);
-                messagesArray.add(msgNode);
-            }
-            return buildJsonRpcResult(id, result);
-        } catch (IllegalArgumentException e) {
-            Context.getCurrentLogger().log(Level.SEVERE, "Error handling prompts/get", e);
-            return buildJsonRpcError(id, -32602, "Invalid params: " + e.getMessage());
+        } catch (ProcessorException e) {
+            getCurrentLogger().log(Level.SEVERE, "An error has occurred while processing a request", e);
+            return new DispatchResult(e.getResult(), e.getRpcError());
         } catch (Exception e) {
-            Context.getCurrentLogger().log(Level.SEVERE, "Error handling prompts/get", e);
-            return buildJsonRpcError(id, -32603, "Internal error: " + e.getMessage());
+            getCurrentLogger().log(Level.SEVERE, "Error processing request", e);
+            return new DispatchResult(buildJsonRpcError(request.get("id"), INTERNAL_ERROR.getCode(),
+                    "Internal error: " + e.getMessage()), INTERNAL_ERROR);
         }
     }
 
     /**
-     * Build a JSON-RPC success response envelope.
+     * Dispatch a JSON-RPC request within a SERVER span, extracting W3C trace context from the
+     * request's {@code params._meta} object (transport-agnostic carrier per the MCP
+     * {@code 2026-07-28} revision) and, when supplied, falling back to the given HTTP
+     * {@code traceparent} header when {@code _meta} carries no trace context.
+     *
+     * <p>Used by both transports so span creation, MDC population, and error recording happen
+     * identically for Streamable HTTP ({@link McpServerResource}) and stdio
+     * ({@link StdioJsonRpcHandler}).</p>
+     *
+     * @param request     the parsed JSON-RPC request.
+     * @param httpRequest the inbound Restlet HTTP request, or {@code null} on stdio.
+     * @return the JSON-RPC response envelope + rpcError wrapped in a {@link DispatchResult}.
      */
-    ObjectNode buildJsonRpcResult(JsonNode id, JsonNode result) {
-        ObjectNode envelope = mapper.createObjectNode();
-        envelope.put("jsonrpc", JSONRPC_VERSION);
-        Context.getCurrentLogger().log(Level.INFO, "Building JSON-RPC result for id: " + id);
-
-        if (id != null) {
-            envelope.set("id", id);
+    public DispatchResult dispatchWithTracing(JsonNode request, Request httpRequest) {
+        if (request == null) {
+            return new DispatchResult(buildJsonRpcError(null, INVALID_REQUEST.getCode(),
+                    "Invalid Request: request body is missing"), INVALID_REQUEST);
         }
-        
-        envelope.set("result", result);
-        return envelope;
+
+        String rpcMethod = request.path("method").asText("");
+        Context extractedContext = (httpRequest != null)
+                ? McpMetaTraceContextBridge.extractContext(request, httpRequest)
+                : McpMetaTraceContextBridge.extractContext(request);
+
+        Span span = TelemetryBootstrap.get().startServerSpan("mcp", rpcMethod,
+                extractedContext, null, capabilityName);
+        try (Scope scope = span.makeCurrent()) {
+            TelemetryBootstrap.populateMdc(span);
+            return dispatch(request);
+        } catch (Exception e) {
+            TelemetryBootstrap.recordError(span, e);
+            throw e;
+        } finally {
+            TelemetryBootstrap.clearMdc();
+            TelemetryBootstrap.endSpan(span);
+        }
     }
 
     /**
-     * Build a JSON-RPC error response envelope.
+     * Returns the method handler of a specific method.
+     * @param methodName the method's name.
+     * @return the handler if found, null otherwise.
      */
-    ObjectNode buildJsonRpcError(JsonNode id, int code, String message) {
-        ObjectNode envelope = mapper.createObjectNode();
-        envelope.put("jsonrpc", JSONRPC_VERSION);
-        Context.getCurrentLogger().log(Level.INFO, "Building JSON-RPC error for id: " + id);
-
-        if (id != null) {
-            envelope.set("id", id);
-        } else {
-            envelope.putNull("id");
-        }
-
-        ObjectNode error = envelope.putObject("error");
-        error.put("code", code);
-        error.put("message", message);
-        return envelope;
+    public McpCallHandler getMethodHandler(String methodName) {
+        return mcpHandlers.get(methodName);
     }
 
     ObjectMapper getMapper() {
         return mapper;
     }
-
 }

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/StdioJsonRpcHandler.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/StdioJsonRpcHandler.java
@@ -21,10 +21,15 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
+
+import io.ikanos.engine.exposes.mcp.model.DispatchResult;
 import org.restlet.Context;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import static io.ikanos.engine.exposes.mcp.model.JsonRpcError.PARSE_ERROR;
+import static io.ikanos.engine.util.JsonRpcResponseBuilder.buildJsonRpcError;
 
 /**
  * MCP stdio transport handler.
@@ -76,7 +81,11 @@ public class StdioJsonRpcHandler implements Runnable {
 
                 try {
                     JsonNode request = dispatcher.getMapper().readTree(line);
-                    ObjectNode response = dispatcher.dispatch(request);
+                    // Extract W3C trace context from params._meta (stdio has no HTTP headers,
+                    // so _meta is the only carrier — see McpMetaTraceContextBridge), create the
+                    // SERVER span, and populate MDC identically to the Streamable HTTP transport.
+                    DispatchResult dispatchResult = dispatcher.dispatchWithTracing(request, null);
+                    ObjectNode response = dispatchResult.responseBody();
 
                     // Notifications return null — no response to write
                     if (response != null) {
@@ -89,13 +98,13 @@ public class StdioJsonRpcHandler implements Runnable {
 
 
                     // Malformed JSON — write parse error response
-                    ObjectNode errorResponse = dispatcher.buildJsonRpcError(
-                            null, -32700, "Parse error: " + e.getMessage());
+                    ObjectNode errorResponse = buildJsonRpcError(
+                            null, PARSE_ERROR.getCode(), "Parse error: " + e.getMessage());
                     try {
                         output.println(dispatcher.getMapper().writeValueAsString(errorResponse));
                         output.flush();
-                    } catch (JsonProcessingException ignored) {
-                        Context.getCurrentLogger().log(Level.SEVERE, "Error serializing error response", ignored);
+                    } catch (JsonProcessingException ex) {
+                        Context.getCurrentLogger().log(Level.SEVERE, "Error serializing error response", ex);
                         // Cannot serialize the error response — nothing more we can do
                     }
                 }
@@ -115,8 +124,8 @@ public class StdioJsonRpcHandler implements Runnable {
         this.running = false;
         try {
             input.close();
-        } catch (IOException ignored) {
-            Context.getCurrentLogger().log(Level.SEVERE, "Error closing input stream", ignored);
+        } catch (IOException e) {
+            Context.getCurrentLogger().log(Level.SEVERE, "Error closing input stream", e);
             // Best-effort close to interrupt the read loop
         }
     }

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/handler/McpCallHandler.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/handler/McpCallHandler.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.ikanos.engine.exposes.mcp.McpServerAdapter;
+import io.ikanos.engine.exposes.mcp.model.HandlerResult;
+import io.ikanos.engine.exposes.mcp.model.McpHeader;
+import io.ikanos.engine.exposes.mcp.processor.DispatchPostProcessor;
+import io.ikanos.engine.exposes.mcp.processor.DispatchPreProcessor;
+
+import java.util.List;
+
+/**
+ * A common base class for all MCP handlers.
+ */
+public abstract class McpCallHandler {
+
+    protected final ObjectMapper MAPPER = new ObjectMapper();
+    protected final McpServerAdapter adapter;
+    private final List<McpHeader> requiredHeaders;
+    private final List<DispatchPreProcessor> preProcessors;
+    private final List<DispatchPostProcessor> postProcessors;
+
+    public McpCallHandler(McpServerAdapter adapter,
+                             List<McpHeader> requiredHeaders,
+                             List<DispatchPreProcessor> preProcessors,
+                             List<DispatchPostProcessor> postProcessors) {
+        this.adapter = adapter;
+        this.requiredHeaders = requiredHeaders;
+        this.preProcessors = preProcessors;
+        this.postProcessors = postProcessors;
+    }
+
+    /**
+     * Handles an MCP call for this handler.
+     * @param requestBody the JsonRpc request's body.
+     * @return the handler's result.
+     */
+    public abstract HandlerResult handle(JsonNode requestBody);
+
+    /**
+     * Get the list of headers that are required by this handler.
+     * @return the list of headers required by this handler.
+     */
+    public List<McpHeader> getRequiredHeaders() {
+        return requiredHeaders;
+    }
+
+    /**
+     * Get the list of pre-processors to apply to incoming requests before invoking
+     * the handler.
+     * @return the list of pre-processors to run.
+     */
+    public List<DispatchPreProcessor> getPreProcessors() {
+        return preProcessors;
+    }
+
+    /**
+     * Get the list of post-processors to apply to outgoing responses after invoking
+     * the handler.
+     * @return the list of post-processors to run.
+     */
+    public List<DispatchPostProcessor> getPostProcessors() {
+        return postProcessors;
+    }
+
+    /**
+     * Get the handler's method name.
+     * @return the handler's method name.
+     */
+    public abstract String getMethodName();
+}

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/handler/McpCallHandlersFactory.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/handler/McpCallHandlersFactory.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.ikanos.engine.exposes.mcp.McpServerAdapter;
+import io.ikanos.engine.exposes.mcp.processor.CacheDataAppender;
+import io.ikanos.engine.exposes.mcp.processor.DispatchPostProcessor;
+import io.ikanos.engine.exposes.mcp.processor.DispatchPreProcessor;
+import io.ikanos.engine.exposes.mcp.processor.ProtocolsVersionsValidator;
+import io.ikanos.engine.exposes.mcp.processor.ServerDataAppender;
+
+import java.util.List;
+
+import static io.ikanos.engine.exposes.mcp.model.McpHeader.MCP_METHOD;
+import static io.ikanos.engine.exposes.mcp.model.McpHeader.MCP_NAME;
+import static io.ikanos.engine.exposes.mcp.model.McpHeader.MCP_PROTOCOL_VERSION;
+
+/**
+ * A factory class for creating {@link McpCallHandler}s.
+ */
+public class McpCallHandlersFactory {
+
+    private McpCallHandlersFactory() {
+        // Utility class — no instances.
+    }
+
+    public static List<McpCallHandler> createAll(McpServerAdapter adapter) {
+        Integer ttlMs = adapter.getMcpServerSpec().getTtlMs();
+        String cacheScope = adapter.getMcpServerSpec().getCacheScope();
+
+        ObjectMapper mapper = new ObjectMapper();
+        DispatchPreProcessor protocolsVersionsValidator = new ProtocolsVersionsValidator(mapper);
+        DispatchPostProcessor cacheDataAppender = new CacheDataAppender(ttlMs, cacheScope);
+        DispatchPostProcessor serverDataAppender = new ServerDataAppender(adapter, mapper);
+
+        return List.of(
+                new ToolsListHandler(adapter, List.of(MCP_PROTOCOL_VERSION, MCP_METHOD),
+                        List.of(protocolsVersionsValidator), List.of(cacheDataAppender, serverDataAppender)),
+                new ToolsCallHandler(adapter, List.of(MCP_PROTOCOL_VERSION, MCP_METHOD, MCP_NAME),
+                        List.of(protocolsVersionsValidator), List.of(serverDataAppender)),
+                new ResourcesListHandler(adapter, List.of(MCP_PROTOCOL_VERSION, MCP_METHOD),
+                        List.of(protocolsVersionsValidator), List.of(cacheDataAppender, serverDataAppender)),
+                new ResourcesReadHandler(adapter, List.of(MCP_PROTOCOL_VERSION, MCP_METHOD, MCP_NAME),
+                        List.of(protocolsVersionsValidator), List.of(cacheDataAppender, serverDataAppender)),
+                new ResourcesTemplatesListHandler(adapter, List.of(MCP_PROTOCOL_VERSION, MCP_METHOD),
+                        List.of(protocolsVersionsValidator), List.of(cacheDataAppender, serverDataAppender)),
+                new PromptsListHandler(adapter, List.of(MCP_PROTOCOL_VERSION, MCP_METHOD),
+                        List.of(protocolsVersionsValidator), List.of(cacheDataAppender, serverDataAppender)),
+                new PromptsGetHandler(adapter, List.of(MCP_PROTOCOL_VERSION, MCP_METHOD, MCP_NAME),
+                        List.of(protocolsVersionsValidator), List.of(serverDataAppender)),
+                new ServerDiscoverHandler(adapter, List.of(MCP_PROTOCOL_VERSION, MCP_METHOD),
+                        List.of(protocolsVersionsValidator), List.of(cacheDataAppender, serverDataAppender))
+        );
+    }
+}

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/handler/PromptsGetHandler.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/handler/PromptsGetHandler.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.ikanos.engine.exposes.mcp.McpServerAdapter;
+import io.ikanos.engine.exposes.mcp.PromptHandler;
+import io.ikanos.engine.exposes.mcp.model.HandlerFailureResult;
+import io.ikanos.engine.exposes.mcp.model.HandlerSuccessResult;
+import io.ikanos.engine.exposes.mcp.model.HandlerResult;
+import io.ikanos.engine.exposes.mcp.model.McpHeader;
+import io.ikanos.engine.exposes.mcp.processor.DispatchPostProcessor;
+import io.ikanos.engine.exposes.mcp.processor.DispatchPreProcessor;
+import org.restlet.Context;
+
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+
+import static io.ikanos.engine.exposes.mcp.model.JsonRpcError.INTERNAL_ERROR;
+import static io.ikanos.engine.exposes.mcp.model.JsonRpcError.INVALID_PARAMS;
+import static io.ikanos.engine.util.JsonRpcResponseBuilder.buildJsonRpcError;
+
+/**
+ * The prompts/get handler.
+ */
+public class PromptsGetHandler extends McpCallHandler {
+
+    public static final String METHOD_NAME = "prompts/get";
+
+    public PromptsGetHandler(McpServerAdapter adapter,
+                             List<McpHeader> requiredHeaders,
+                             List<DispatchPreProcessor> preProcessors,
+                             List<DispatchPostProcessor> postProcessors) {
+        super(adapter, requiredHeaders, preProcessors, postProcessors);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public HandlerResult handle(JsonNode requestBody) {
+        JsonNode idNode = requestBody.get("id");
+        JsonNode params = requestBody.get("params");
+
+        if (params == null) {
+            return new HandlerFailureResult(INVALID_PARAMS, buildJsonRpcError(idNode, INVALID_PARAMS.getCode(), "Invalid params: missing params"));
+        }
+
+        String name = params.path("name").asText("");
+        if (name.isEmpty()) {
+            return new HandlerFailureResult(INVALID_PARAMS, buildJsonRpcError(idNode, INVALID_PARAMS.getCode(), "Invalid params: name is required"));
+        }
+
+        try {
+            JsonNode argumentsNode = params.get("arguments");
+            Map<String, Object> arguments = argumentsNode != null
+                    ? MAPPER.treeToValue(argumentsNode, Map.class)
+                    : new java.util.HashMap<>();
+
+            List<PromptHandler.RenderedMessage> messages =
+                    adapter.getPromptHandler().render(name, arguments);
+
+            ObjectNode result = MAPPER.createObjectNode();
+            ArrayNode messagesArray = result.putArray("messages");
+            for (PromptHandler.RenderedMessage msg : messages) {
+                ObjectNode msgNode = MAPPER.createObjectNode();
+                msgNode.put("role", msg.role);
+                ObjectNode contentNode = msgNode.putObject("content");
+                contentNode.put("type", "text");
+                contentNode.put("text", msg.text);
+                messagesArray.add(msgNode);
+            }
+
+            result.put("resultType", "complete");
+            return new HandlerSuccessResult(result);
+        } catch (IllegalArgumentException e) {
+            Context.getCurrentLogger().log(Level.SEVERE, "Error handling prompts/get", e);
+            return new HandlerFailureResult(INVALID_PARAMS, buildJsonRpcError(idNode, INVALID_PARAMS.getCode(), "Invalid params: " + e.getMessage()));
+        } catch (Exception e) {
+            Context.getCurrentLogger().log(Level.SEVERE, "Error handling prompts/get", e);
+            return new HandlerFailureResult(INTERNAL_ERROR, buildJsonRpcError(idNode, INTERNAL_ERROR.getCode(), "Internal error: " + e.getMessage()));
+        }
+    }
+
+    @Override
+    public String getMethodName() {
+        return METHOD_NAME;
+    }
+}

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/handler/PromptsListHandler.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/handler/PromptsListHandler.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.ikanos.engine.exposes.mcp.McpServerAdapter;
+import io.ikanos.engine.exposes.mcp.model.HandlerSuccessResult;
+import io.ikanos.engine.exposes.mcp.model.HandlerResult;
+import io.ikanos.engine.exposes.mcp.model.McpHeader;
+import io.ikanos.engine.exposes.mcp.processor.DispatchPostProcessor;
+import io.ikanos.engine.exposes.mcp.processor.DispatchPreProcessor;
+import io.ikanos.spec.exposes.mcp.McpPromptArgumentSpec;
+import io.ikanos.spec.exposes.mcp.McpServerPromptSpec;
+
+import java.util.List;
+
+/**
+ * The prompts/list handler.
+ */
+public class PromptsListHandler extends McpCallHandler {
+
+    private static final String METHOD_NAME = "prompts/list";
+
+    public PromptsListHandler(McpServerAdapter adapter, List<McpHeader> requiredHeaders, List<DispatchPreProcessor> preProcessors, List<DispatchPostProcessor> postProcessors) {
+        super(adapter, requiredHeaders, preProcessors, postProcessors);
+    }
+
+    @Override
+    public HandlerResult handle(JsonNode requestBody) {
+        ObjectNode result = MAPPER.createObjectNode();
+        ArrayNode promptsArray = result.putArray("prompts");
+
+        for (McpServerPromptSpec spec : adapter.getPromptHandler().listAll()) {
+            ObjectNode promptNode = MAPPER.createObjectNode();
+            promptNode.put("name", spec.getName());
+            if (spec.getDisplay() != null) {
+                promptNode.put("title", spec.getDisplay());
+            }
+            if (spec.getDescription() != null) {
+                promptNode.put("description", spec.getDescription());
+            }
+            if (!spec.getArguments().isEmpty()) {
+                ArrayNode argsArray = promptNode.putArray("arguments");
+                for (McpPromptArgumentSpec arg : spec.getArguments().values()) {
+                    ObjectNode argNode = MAPPER.createObjectNode();
+                    argNode.put("name", arg.getName());
+                    if (arg.getDisplay() != null) {
+                        argNode.put("title", arg.getDisplay());
+                    }
+                    if (arg.getDescription() != null) {
+                        argNode.put("description", arg.getDescription());
+                    }
+                    argNode.put("required", arg.isRequired());
+                    argsArray.add(argNode);
+                }
+            }
+            promptsArray.add(promptNode);
+        }
+
+        result.put("resultType", "complete");
+        return new HandlerSuccessResult(result);
+    }
+
+    @Override
+    public String getMethodName() {
+        return METHOD_NAME;
+    }
+}

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/handler/ResourcesListHandler.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/handler/ResourcesListHandler.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.ikanos.engine.exposes.mcp.McpServerAdapter;
+import io.ikanos.engine.exposes.mcp.model.HandlerSuccessResult;
+import io.ikanos.engine.exposes.mcp.model.HandlerResult;
+import io.ikanos.engine.exposes.mcp.model.McpHeader;
+import io.ikanos.engine.exposes.mcp.processor.DispatchPostProcessor;
+import io.ikanos.engine.exposes.mcp.processor.DispatchPreProcessor;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The resources/list handler.
+ */
+public class ResourcesListHandler extends McpCallHandler {
+
+    public static final String METHOD_NAME = "resources/list";
+
+    public ResourcesListHandler(McpServerAdapter adapter, List<McpHeader> requiredHeaders, List<DispatchPreProcessor> preProcessors, List<DispatchPostProcessor> postProcessors) {
+        super(adapter, requiredHeaders, preProcessors, postProcessors);
+    }
+
+    @Override
+    public HandlerResult handle(JsonNode requestBody) {
+        ObjectNode result = MAPPER.createObjectNode();
+        ArrayNode resourcesArray = result.putArray("resources");
+
+        for (Map<String, String> entry : adapter.getResourceHandler().listAll()) {
+            ObjectNode node = MAPPER.createObjectNode();
+            node.put("uri", entry.get("uri"));
+            node.put("name", entry.get("name"));
+            String title = entry.get("display");
+            if (title != null) {
+                node.put("title", title);
+            }
+            String description = entry.get("description");
+            if (description != null) {
+                node.put("description", description);
+            }
+            String mimeType = entry.get("mimeType");
+            if (mimeType != null) {
+                node.put("mimeType", mimeType);
+            }
+            resourcesArray.add(node);
+        }
+
+        result.put("resultType", "complete");
+        return new HandlerSuccessResult(result);
+    }
+
+    @Override
+    public String getMethodName() {
+        return METHOD_NAME;
+    }
+}

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/handler/ResourcesReadHandler.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/handler/ResourcesReadHandler.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.ikanos.engine.exposes.mcp.McpServerAdapter;
+import io.ikanos.engine.exposes.mcp.ResourceHandler;
+import io.ikanos.engine.exposes.mcp.model.HandlerFailureResult;
+import io.ikanos.engine.exposes.mcp.model.HandlerSuccessResult;
+import io.ikanos.engine.exposes.mcp.model.HandlerResult;
+import io.ikanos.engine.exposes.mcp.model.McpHeader;
+import io.ikanos.engine.exposes.mcp.processor.DispatchPostProcessor;
+import io.ikanos.engine.exposes.mcp.processor.DispatchPreProcessor;
+import org.restlet.Context;
+
+import java.util.List;
+import java.util.logging.Level;
+
+import static io.ikanos.engine.exposes.mcp.model.JsonRpcError.INTERNAL_ERROR;
+import static io.ikanos.engine.exposes.mcp.model.JsonRpcError.INVALID_PARAMS;
+import static io.ikanos.engine.util.JsonRpcResponseBuilder.buildJsonRpcError;
+
+/**
+ * The resources/read handler.
+ */
+public class ResourcesReadHandler extends McpCallHandler {
+
+    public static final String METHOD_NAME = "resources/read";
+
+    public ResourcesReadHandler(McpServerAdapter adapter, List<McpHeader> requiredHeaders, List<DispatchPreProcessor> preProcessors, List<DispatchPostProcessor> postProcessors) {
+        super(adapter, requiredHeaders, preProcessors, postProcessors);
+    }
+
+    @Override
+    public HandlerResult handle(JsonNode requestBody) {
+        JsonNode idNode = requestBody.get("id");
+        JsonNode params = requestBody.get("params");
+
+        if (params == null) {
+            return new HandlerFailureResult(INVALID_PARAMS, buildJsonRpcError(idNode, INVALID_PARAMS.getCode(), "Invalid params: missing params"));
+        }
+        String uri = params.path("uri").asText("");
+        if (uri.isEmpty()) {
+            return new HandlerFailureResult(INVALID_PARAMS, buildJsonRpcError(idNode, INVALID_PARAMS.getCode(), "Invalid params: uri is required"));
+        }
+
+        try {
+            List<ResourceHandler.ResourceContent> contents =
+                    adapter.getResourceHandler().read(uri);
+            ObjectNode result = MAPPER.createObjectNode();
+            ArrayNode contentsArray = result.putArray("contents");
+            for (ResourceHandler.ResourceContent c : contents) {
+                ObjectNode contentNode = MAPPER.createObjectNode();
+                contentNode.put("uri", c.uri);
+                if (c.mimeType != null) {
+                    contentNode.put("mimeType", c.mimeType);
+                }
+                if (c.blob != null) {
+                    contentNode.put("blob", c.blob);
+                } else {
+                    contentNode.put("text", c.text != null ? c.text : "");
+                }
+                contentsArray.add(contentNode);
+            }
+
+            result.put("resultType", "complete");
+            return new HandlerSuccessResult(result);
+        } catch (IllegalArgumentException e) {
+            Context.getCurrentLogger().log(Level.SEVERE, "Error handling resources/read", e);
+            return new HandlerFailureResult(INVALID_PARAMS, buildJsonRpcError(idNode, INVALID_PARAMS.getCode(), "Invalid params: " + e.getMessage()));
+        } catch (Exception e) {
+            Context.getCurrentLogger().log(Level.SEVERE, "Error handling resources/read", e);
+            return new HandlerFailureResult(INTERNAL_ERROR, buildJsonRpcError(idNode, INTERNAL_ERROR.getCode(), "Internal error: " + e.getMessage()));
+        }
+    }
+
+    @Override
+    public String getMethodName() {
+        return METHOD_NAME;
+    }
+}

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/handler/ResourcesTemplatesListHandler.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/handler/ResourcesTemplatesListHandler.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.ikanos.engine.exposes.mcp.McpServerAdapter;
+import io.ikanos.engine.exposes.mcp.model.HandlerSuccessResult;
+import io.ikanos.engine.exposes.mcp.model.HandlerResult;
+import io.ikanos.engine.exposes.mcp.model.McpHeader;
+import io.ikanos.engine.exposes.mcp.processor.DispatchPostProcessor;
+import io.ikanos.engine.exposes.mcp.processor.DispatchPreProcessor;
+import io.ikanos.spec.exposes.mcp.McpServerResourceSpec;
+
+import java.util.List;
+
+/**
+ * The resources/templates/list handler.
+ */
+public class ResourcesTemplatesListHandler extends McpCallHandler {
+
+    public static final String METHOD_NAME = "resources/templates/list";
+
+    public ResourcesTemplatesListHandler(McpServerAdapter adapter, List<McpHeader> requiredHeaders, List<DispatchPreProcessor> preProcessors, List<DispatchPostProcessor> postProcessors) {
+        super(adapter, requiredHeaders, preProcessors, postProcessors);
+    }
+
+    @Override
+    public HandlerResult handle(JsonNode requestBody) {
+        ObjectNode result = MAPPER.createObjectNode();
+        ArrayNode templatesArray = result.putArray("resourceTemplates");
+
+        for (McpServerResourceSpec spec : adapter.getResourceHandler().listTemplates()) {
+            ObjectNode node = MAPPER.createObjectNode();
+            node.put("uriTemplate", spec.getUri());
+            node.put("name", spec.getName());
+            if (spec.getDisplay() != null) {
+                node.put("title", spec.getDisplay());
+            }
+            if (spec.getDescription() != null) {
+                node.put("description", spec.getDescription());
+            }
+            if (spec.getMimeType() != null) {
+                node.put("mimeType", spec.getMimeType());
+            }
+            templatesArray.add(node);
+        }
+
+        result.put("resultType", "complete");
+        return new HandlerSuccessResult(result);
+    }
+
+    @Override
+    public String getMethodName() {
+        return METHOD_NAME;
+    }
+}

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/handler/ServerDiscoverHandler.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/handler/ServerDiscoverHandler.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.ikanos.engine.exposes.mcp.McpServerAdapter;
+import io.ikanos.engine.exposes.mcp.model.HandlerSuccessResult;
+import io.ikanos.engine.exposes.mcp.model.HandlerResult;
+import io.ikanos.engine.exposes.mcp.model.McpHeader;
+import io.ikanos.engine.exposes.mcp.processor.DispatchPostProcessor;
+import io.ikanos.engine.exposes.mcp.processor.DispatchPreProcessor;
+
+import java.util.List;
+
+import static io.ikanos.engine.exposes.mcp.ProtocolDispatcher.MCP_PROTOCOL_VERSION;
+
+/**
+ * The server/discover handler.
+ */
+public class ServerDiscoverHandler extends McpCallHandler {
+
+    public static final String METHOD_NAME = "server/discover";
+
+    public ServerDiscoverHandler(McpServerAdapter adapter, List<McpHeader> requiredHeaders, List<DispatchPreProcessor> preProcessors, List<DispatchPostProcessor> postProcessors) {
+        super(adapter, requiredHeaders, preProcessors, postProcessors);
+    }
+
+    @Override
+    public HandlerResult handle(JsonNode requestBody) {
+        ObjectNode result = MAPPER.createObjectNode();
+
+        ArrayNode supportedVersions = result.putArray("supportedVersions");
+        supportedVersions.add(MCP_PROTOCOL_VERSION);
+
+        // Conditionally advertise capabilities based on what is declared in the spec
+        ObjectNode capabilities = MAPPER.createObjectNode();
+        capabilities.putObject("tools");
+        if (!adapter.getMcpServerSpec().getResources().isEmpty()) {
+            capabilities.putObject("resources");
+        }
+        if (!adapter.getMcpServerSpec().getPrompts().isEmpty()) {
+            capabilities.putObject("prompts");
+        }
+        result.set("capabilities", capabilities);
+
+        // Instructions from the spec description
+        if (adapter.getMcpServerSpec().getDescription() != null) {
+            result.put("instructions", adapter.getMcpServerSpec().getDescription());
+        }
+
+        result.put("resultType", "complete");
+        return new HandlerSuccessResult(result);
+    }
+
+    @Override
+    public String getMethodName() {
+        return METHOD_NAME;
+    }
+}

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/handler/ToolsCallHandler.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/handler/ToolsCallHandler.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.ikanos.engine.exposes.mcp.McpServerAdapter;
+import io.ikanos.engine.exposes.mcp.model.HandlerFailureResult;
+import io.ikanos.engine.exposes.mcp.model.HandlerSuccessResult;
+import io.ikanos.engine.exposes.mcp.model.HandlerResult;
+import io.ikanos.engine.exposes.mcp.model.McpHeader;
+import io.ikanos.engine.exposes.mcp.processor.DispatchPostProcessor;
+import io.ikanos.engine.exposes.mcp.processor.DispatchPreProcessor;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.restlet.Context;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+
+import static io.ikanos.engine.exposes.mcp.model.JsonRpcError.INVALID_PARAMS;
+import static io.ikanos.engine.util.JsonRpcResponseBuilder.buildJsonRpcError;
+
+/**
+ * The tools/call handler.
+ */
+public class ToolsCallHandler extends McpCallHandler {
+
+    public static final String METHOD_NAME = "tools/call";
+
+    public ToolsCallHandler(McpServerAdapter adapter, List<McpHeader> requiredHeaders, List<DispatchPreProcessor> preProcessors, List<DispatchPostProcessor> postProcessors) {
+        super(adapter, requiredHeaders, preProcessors, postProcessors);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public HandlerResult handle(JsonNode requestBody) {
+        JsonNode idNode = requestBody.get("id");
+        JsonNode params = requestBody.get("params");
+
+        if (params == null) {
+            return new HandlerFailureResult(INVALID_PARAMS, buildJsonRpcError(idNode, INVALID_PARAMS.getCode(), "Invalid params: missing params"));
+        }
+
+        String toolName = params.path("name").asText("");
+        JsonNode argumentsNode = params.get("arguments");
+
+        try {
+            Map<String, Object> arguments = argumentsNode != null
+                    ? MAPPER.treeToValue(argumentsNode, Map.class)
+                    : new ConcurrentHashMap<>();
+            McpSchema.CallToolResult toolResult =
+                    adapter.getToolHandler().handleToolCall(toolName, arguments);
+            ObjectNode result = MAPPER.valueToTree(toolResult);
+
+            result.put("resultType", "complete");
+            return new HandlerSuccessResult(result);
+        } catch (IllegalArgumentException e) {
+            Context.getCurrentLogger().log(Level.SEVERE, "Error handling tools call", e);
+            return new HandlerFailureResult(INVALID_PARAMS, buildJsonRpcError(idNode, INVALID_PARAMS.getCode(), "Invalid params: " + e.getMessage()));
+        } catch (Exception e) {
+            Context.getCurrentLogger().log(Level.SEVERE, "Error handling tools call", e);
+            // Tool execution error — return as a tool result with isError=true
+            ObjectNode result = MAPPER.createObjectNode();
+            ArrayNode content = result.putArray("content");
+            ObjectNode textContent = content.addObject();
+            textContent.put("type", "text");
+            textContent.put("text", "Error: " + e.getMessage());
+            result.put("isError", true);
+            result.put("resultType", "complete");
+            return new HandlerSuccessResult(result);
+        }
+    }
+
+    @Override
+    public String getMethodName() {
+        return METHOD_NAME;
+    }
+}

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/handler/ToolsListHandler.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/handler/ToolsListHandler.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.ikanos.engine.exposes.mcp.McpServerAdapter;
+import io.ikanos.engine.exposes.mcp.model.HandlerSuccessResult;
+import io.ikanos.engine.exposes.mcp.model.HandlerResult;
+import io.ikanos.engine.exposes.mcp.model.McpHeader;
+import io.ikanos.engine.exposes.mcp.processor.DispatchPostProcessor;
+import io.ikanos.engine.exposes.mcp.processor.DispatchPreProcessor;
+import io.modelcontextprotocol.spec.McpSchema;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The tools/list handler.
+ */
+public class ToolsListHandler extends McpCallHandler {
+
+    public static final String METHOD_NAME = "tools/list";
+
+    public ToolsListHandler(McpServerAdapter adapter,
+                            List<McpHeader> requiredHeaders,
+                            List<DispatchPreProcessor> preProcessors,
+                            List<DispatchPostProcessor> postProcessors) {
+        super(adapter, requiredHeaders, preProcessors, postProcessors);
+    }
+
+    @Override
+    public HandlerResult handle(JsonNode requestBody) {
+        ObjectNode result = MAPPER.createObjectNode();
+        ArrayNode toolsArray = result.putArray("tools");
+        Map<String, String> labels = adapter.getToolLabels();
+
+        for (McpSchema.Tool tool : adapter.getTools()) {
+            ObjectNode toolNode = MAPPER.createObjectNode();
+            toolNode.put("name", tool.name());
+
+            String title = labels.get(tool.name());
+            if (title != null) {
+                toolNode.put("title", title);
+            }
+
+            if (tool.description() != null) {
+                toolNode.put("description", tool.description());
+            }
+
+            if (tool.inputSchema() != null) {
+                toolNode.set("inputSchema", MAPPER.valueToTree(tool.inputSchema()));
+            }
+
+            if (tool.annotations() != null) {
+                ObjectNode annotationsNode = MAPPER.createObjectNode();
+                McpSchema.ToolAnnotations ann = tool.annotations();
+                if (ann.title() != null) {
+                    annotationsNode.put("title", ann.title());
+                }
+                if (ann.readOnlyHint() != null) {
+                    annotationsNode.put("readOnlyHint", ann.readOnlyHint());
+                }
+                if (ann.destructiveHint() != null) {
+                    annotationsNode.put("destructiveHint", ann.destructiveHint());
+                }
+                if (ann.idempotentHint() != null) {
+                    annotationsNode.put("idempotentHint", ann.idempotentHint());
+                }
+                if (ann.openWorldHint() != null) {
+                    annotationsNode.put("openWorldHint", ann.openWorldHint());
+                }
+                if (!annotationsNode.isEmpty()) {
+                    toolNode.set("annotations", annotationsNode);
+                }
+            }
+
+            toolsArray.add(toolNode);
+        }
+
+        result.put("resultType", "complete");
+        return new HandlerSuccessResult(result);
+    }
+
+    @Override
+    public String getMethodName() {
+        return METHOD_NAME;
+    }
+}

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/handler/package-info.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/handler/package-info.java
@@ -1,0 +1,25 @@
+/**
+ * Handlers for the MCP JSON-RPC methods exposed by the {@code type: mcp} server adapter.
+ *
+ * <p>Each JSON-RPC method supported by the MCP protocol ({@code tools/list}, {@code tools/call},
+ * {@code resources/list}, {@code resources/read}, {@code resources/templates/list},
+ * {@code prompts/list}, {@code prompts/get}, and the server-discovery method) is implemented by
+ * a dedicated {@link io.ikanos.engine.exposes.mcp.handler.McpCallHandler} subclass. Handlers are
+ * looked up and dispatched by
+ * {@link io.ikanos.engine.exposes.mcp.ProtocolDispatcher} based on the incoming request's
+ * {@code method} field, and are assembled once per adapter by
+ * {@link io.ikanos.engine.exposes.mcp.handler.McpCallHandlersFactory}.</p>
+ *
+ * <p>{@link io.ikanos.engine.exposes.mcp.handler.McpCallHandler} is the common base class: it
+ * declares the required MCP headers for a given method (e.g. protocol version, method name,
+ * tool/resource/prompt name) and holds the ordered lists of
+ * {@link io.ikanos.engine.exposes.mcp.processor.DispatchPreProcessor}s and
+ * {@link io.ikanos.engine.exposes.mcp.processor.DispatchPostProcessor}s that run respectively
+ * before and after {@link io.ikanos.engine.exposes.mcp.handler.McpCallHandler#handle(com.fasterxml.jackson.databind.JsonNode)}
+ * — for example protocol-version validation, response caching directives, and server metadata
+ * enrichment.</p>
+ *
+ * <p>Handlers are stateless beyond their constructor-injected dependencies and are safe to reuse
+ * across concurrent requests.</p>
+ */
+package io.ikanos.engine.exposes.mcp.handler;

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/model/DispatchResult.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/model/DispatchResult.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp.model;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * A record representing a dispatch result.
+ *
+ * @param rpcError     the JsonRpc error if relevant (an error occurred), null otherwise.
+ * @param isOnError    true if an error occurred, false otherwise.
+ * @param responseBody the response body.
+ */
+public record DispatchResult(ObjectNode responseBody, boolean isOnError, JsonRpcError rpcError) {
+
+    public DispatchResult(ObjectNode responseBody, JsonRpcError rpcError) {
+        this(responseBody, true, rpcError);
+    }
+
+    public DispatchResult(ObjectNode responseBody) {
+        this(responseBody, false, null);
+    }
+}

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/model/HandlerFailureResult.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/model/HandlerFailureResult.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp.model;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * A record representing a failing handler's result.
+ *
+ * @param rpcError the JsonRpc rpcError.
+ * @param body the body of the response.
+ */
+public record HandlerFailureResult(JsonRpcError rpcError, ObjectNode body) implements HandlerResult {
+}

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/model/HandlerResult.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/model/HandlerResult.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp.model;
+
+/**
+ * A marker interface for handler's results.
+ */
+public sealed interface HandlerResult permits HandlerSuccessResult, HandlerFailureResult {
+}

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/model/HandlerSuccessResult.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/model/HandlerSuccessResult.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp.model;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * A record representing a successful handler's result.
+ *
+ * @param result the result of the response.
+ */
+public record HandlerSuccessResult(ObjectNode result) implements HandlerResult {
+}

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/model/JsonRpcCodeMapper.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/model/JsonRpcCodeMapper.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp.model;
+
+import java.util.Map;
+
+import static io.ikanos.engine.exposes.mcp.model.JsonRpcError.HEADER_MISMATCH;
+import static io.ikanos.engine.exposes.mcp.model.JsonRpcError.INTERNAL_ERROR;
+import static io.ikanos.engine.exposes.mcp.model.JsonRpcError.INVALID_PARAMS;
+import static io.ikanos.engine.exposes.mcp.model.JsonRpcError.INVALID_REQUEST;
+import static io.ikanos.engine.exposes.mcp.model.JsonRpcError.METHOD_NOT_FOUND;
+import static io.ikanos.engine.exposes.mcp.model.JsonRpcError.MISSING_REQUIRED_CLIENT_CAPABILITY;
+import static io.ikanos.engine.exposes.mcp.model.JsonRpcError.PARSE_ERROR;
+import static io.ikanos.engine.exposes.mcp.model.JsonRpcError.UNSUPPORTED_PROTOCOL_VERSION;
+
+/**
+ * A mapper that maps JsonRpc errors to the HTTP status rpcError
+ * specified by the MCP specification.
+ */
+public class JsonRpcCodeMapper {
+
+    private static final Map<JsonRpcError, Integer> JSON_RPC_CODE_TO_HTTP_STATUS = Map.ofEntries(
+            // Malformed/invalid requests are client errors.
+            Map.entry(PARSE_ERROR, 400),
+            Map.entry(INVALID_REQUEST, 400),
+            Map.entry(INVALID_PARAMS, 400),
+            // The server doesn't implement the requested RPC method: distinguished from a
+            // generic 400 so clients can tell it apart from a legacy HTTP+SSE 404 during
+            // backward-compatibility probing.
+            Map.entry(METHOD_NOT_FOUND, 404),
+            // Unexpected failures while processing an otherwise well-formed request.
+            Map.entry(INTERNAL_ERROR, 500),
+            // Header/body mismatch or missing mandatory header.
+            Map.entry(HEADER_MISMATCH, 400),
+            // Request requires a client capability that was not declared in _meta.
+            Map.entry(MISSING_REQUIRED_CLIENT_CAPABILITY, 400),
+            // Requested protocol version is unknown or unsupported by the server.
+            Map.entry(UNSUPPORTED_PROTOCOL_VERSION, 400)
+    );
+
+    private JsonRpcCodeMapper() {
+        // Empty constructor
+    }
+
+    /**
+     * Get the HTTP status rpcError based on the JsonRpc one according to the specification.
+     * @param jsonRpcError the JsonRpc error.
+     * @return a valid HTTP status rpcError if found, -1 otherwise.
+     * @throws IllegalArgumentException in case no mapping exists for the {@link JsonRpcError}.
+     */
+    public static int getHttpStatusCodeOfJsonRpcCode(JsonRpcError jsonRpcError) {
+        Integer httpStatus = JSON_RPC_CODE_TO_HTTP_STATUS.get(jsonRpcError);
+        if (httpStatus == null) {
+            throw new IllegalArgumentException("No mapping exists for the JsonRpc code: %s".formatted(jsonRpcError.getCode()));
+        }
+
+        return httpStatus;
+    }
+}

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/model/JsonRpcError.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/model/JsonRpcError.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp.model;
+
+/**
+ * An enumeration listing all the JsonRpc errors relevant to MCP.
+ */
+public enum JsonRpcError {
+
+    // Standard JSON-RPC 2.0 codes (MCP spec: "-32700", "-32600" to "-32603")
+    PARSE_ERROR(-32700),
+    INVALID_REQUEST(-32600),
+    METHOD_NOT_FOUND(-32601),
+    INVALID_PARAMS(-32602),
+    INTERNAL_ERROR(-32603),
+
+    // MCP-reserved sub-range (-32020 to -32099)
+    HEADER_MISMATCH(-32020),
+    MISSING_REQUIRED_CLIENT_CAPABILITY(-32021),
+    UNSUPPORTED_PROTOCOL_VERSION(-32022);
+
+    private final int code;
+
+    JsonRpcError(int code) {
+        this.code = code;
+    }
+
+    public int getCode() {
+        return code;
+    }
+}

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/model/McpHeader.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/model/McpHeader.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp.model;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.ikanos.engine.exposes.mcp.handler.PromptsGetHandler;
+import io.ikanos.engine.exposes.mcp.handler.ResourcesReadHandler;
+import io.ikanos.engine.exposes.mcp.handler.ToolsCallHandler;
+import org.restlet.data.Header;
+import org.restlet.util.Series;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An enumeration of MCP headers.
+ */
+public enum McpHeader {
+
+    MCP_PROTOCOL_VERSION("MCP-Protocol-Version", List.of("params", "_meta", "io.modelcontextprotocol/protocolVersion"), false),
+    MCP_METHOD("Mcp-Method", List.of("method"), false),
+    MCP_NAME("Mcp-Name", Collections.emptyList(), true) {
+        static final Map<String, List<String>> MCP_NAME_BY_METHOD_NAME = Map.of(
+                ToolsCallHandler.METHOD_NAME, List.of("params", "name"),
+                ResourcesReadHandler.METHOD_NAME, List.of("params", "uri"),
+                PromptsGetHandler.METHOD_NAME, List.of("params", "name")
+        );
+
+        /**
+         * The Mcp-Name header has a specificity when it comes to the path.
+         * Depending on the method, it could either be: params->name or params->uri.
+         * @param methodName the MCP method's name.
+         * @return the path to use.
+         */
+        @Override
+        protected List<String> getPath(String methodName) {
+            return MCP_NAME_BY_METHOD_NAME.getOrDefault(methodName, Collections.emptyList());
+        }
+    };
+
+    /**
+     * Marker prefix/suffix wrapping a base64-encoded value inside an MCP header, e.g.
+     * {@code X-Custom-Header: =?base64?SGVsbG8gV29ybGQ=?=}. Mirrors the MIME
+     * "encoded-word" convention ({@code =?charset?encoding?encoded-text?=}) so
+     * non-ASCII or binary header values can travel safely over transports that only
+     * support ASCII headers. A header value is treated as base64-encoded only when it
+     * starts with {@code ENCODING_PREFIX} and ends with {@code ENCODING_SUFFIX}; the
+     * substring between the two markers is decoded, otherwise the raw value is used
+     * as-is.
+     */
+    private static final String ENCODING_PREFIX = "=?base64?";
+    private static final String ENCODING_SUFFIX = "?=";
+    private final String headerName;
+    private final List<String> path;
+    private final boolean canBeB64Encoded;
+
+    McpHeader(String headerName, List<String> path, boolean canBeB64Encoded) {
+        this.headerName = headerName;
+        this.path = path;
+        this.canBeB64Encoded = canBeB64Encoded;
+    }
+
+    public String getHeaderName() {
+        return headerName;
+    }
+
+    public String extractValueFromRequestBody(String methodName, JsonNode jsonrpcRequestBody) {
+        JsonNode node = jsonrpcRequestBody;
+        for (String pathPart : getPath(methodName)) {
+            node = node.path(pathPart);
+        }
+        return node.asText();
+    }
+
+    protected List<String> getPath(String methodName) {
+        return path;
+    }
+
+    /**
+     * Get the value of the header from a set of headers.
+     * Some headers might have their value encrypted in Base64,
+     * the pattern is: =?base64?{BASE64_ENCODED_VALUE}?=.
+     * @param headers the headers set.
+     * @return the value of the header if found, null otherwise.
+     * @throws IllegalArgumentException if an error occurs while decoding an encoded value.
+     */
+    public String getHeaderValue(Series<Header> headers) {
+        for (Header header : headers) {
+            // The spec states that the header names' comparisons must be case-insensitive
+            // See: https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http#server-validation
+            if (headerName.equalsIgnoreCase(header.getName())) {
+                if (canBeB64Encoded && header.getValue().startsWith(ENCODING_PREFIX) && header.getValue().endsWith(ENCODING_SUFFIX)) {
+                    String encodedValue = header.getValue().substring(ENCODING_PREFIX.length(), header.getValue().length() - ENCODING_SUFFIX.length());
+                    byte[] decoded = Base64.getDecoder().decode(encodedValue);
+                    return new String(decoded, StandardCharsets.UTF_8); // The spec states that the UTF-8 representation is used for encoding
+                } else {
+                    return header.getValue();
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/model/package-info.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/model/package-info.java
@@ -1,0 +1,25 @@
+/**
+ * Shared model types for the MCP JSON-RPC protocol layer.
+ *
+ * <p>These classes are protocol-level building blocks used by both the
+ * {@link io.ikanos.engine.exposes.mcp.handler} handlers and the dispatch pipeline
+ * ({@link io.ikanos.engine.exposes.mcp.ProtocolDispatcher}, pre/post-processors):</p>
+ *
+ * <ul>
+ *   <li>{@link io.ikanos.engine.exposes.mcp.model.HandlerResult} — sealed result of a handler's
+ *   execution, either a {@link io.ikanos.engine.exposes.mcp.model.HandlerSuccessResult} or a
+ *   {@link io.ikanos.engine.exposes.mcp.model.HandlerFailureResult}.</li>
+ *   <li>{@link io.ikanos.engine.exposes.mcp.model.DispatchResult} — the outcome of dispatching a
+ *   full JSON-RPC request, carrying the response body and, on error, the associated
+ *   {@link io.ikanos.engine.exposes.mcp.model.JsonRpcError}.</li>
+ *   <li>{@link io.ikanos.engine.exposes.mcp.model.JsonRpcError} — the JSON-RPC / MCP error codes
+ *   (standard JSON-RPC 2.0 codes plus the MCP-reserved sub-range), and
+ *   {@link io.ikanos.engine.exposes.mcp.model.JsonRpcCodeMapper} — maps each one to the HTTP
+ *   status required by the MCP specification.</li>
+ *   <li>{@link io.ikanos.engine.exposes.mcp.model.McpHeader} — the MCP-specific HTTP headers
+ *   (protocol version, method, name) required by handlers, including where to read each header's
+ *   value from the JSON-RPC request body and how base64-encoded header values (MIME
+ *   "encoded-word" style, {@code =?base64?...?=}) are decoded.</li>
+ * </ul>
+ */
+package io.ikanos.engine.exposes.mcp.model;

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/processor/CacheDataAppender.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/processor/CacheDataAppender.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp.processor;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.ikanos.exception.ProcessorException;
+
+import java.util.Objects;
+
+import static io.ikanos.engine.exposes.mcp.model.JsonRpcError.INTERNAL_ERROR;
+import static io.ikanos.engine.util.JsonRpcResponseBuilder.buildJsonRpcError;
+
+/**
+ * A post-processor that appends cache data to responses.
+ */
+public class CacheDataAppender implements DispatchPostProcessor {
+
+    private final int ttlMs;
+    private final String cacheScope;
+
+    public CacheDataAppender(Integer ttlMs, String cacheScope) {
+        this.ttlMs = Objects.requireNonNullElse(ttlMs, 0);
+        this.cacheScope = Objects.requireNonNullElse(cacheScope, "private");
+    }
+
+    @Override
+    public void apply(ObjectNode response) throws ProcessorException {
+        if (response.get("result") instanceof ObjectNode result) {
+            result.put("ttlMs", ttlMs);
+            result.put("cacheScope", cacheScope);
+        } else {
+            throw new ProcessorException("Internal error: expected a result tag", INTERNAL_ERROR,
+                    buildJsonRpcError(null, INTERNAL_ERROR.getCode(), "Internal error: expected a result tag"));
+        }
+    }
+}

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/processor/DispatchPostProcessor.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/processor/DispatchPostProcessor.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp.processor;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.ikanos.exception.ProcessorException;
+
+/**
+ * Common interface for post-processors that must run
+ * on responses after applying the dispatch.
+ */
+public interface DispatchPostProcessor {
+
+    /**
+     * Run the processor.
+     * @param response the response's body.
+     * @throws ProcessorException when an error occurs while running the post-processor.
+     */
+    void apply(ObjectNode response) throws ProcessorException;
+}

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/processor/DispatchPreProcessor.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/processor/DispatchPreProcessor.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp.processor;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.ikanos.exception.ProcessorException;
+
+/**
+ * Common interface for pre-processors that must run
+ * on requests before applying the dispatch.
+ */
+public interface DispatchPreProcessor {
+
+    /**
+     * Run the processor.
+     * @param request the request's body.
+     * @throws ProcessorException when an error occurs while running the post-processor.
+     */
+    void apply(JsonNode request) throws ProcessorException;
+}

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/processor/ProtocolsVersionsValidator.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/processor/ProtocolsVersionsValidator.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp.processor;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.ikanos.exception.ProcessorException;
+
+import static io.ikanos.engine.exposes.mcp.ProtocolDispatcher.JSONRPC_VERSION;
+import static io.ikanos.engine.exposes.mcp.ProtocolDispatcher.MCP_PROTOCOL_VERSION;
+import static io.ikanos.engine.exposes.mcp.model.JsonRpcError.INVALID_REQUEST;
+import static io.ikanos.engine.exposes.mcp.model.JsonRpcError.UNSUPPORTED_PROTOCOL_VERSION;
+import static io.ikanos.engine.util.JsonRpcResponseBuilder.buildJsonRpcError;
+
+/**
+ * A pre-processor for validating the protocols' versions.
+ */
+public class ProtocolsVersionsValidator implements DispatchPreProcessor {
+
+    private final ObjectMapper mapper;
+
+    public ProtocolsVersionsValidator(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public void apply(JsonNode request) throws ProcessorException {
+        String jsonrpc = request.path("jsonrpc").asText("");
+        JsonNode idNode = request.get("id");
+        String bodyProtocolVersion = request.path("params").path("_meta")
+                .path("io.modelcontextprotocol/protocolVersion").asText("");
+
+        if (!JSONRPC_VERSION.equals(jsonrpc)) {
+            throw new ProcessorException("Invalid Request: jsonrpc must be '2.0', got %s".formatted(jsonrpc),
+                    INVALID_REQUEST, buildJsonRpcError(idNode, INVALID_REQUEST.getCode(),
+                    "Invalid Request: jsonrpc must be '2.0'"));
+        }
+
+        if (!MCP_PROTOCOL_VERSION.equals(bodyProtocolVersion)) {
+            ObjectNode data = mapper.createObjectNode();
+            ArrayNode supported = data.putArray("supported");
+            supported.add(MCP_PROTOCOL_VERSION);
+            data.put("requested", bodyProtocolVersion);
+            throw new ProcessorException("Unsupported protocol version %s".formatted(bodyProtocolVersion), UNSUPPORTED_PROTOCOL_VERSION,
+                    buildJsonRpcError(idNode, UNSUPPORTED_PROTOCOL_VERSION.getCode(), "Unsupported protocol version", data));
+        }
+    }
+}

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/processor/ServerDataAppender.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/processor/ServerDataAppender.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp.processor;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.ikanos.engine.exposes.mcp.McpServerAdapter;
+import io.ikanos.engine.exposes.mcp.ProtocolDispatcher;
+import io.ikanos.exception.ProcessorException;
+import io.ikanos.spec.InfoSpec;
+
+import static io.ikanos.engine.exposes.mcp.model.JsonRpcError.INTERNAL_ERROR;
+import static io.ikanos.engine.util.JsonRpcResponseBuilder.buildJsonRpcError;
+
+/**
+ * A post-processor that appends server data to responses.
+ */
+public class ServerDataAppender implements DispatchPostProcessor {
+
+    private final JsonNode serverInfo;
+
+    public ServerDataAppender(McpServerAdapter adapter, ObjectMapper mapper) {
+        ObjectNode serverInfoData = mapper.createObjectNode();
+        serverInfoData.put("name", adapter.getMcpServerSpec().getNamespace());
+        InfoSpec infoSpec = adapter.getCapability().getSpec().getInfo();
+        if (infoSpec != null && infoSpec.getVersion() != null) {
+            serverInfoData.put("version", infoSpec.getVersion());
+        } else {
+            serverInfoData.put("version", "unspecified");
+        }
+        ObjectNode severInfoObjectNode = mapper.createObjectNode();
+        severInfoObjectNode.set("io.modelcontextprotocol/serverInfo", serverInfoData);
+        this.serverInfo = severInfoObjectNode;
+    }
+
+    @Override
+    public void apply(ObjectNode response) throws ProcessorException {
+        response.put("jsonrpc", ProtocolDispatcher.JSONRPC_VERSION);
+        ObjectNode result = (ObjectNode) response.get("result");
+
+        if (result == null) {
+            throw new ProcessorException("Internal error: expected a result tag", INTERNAL_ERROR,
+                    buildJsonRpcError(null, INTERNAL_ERROR.getCode(), "Internal error: expected a result tag"));
+        }
+
+        result.set("_meta", serverInfo);
+    }
+}

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/processor/package-info.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/mcp/processor/package-info.java
@@ -1,0 +1,27 @@
+/**
+ * Pre- and post-processors that run around an MCP call handler's execution, as wired by
+ * {@link io.ikanos.engine.exposes.mcp.handler.McpCallHandlersFactory}.
+ *
+ * <p>Two small functional-style contracts define the extension points:</p>
+ * <ul>
+ *   <li>{@link io.ikanos.engine.exposes.mcp.processor.DispatchPreProcessor} — runs on the
+ *   request body before the handler, and may abort dispatch by throwing a
+ *   {@link io.ikanos.exception.ProcessorException} (e.g. an unsupported protocol version).</li>
+ *   <li>{@link io.ikanos.engine.exposes.mcp.processor.DispatchPostProcessor} — runs on the
+ *   response body after the handler, typically to enrich it before it is sent back to the
+ *   client.</li>
+ * </ul>
+ *
+ * <p>Built-in implementations:</p>
+ * <ul>
+ *   <li>{@link io.ikanos.engine.exposes.mcp.processor.ProtocolsVersionsValidator} — a
+ *   pre-processor rejecting requests whose MCP protocol version or {@code jsonrpc} version
+ *   don't match what the server supports.</li>
+ *   <li>{@link io.ikanos.engine.exposes.mcp.processor.CacheDataAppender} — a post-processor
+ *   adding {@code ttlMs} / {@code cacheScope} caching hints to the response.</li>
+ *   <li>{@link io.ikanos.engine.exposes.mcp.processor.ServerDataAppender} — a post-processor
+ *   stamping the {@code jsonrpc} version and server identity metadata
+ *   ({@code io.modelcontextprotocol/serverInfo}) onto the response.</li>
+ * </ul>
+ */
+package io.ikanos.engine.exposes.mcp.processor;

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/observability/McpMetaTraceContextBridge.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/observability/McpMetaTraceContextBridge.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.observability;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.opentelemetry.context.Context;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.restlet.Request;
+
+/**
+ * Bridge between the OpenTelemetry SDK and the MCP JSON-RPC message model.
+ *
+ * <p>Extracts W3C trace context ({@code traceparent}, {@code tracestate}, {@code baggage}) from
+ * the {@code params._meta} object of an inbound JSON-RPC request via
+ * {@link McpMetaTraceContextGetter}. This is the transport-agnostic counterpart to
+ * {@link OtelRestletBridge}: the MCP {@code 2026-07-28} revision documents these keys as the
+ * canonical, message-level carrier for trace context propagation, so the same extraction applies
+ * whether the request arrived over Streamable HTTP or stdio (which has no HTTP headers at
+ * all).</p>
+ *
+ * <p>Falls back to {@link Context#current()} when no trace context is present in {@code _meta}.
+ * </p>
+ */
+public final class McpMetaTraceContextBridge {
+
+    private McpMetaTraceContextBridge() {
+        // Utility class — no instances.
+    }
+
+    /**
+     * Extracts a W3C trace {@link Context} from the {@code params._meta} object of the inbound
+     * JSON-RPC {@code request} using the current {@code TextMapPropagator}. Falls back to
+     * {@link Context#current()} when no {@code traceparent} entry is present.
+     *
+     * <p>Used by transports with no HTTP layer (stdio).</p>
+     */
+    @Nonnull
+    public static Context extractContext(JsonNode request) {
+        return extractContext(request, OtelRestletBridge.currentContext());
+    }
+
+    /**
+     * Extracts a W3C trace {@link Context}, preferring the {@code params._meta} carrier of the
+     * JSON-RPC {@code request} and falling back to the W3C {@code traceparent} HTTP header of
+     * {@code httpRequest} when {@code _meta} carries no trace context.
+     *
+     * <p>The MCP {@code 2026-07-28} revision documents {@code _meta} as the canonical,
+     * transport-independent carrier, but the HTTP header remains a valid carrier for clients
+     * that have not yet adopted the {@code _meta} convention — so it is kept as a fallback
+     * rather than dropped. Used by the Streamable HTTP transport ({@link
+     * io.ikanos.engine.exposes.mcp.McpServerResource}), which has both carriers available.</p>
+     */
+    @Nonnull
+    public static Context extractContext(JsonNode request, @Nullable Request httpRequest) {
+        return extractContext(request, OtelRestletBridge.extractContext(httpRequest));
+    }
+
+    @Nonnull
+    private static Context extractContext(JsonNode request, @Nonnull Context fallbackContext) {
+        return OtelNullSafety.nonNull(TelemetryBootstrap.get().getOpenTelemetry()
+                .getPropagators().getTextMapPropagator()
+                .extract(fallbackContext, request, headerGetter()));
+    }
+
+    /**
+     * Returns the MCP {@code _meta} text-map getter singleton typed as {@code @Nonnull}.
+     */
+    @Nonnull
+    public static McpMetaTraceContextGetter headerGetter() {
+        return OtelNullSafety.nonNull(McpMetaTraceContextGetter.INSTANCE);
+    }
+}

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/observability/McpMetaTraceContextGetter.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/observability/McpMetaTraceContextGetter.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.observability;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Extracts W3C trace context ({@code traceparent}, {@code tracestate}, {@code baggage}) from
+ * the {@code params._meta} object of an inbound MCP JSON-RPC request.
+ *
+ * <p>The MCP {@code 2026-07-28} revision documents these three keys as reserved, non-prefixed
+ * {@code _meta} entries carrying OpenTelemetry trace context. Because MCP is transport-agnostic
+ * (stdio has no HTTP headers to carry a {@code traceparent}), the message-level {@code _meta}
+ * object — not an HTTP header — is the canonical, transport-independent carrier for this
+ * propagation convention. This getter is intended to be used from the shared
+ * {@code ProtocolDispatcher} so both the Streamable HTTP and stdio transports extract trace
+ * context the same way.</p>
+ *
+ * <p>Mirrors {@link RestletHeaderGetter}, which remains the HTTP-header-based carrier used by
+ * the REST and Skill adapters.</p>
+ */
+public class McpMetaTraceContextGetter implements TextMapGetter<JsonNode> {
+
+    public static final McpMetaTraceContextGetter INSTANCE = new McpMetaTraceContextGetter();
+
+    private static final String PARAMS = "params";
+    private static final String META = "_meta";
+
+    @Override
+    public Iterable<String> keys(@Nullable JsonNode request) {
+        JsonNode meta = metaNode(request);
+        if (meta == null || !meta.isObject()) {
+            return Collections.emptyList();
+        }
+        List<String> names = new ArrayList<>();
+        meta.fieldNames().forEachRemaining(names::add);
+        return names;
+    }
+
+    @Override
+    @Nullable
+    public String get(@Nullable JsonNode request, @Nonnull String key) {
+        JsonNode meta = metaNode(request);
+        if (meta == null || key == null) {
+            return null;
+        }
+        JsonNode value = meta.get(key);
+        return (value == null || value.isMissingNode() || value.isNull()) ? null : value.asText();
+    }
+
+    /**
+     * Resolves the {@code params._meta} node of the request, or {@code null} when absent.
+     */
+    @Nullable
+    private static JsonNode metaNode(@Nullable JsonNode request) {
+        if (request == null) {
+            return null;
+        }
+        JsonNode meta = request.path(PARAMS).path(META);
+        return meta.isMissingNode() ? null : meta;
+    }
+}

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/util/JsonRpcResponseBuilder.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/util/JsonRpcResponseBuilder.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import static io.ikanos.engine.exposes.mcp.ProtocolDispatcher.JSONRPC_VERSION;
+
+/**
+ * A helper class for building Json-Rpc response bodies.
+ */
+public final class JsonRpcResponseBuilder {
+
+    static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private JsonRpcResponseBuilder() {
+        // Hidden constructor
+    }
+
+    /**
+     * Build a JSON-RPC error response envelope.
+     */
+    public static ObjectNode buildJsonRpcError(JsonNode id, int code, String message) {
+        ObjectNode envelope = MAPPER.createObjectNode();
+        envelope.put("jsonrpc", JSONRPC_VERSION);
+
+        if (id != null) {
+            envelope.set("id", id);
+        } else {
+            envelope.putNull("id");
+        }
+
+        ObjectNode error = envelope.putObject("error");
+        error.put("code", code);
+        error.put("message", message);
+        return envelope;
+    }
+
+    /**
+     * Build a JSON-RPC error response envelope.
+     */
+    public static ObjectNode buildJsonRpcError(JsonNode id, int code, String message, JsonNode data) {
+        ObjectNode envelope = MAPPER.createObjectNode();
+        envelope.put("jsonrpc", JSONRPC_VERSION);
+
+        if (id != null) {
+            envelope.set("id", id);
+        } else {
+            envelope.putNull("id");
+        }
+
+        ObjectNode error = envelope.putObject("error");
+        error.put("code", code);
+        if (message != null) {
+            error.put("message", message);
+        }
+        error.set("data", data);
+        return envelope;
+    }
+}

--- a/modules/ikanos-engine/src/main/java/io/ikanos/exception/ProcessorException.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/exception/ProcessorException.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.exception;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.ikanos.engine.exposes.mcp.model.JsonRpcError;
+
+/**
+ * A custom exception for errors raised by dispatch processors.
+ */
+public class ProcessorException extends Exception {
+
+    private final JsonRpcError rpcError;
+    private final ObjectNode result;
+
+    public ProcessorException(String message, JsonRpcError rpcError, ObjectNode result) {
+        super(message);
+        this.rpcError = rpcError;
+        this.result = result;
+    }
+
+    public JsonRpcError getRpcError() {
+        return rpcError;
+    }
+
+    public ObjectNode getResult() {
+        return result;
+    }
+}

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/AggregateIntegrationTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/AggregateIntegrationTest.java
@@ -197,7 +197,8 @@ public class AggregateIntegrationTest {
         ProtocolDispatcher dispatcher = new ProtocolDispatcher(adapter);
 
         JsonNode response = dispatcher.dispatch(JSON.readTree(
-                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}"));
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\",\"params\":{\"_meta\":{\"io.modelcontextprotocol/protocolVersion\":\"%s\"}}}"
+                        .formatted(ProtocolDispatcher.MCP_PROTOCOL_VERSION))).responseBody();
 
         JsonNode tools = response.path("result").path("tools");
         assertEquals(2, tools.size());

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/McpAuthenticationIntegrationTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/McpAuthenticationIntegrationTest.java
@@ -45,170 +45,183 @@ class McpAuthenticationIntegrationTest {
     @Test
     void bearerAuthShouldRejectRequestWithoutToken() throws Exception {
         McpServerAdapter adapter = startBearerProtectedServer();
-        HttpClient client = HttpClient.newHttpClient();
-        String baseUrl = baseUrlFor(adapter);
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            String baseUrl = baseUrlFor(adapter);
 
-        try {
-            HttpResponse<String> response = client.send(
-                    HttpRequest.newBuilder(URI.create(baseUrl))
-                            .POST(HttpRequest.BodyPublishers.ofString(
-                                    "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}"))
-                            .header("Content-Type", "application/json")
-                            .build(),
-                    HttpResponse.BodyHandlers.ofString());
+            try {
+                HttpResponse<String> response = client.send(
+                        HttpRequest.newBuilder(URI.create(baseUrl))
+                                .POST(HttpRequest.BodyPublishers.ofString(discoverBody()))
+                                .header("Content-Type", "application/json")
+                                .header("MCP-Protocol-Version", ProtocolDispatcher.MCP_PROTOCOL_VERSION)
+                                .header("Mcp-Method", "server/discover")
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
 
-            assertEquals(401, response.statusCode(),
-                    "Request without bearer token should be rejected");
-        } finally {
-            adapter.stop();
+                assertEquals(401, response.statusCode(),
+                        "Request without bearer token should be rejected");
+            } finally {
+                adapter.stop();
+            }
         }
     }
 
     @Test
     void bearerAuthShouldRejectRequestWithWrongToken() throws Exception {
         McpServerAdapter adapter = startBearerProtectedServer();
-        HttpClient client = HttpClient.newHttpClient();
-        String baseUrl = baseUrlFor(adapter);
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            String baseUrl = baseUrlFor(adapter);
 
-        try {
-            HttpResponse<String> response = client.send(
-                    HttpRequest.newBuilder(URI.create(baseUrl))
-                            .POST(HttpRequest.BodyPublishers.ofString(
-                                    "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}"))
-                            .header("Content-Type", "application/json")
-                            .header("Authorization", "Bearer wrong-token")
-                            .build(),
-                    HttpResponse.BodyHandlers.ofString());
+            try {
+                HttpResponse<String> response = client.send(
+                        HttpRequest.newBuilder(URI.create(baseUrl))
+                                .POST(HttpRequest.BodyPublishers.ofString(discoverBody()))
+                                .header("Content-Type", "application/json")
+                                .header("MCP-Protocol-Version", ProtocolDispatcher.MCP_PROTOCOL_VERSION)
+                                .header("Mcp-Method", "server/discover")
+                                .header("Authorization", "Bearer wrong-token")
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
 
-            assertEquals(401, response.statusCode(),
-                    "Request with wrong bearer token should be rejected");
-        } finally {
-            adapter.stop();
+                assertEquals(401, response.statusCode(),
+                        "Request with wrong bearer token should be rejected");
+            } finally {
+                adapter.stop();
+            }
         }
     }
 
     @Test
     void bearerAuthShouldAcceptRequestWithCorrectToken() throws Exception {
         McpServerAdapter adapter = startBearerProtectedServer();
-        HttpClient client = HttpClient.newHttpClient();
-        String baseUrl = baseUrlFor(adapter);
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            String baseUrl = baseUrlFor(adapter);
 
-        try {
-            HttpResponse<String> response = client.send(
-                    HttpRequest.newBuilder(URI.create(baseUrl))
-                            .POST(HttpRequest.BodyPublishers.ofString(
-                                    "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}"))
-                            .header("Content-Type", "application/json")
-                            .header("Authorization", "Bearer mcp-secret-token-123")
-                            .build(),
-                    HttpResponse.BodyHandlers.ofString());
+            try {
+                HttpResponse<String> response = client.send(
+                        HttpRequest.newBuilder(URI.create(baseUrl))
+                                .POST(HttpRequest.BodyPublishers.ofString(discoverBody()))
+                                .header("Content-Type", "application/json")
+                                .header("MCP-Protocol-Version", ProtocolDispatcher.MCP_PROTOCOL_VERSION)
+                                .header("Mcp-Method", "server/discover")
+                                .header("Authorization", "Bearer mcp-secret-token-123")
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
 
-            assertEquals(200, response.statusCode(),
-                    "Request with correct bearer token should be accepted");
+                assertEquals(200, response.statusCode(),
+                        "Request with correct bearer token should be accepted");
 
-            JsonNode body = JSON.readTree(response.body());
-            assertNotNull(body.path("result").path("protocolVersion").asText(),
-                    "Initialize response should contain protocolVersion");
-        } finally {
-            adapter.stop();
+                JsonNode body = JSON.readTree(response.body());
+                assertNotNull(body.path("result").path("supportedVersions"),
+                        "server/discover response should contain supportedVersions");
+            } finally {
+                adapter.stop();
+            }
         }
     }
 
     @Test
     void apiKeyAuthShouldRejectRequestWithoutKey() throws Exception {
         McpServerAdapter adapter = startApiKeyProtectedServer();
-        HttpClient client = HttpClient.newHttpClient();
-        String baseUrl = baseUrlFor(adapter);
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            String baseUrl = baseUrlFor(adapter);
 
-        try {
-            HttpResponse<String> response = client.send(
-                    HttpRequest.newBuilder(URI.create(baseUrl))
-                            .POST(HttpRequest.BodyPublishers.ofString(
-                                    "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}"))
-                            .header("Content-Type", "application/json")
-                            .build(),
-                    HttpResponse.BodyHandlers.ofString());
+            try {
+                HttpResponse<String> response = client.send(
+                        HttpRequest.newBuilder(URI.create(baseUrl))
+                                .POST(HttpRequest.BodyPublishers.ofString(discoverBody()))
+                                .header("Content-Type", "application/json")
+                                .header("MCP-Protocol-Version", ProtocolDispatcher.MCP_PROTOCOL_VERSION)
+                                .header("Mcp-Method", "server/discover")
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
 
-            assertEquals(401, response.statusCode(),
-                    "Request without API key should be rejected");
-        } finally {
-            adapter.stop();
+                assertEquals(401, response.statusCode(),
+                        "Request without API key should be rejected");
+            } finally {
+                adapter.stop();
+            }
         }
     }
 
     @Test
     void apiKeyAuthShouldAcceptRequestWithCorrectKey() throws Exception {
         McpServerAdapter adapter = startApiKeyProtectedServer();
-        HttpClient client = HttpClient.newHttpClient();
-        String baseUrl = baseUrlFor(adapter);
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            String baseUrl = baseUrlFor(adapter);
 
-        try {
-            HttpResponse<String> response = client.send(
-                    HttpRequest.newBuilder(URI.create(baseUrl))
-                            .POST(HttpRequest.BodyPublishers.ofString(
-                                    "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}"))
-                            .header("Content-Type", "application/json")
-                            .header("X-MCP-Key", "abc-key-456")
-                            .build(),
-                    HttpResponse.BodyHandlers.ofString());
+            try {
+                HttpResponse<String> response = client.send(
+                        HttpRequest.newBuilder(URI.create(baseUrl))
+                                .POST(HttpRequest.BodyPublishers.ofString(discoverBody()))
+                                .header("Content-Type", "application/json")
+                                .header("MCP-Protocol-Version", ProtocolDispatcher.MCP_PROTOCOL_VERSION)
+                                .header("Mcp-Method", "server/discover")
+                                .header("X-MCP-Key", "abc-key-456")
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
 
-            assertEquals(200, response.statusCode(),
-                    "Request with correct API key should be accepted");
+                assertEquals(200, response.statusCode(),
+                        "Request with correct API key should be accepted");
 
-            JsonNode body = JSON.readTree(response.body());
-            assertNotNull(body.path("result").path("protocolVersion").asText(),
-                    "Initialize response should contain protocolVersion");
-        } finally {
-            adapter.stop();
+                JsonNode body = JSON.readTree(response.body());
+                assertNotNull(body.path("result").path("supportedVersions"),
+                        "server/discover response should contain supportedVersions");
+            } finally {
+                adapter.stop();
+            }
         }
     }
 
     @Test
     void bearerAuthShouldProtectAllMethods() throws Exception {
         McpServerAdapter adapter = startBearerProtectedServer();
-        HttpClient client = HttpClient.newHttpClient();
-        String baseUrl = baseUrlFor(adapter);
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            String baseUrl = baseUrlFor(adapter);
 
-        try {
-            // GET without token should be rejected
-            HttpResponse<String> getResponse = client.send(
-                    HttpRequest.newBuilder(URI.create(baseUrl)).GET().build(),
-                    HttpResponse.BodyHandlers.ofString());
-            assertEquals(401, getResponse.statusCode(),
-                    "GET without token should be rejected");
+            try {
+                // GET without token should be rejected
+                HttpResponse<String> getResponse = client.send(
+                        HttpRequest.newBuilder(URI.create(baseUrl)).GET().build(),
+                        HttpResponse.BodyHandlers.ofString());
+                assertEquals(401, getResponse.statusCode(),
+                        "GET without token should be rejected");
 
-            // DELETE without token should be rejected
-            HttpResponse<String> deleteResponse = client.send(
-                    HttpRequest.newBuilder(URI.create(baseUrl))
-                            .method("DELETE", HttpRequest.BodyPublishers.noBody())
-                            .build(),
-                    HttpResponse.BodyHandlers.ofString());
-            assertEquals(401, deleteResponse.statusCode(),
-                    "DELETE without token should be rejected");
-        } finally {
-            adapter.stop();
+                // DELETE without token should be rejected
+                HttpResponse<String> deleteResponse = client.send(
+                        HttpRequest.newBuilder(URI.create(baseUrl))
+                                .method("DELETE", HttpRequest.BodyPublishers.noBody())
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
+                assertEquals(401, deleteResponse.statusCode(),
+                        "DELETE without token should be rejected");
+            } finally {
+                adapter.stop();
+            }
         }
     }
 
     @Test
     void noAuthShouldAllowAllRequests() throws Exception {
         McpServerAdapter adapter = startUnprotectedServer();
-        HttpClient client = HttpClient.newHttpClient();
-        String baseUrl = baseUrlFor(adapter);
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            String baseUrl = baseUrlFor(adapter);
 
-        try {
-            HttpResponse<String> response = client.send(
-                    HttpRequest.newBuilder(URI.create(baseUrl))
-                            .POST(HttpRequest.BodyPublishers.ofString(
-                                    "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}"))
-                            .header("Content-Type", "application/json")
-                            .build(),
-                    HttpResponse.BodyHandlers.ofString());
+            try {
+                HttpResponse<String> response = client.send(
+                        HttpRequest.newBuilder(URI.create(baseUrl))
+                                .POST(HttpRequest.BodyPublishers.ofString(discoverBody()))
+                                .header("Content-Type", "application/json")
+                                .header("MCP-Protocol-Version", ProtocolDispatcher.MCP_PROTOCOL_VERSION)
+                                .header("Mcp-Method", "server/discover")
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
 
-            assertEquals(200, response.statusCode(),
-                    "Unprotected server should accept all requests");
-        } finally {
-            adapter.stop();
+                assertEquals(200, response.statusCode(),
+                        "Unprotected server should accept all requests");
+            } finally {
+                adapter.stop();
+            }
         }
     }
 
@@ -220,41 +233,50 @@ class McpAuthenticationIntegrationTest {
         try {
             McpServerAdapter adapter = startBearerProtectedServerWithBinding(
                     secretsFile.toUri().toString());
-            HttpClient client = HttpClient.newHttpClient();
-            String baseUrl = baseUrlFor(adapter);
+            try (HttpClient client = HttpClient.newHttpClient()) {
+                String baseUrl = baseUrlFor(adapter);
 
-            try {
-                // Correct token from the file should be accepted
-                HttpResponse<String> response = client.send(
-                        HttpRequest.newBuilder(URI.create(baseUrl))
-                                .POST(HttpRequest.BodyPublishers.ofString(
-                                        "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}"))
-                                .header("Content-Type", "application/json")
-                                .header("Authorization", "Bearer sk-mcp-from-file")
-                                .build(),
-                        HttpResponse.BodyHandlers.ofString());
+                try {
+                    // Correct token from the file should be accepted
+                    HttpResponse<String> response = client.send(
+                            HttpRequest.newBuilder(URI.create(baseUrl))
+                                    .POST(HttpRequest.BodyPublishers.ofString(discoverBody()))
+                                    .header("Content-Type", "application/json")
+                                    .header("MCP-Protocol-Version", ProtocolDispatcher.MCP_PROTOCOL_VERSION)
+                                    .header("Mcp-Method", "server/discover")
+                                    .header("Authorization", "Bearer sk-mcp-from-file")
+                                    .build(),
+                            HttpResponse.BodyHandlers.ofString());
 
-                assertEquals(200, response.statusCode(),
-                        "Token resolved from file binding should be accepted");
+                    assertEquals(200, response.statusCode(),
+                            "Token resolved from file binding should be accepted");
 
-                // Wrong token should still be rejected
-                HttpResponse<String> rejectedResponse = client.send(
-                        HttpRequest.newBuilder(URI.create(baseUrl))
-                                .POST(HttpRequest.BodyPublishers.ofString(
-                                        "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}"))
-                                .header("Content-Type", "application/json")
-                                .header("Authorization", "Bearer wrong-token")
-                                .build(),
-                        HttpResponse.BodyHandlers.ofString());
+                    // Wrong token should still be rejected
+                    HttpResponse<String> rejectedResponse = client.send(
+                            HttpRequest.newBuilder(URI.create(baseUrl))
+                                    .POST(HttpRequest.BodyPublishers.ofString(discoverBody()))
+                                    .header("Content-Type", "application/json")
+                                    .header("MCP-Protocol-Version", ProtocolDispatcher.MCP_PROTOCOL_VERSION)
+                                    .header("Mcp-Method", "server/discover")
+                                    .header("Authorization", "Bearer wrong-token")
+                                    .build(),
+                            HttpResponse.BodyHandlers.ofString());
 
-                assertEquals(401, rejectedResponse.statusCode(),
-                        "Wrong token should still be rejected when using file binding");
-            } finally {
-                adapter.stop();
+                    assertEquals(401, rejectedResponse.statusCode(),
+                            "Wrong token should still be rejected when using file binding");
+                } finally {
+                    adapter.stop();
+                }
             }
         } finally {
             Files.deleteIfExists(secretsFile);
         }
+    }
+
+    private static String discoverBody() {
+        return "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"server/discover\","
+                + "\"params\":{\"_meta\":{\"io.modelcontextprotocol/protocolVersion\":\""
+                + ProtocolDispatcher.MCP_PROTOCOL_VERSION + "\"}}}";
     }
 
     private McpServerAdapter startBearerProtectedServer() throws Exception {

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/McpBinaryStdioIntegrationTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/McpBinaryStdioIntegrationTest.java
@@ -86,13 +86,10 @@ public class McpBinaryStdioIntegrationTest {
 
             ProtocolDispatcher dispatcher = new ProtocolDispatcher(adapter);
 
-            String input = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\","
-                    + "\"params\":{\"protocolVersion\":\"2025-11-25\","
-                    + "\"clientInfo\":{\"name\":\"test\",\"version\":\"1.0\"},"
-                    + "\"capabilities\":{}}}\n"
-                    + "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n"
-                    + "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\","
-                    + "\"params\":{\"name\":\"get-photo\",\"arguments\":{\"id\":\"p-1\"}}}\n";
+            String input = "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\","
+                    + "\"params\":{\"name\":\"get-photo\",\"arguments\":{\"id\":\"p-1\"},"
+                    + "\"_meta\":{\"io.modelcontextprotocol/protocolVersion\":\""
+                    + ProtocolDispatcher.MCP_PROTOCOL_VERSION + "\"}}}\n";
 
             ByteArrayInputStream in =
                     new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8));
@@ -103,11 +100,12 @@ public class McpBinaryStdioIntegrationTest {
 
             String output = out.toString(StandardCharsets.UTF_8);
             String[] lines = output.strip().split("\\n");
-            // initialize + tools/call (the notification produces no response line).
-            assertEquals(2, lines.length, "expected initialize + tools/call responses");
+            // Protocol 2026-07-28 is stateless — no initialize/notifications handshake, so a
+            // single tools/call line produces a single response line.
+            assertEquals(1, lines.length, "expected a single tools/call response");
 
             ObjectMapper mapper = new ObjectMapper();
-            JsonNode callResponse = mapper.readTree(lines[1]);
+            JsonNode callResponse = mapper.readTree(lines[0]);
             assertEquals(2, callResponse.path("id").asInt());
 
             JsonNode result = callResponse.path("result");

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/McpOAuth2IntegrationTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/McpOAuth2IntegrationTest.java
@@ -118,155 +118,164 @@ class McpOAuth2IntegrationTest {
     @Test
     void oauth2ShouldRejectRequestWithoutToken() throws Exception {
         McpServerAdapter adapter = startOAuth2Server();
-        HttpClient client = HttpClient.newHttpClient();
-        String baseUrl = baseUrlFor(adapter);
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            String baseUrl = baseUrlFor(adapter);
 
-        try {
-            HttpResponse<String> response = client.send(
-                    HttpRequest.newBuilder(URI.create(baseUrl))
-                            .POST(HttpRequest.BodyPublishers.ofString(
-                                    "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}"))
-                            .header("Content-Type", "application/json")
-                            .build(),
-                    HttpResponse.BodyHandlers.ofString());
+            try {
+                HttpResponse<String> response = client.send(
+                        HttpRequest.newBuilder(URI.create(baseUrl))
+                                .POST(HttpRequest.BodyPublishers.ofString(discoverBody()))
+                                .header("Content-Type", "application/json")
+                                .header("MCP-Protocol-Version", ProtocolDispatcher.MCP_PROTOCOL_VERSION)
+                                .header("Mcp-Method", "server/discover")
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
 
-            assertEquals(401, response.statusCode(),
-                    "Request without bearer token should return 401");
+                assertEquals(401, response.statusCode(),
+                        "Request without bearer token should return 401");
 
-            String wwwAuth = response.headers().firstValue("WWW-Authenticate").orElse("");
-            assertTrue(wwwAuth.contains("Bearer"), "Should contain Bearer challenge");
-            assertTrue(wwwAuth.contains("resource_metadata"),
-                    "Should contain resource_metadata URL");
-        } finally {
-            adapter.stop();
+                String wwwAuth = response.headers().firstValue("WWW-Authenticate").orElse("");
+                assertTrue(wwwAuth.contains("Bearer"), "Should contain Bearer challenge");
+                assertTrue(wwwAuth.contains("resource_metadata"),
+                        "Should contain resource_metadata URL");
+            } finally {
+                adapter.stop();
+            }
         }
     }
 
     @Test
     void oauth2ShouldRejectExpiredToken() throws Exception {
         McpServerAdapter adapter = startOAuth2Server();
-        HttpClient client = HttpClient.newHttpClient();
-        String baseUrl = baseUrlFor(adapter);
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            String baseUrl = baseUrlFor(adapter);
 
-        try {
-            String token = signedJwt(new JWTClaimsSet.Builder()
-                    .issuer("http://127.0.0.1:" + mockAsPort)
-                    .audience("http://127.0.0.1:" + adapter.getMcpServerSpec().getPort() + "/mcp")
-                    .expirationTime(new Date(System.currentTimeMillis() - 60_000))
-                    .claim("scope", "tools:read")
-                    .build());
+            try {
+                String token = signedJwt(new JWTClaimsSet.Builder()
+                        .issuer("http://127.0.0.1:" + mockAsPort)
+                        .audience("http://127.0.0.1:" + adapter.getMcpServerSpec().getPort() + "/mcp")
+                        .expirationTime(new Date(System.currentTimeMillis() - 60_000))
+                        .claim("scope", "tools:read")
+                        .build());
 
-            HttpResponse<String> response = client.send(
-                    HttpRequest.newBuilder(URI.create(baseUrl))
-                            .POST(HttpRequest.BodyPublishers.ofString(
-                                    "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}"))
-                            .header("Content-Type", "application/json")
-                            .header("Authorization", "Bearer " + token)
-                            .build(),
-                    HttpResponse.BodyHandlers.ofString());
+                HttpResponse<String> response = client.send(
+                        HttpRequest.newBuilder(URI.create(baseUrl))
+                                .POST(HttpRequest.BodyPublishers.ofString(discoverBody()))
+                                .header("Content-Type", "application/json")
+                                .header("MCP-Protocol-Version", ProtocolDispatcher.MCP_PROTOCOL_VERSION)
+                                .header("Mcp-Method", "server/discover")
+                                .header("Authorization", "Bearer " + token)
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
 
-            assertEquals(401, response.statusCode(),
-                    "Expired token should return 401");
-        } finally {
-            adapter.stop();
+                assertEquals(401, response.statusCode(),
+                        "Expired token should return 401");
+            } finally {
+                adapter.stop();
+            }
         }
     }
 
     @Test
     void oauth2ShouldAcceptValidToken() throws Exception {
         McpServerAdapter adapter = startOAuth2Server();
-        HttpClient client = HttpClient.newHttpClient();
-        String baseUrl = baseUrlFor(adapter);
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            String baseUrl = baseUrlFor(adapter);
 
-        try {
-            String resourceUri = "http://127.0.0.1:" + adapter.getMcpServerSpec().getPort() + "/mcp";
-            String token = signedJwt(new JWTClaimsSet.Builder()
-                    .issuer("http://127.0.0.1:" + mockAsPort)
-                    .audience(resourceUri)
-                    .expirationTime(new Date(System.currentTimeMillis() + 300_000))
-                    .claim("scope", "tools:read")
-                    .build());
+            try {
+                String resourceUri = "http://127.0.0.1:" + adapter.getMcpServerSpec().getPort() + "/mcp";
+                String token = signedJwt(new JWTClaimsSet.Builder()
+                        .issuer("http://127.0.0.1:" + mockAsPort)
+                        .audience(resourceUri)
+                        .expirationTime(new Date(System.currentTimeMillis() + 300_000))
+                        .claim("scope", "tools:read")
+                        .build());
 
-            HttpResponse<String> response = client.send(
-                    HttpRequest.newBuilder(URI.create(baseUrl))
-                            .POST(HttpRequest.BodyPublishers.ofString(
-                                    "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}"))
-                            .header("Content-Type", "application/json")
-                            .header("Authorization", "Bearer " + token)
-                            .build(),
-                    HttpResponse.BodyHandlers.ofString());
+                HttpResponse<String> response = client.send(
+                        HttpRequest.newBuilder(URI.create(baseUrl))
+                                .POST(HttpRequest.BodyPublishers.ofString(discoverBody()))
+                                .header("Content-Type", "application/json")
+                                .header("MCP-Protocol-Version", ProtocolDispatcher.MCP_PROTOCOL_VERSION)
+                                .header("Mcp-Method", "server/discover")
+                                .header("Authorization", "Bearer " + token)
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
 
-            assertEquals(200, response.statusCode(),
-                    "Valid token should return 200");
+                assertEquals(200, response.statusCode(),
+                        "Valid token should return 200");
 
-            JsonNode body = JSON.readTree(response.body());
-            assertNotNull(body.path("result").path("protocolVersion").asText(null),
-                    "Initialize response should contain protocolVersion");
-        } finally {
-            adapter.stop();
+                JsonNode body = JSON.readTree(response.body());
+                assertNotNull(body.path("result").path("supportedVersions"),
+                        "server/discover response should contain supportedVersions");
+            } finally {
+                adapter.stop();
+            }
         }
     }
 
     @Test
     void oauth2ShouldServeProtectedResourceMetadata() throws Exception {
         McpServerAdapter adapter = startOAuth2Server();
-        HttpClient client = HttpClient.newHttpClient();
-        String baseUrl = "http://127.0.0.1:" + adapter.getMcpServerSpec().getPort();
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            String baseUrl = "http://127.0.0.1:" + adapter.getMcpServerSpec().getPort();
 
-        try {
-            HttpResponse<String> response = client.send(
-                    HttpRequest.newBuilder(
-                            URI.create(baseUrl + "/.well-known/oauth-protected-resource/mcp"))
-                            .GET()
-                            .build(),
-                    HttpResponse.BodyHandlers.ofString());
+            try {
+                HttpResponse<String> response = client.send(
+                        HttpRequest.newBuilder(
+                                        URI.create(baseUrl + "/.well-known/oauth-protected-resource/mcp"))
+                                .GET()
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
 
-            assertEquals(200, response.statusCode(),
-                    "Protected Resource Metadata should be served");
+                assertEquals(200, response.statusCode(),
+                        "Protected Resource Metadata should be served");
 
-            JsonNode metadata = JSON.readTree(response.body());
-            assertNotNull(metadata.get("resource"), "Metadata should contain resource");
-            assertNotNull(metadata.get("authorization_servers"),
-                    "Metadata should contain authorization_servers");
-            assertEquals("header",
-                    metadata.get("bearer_methods_supported").get(0).asText());
-        } finally {
-            adapter.stop();
+                JsonNode metadata = JSON.readTree(response.body());
+                assertNotNull(metadata.get("resource"), "Metadata should contain resource");
+                assertNotNull(metadata.get("authorization_servers"),
+                        "Metadata should contain authorization_servers");
+                assertEquals("header",
+                        metadata.get("bearer_methods_supported").get(0).asText());
+            } finally {
+                adapter.stop();
+            }
         }
     }
 
     @Test
     void oauth2ShouldReturnForbiddenForInsufficientScope() throws Exception {
         McpServerAdapter adapter = startOAuth2ServerWithScopes();
-        HttpClient client = HttpClient.newHttpClient();
-        String baseUrl = baseUrlFor(adapter);
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            String baseUrl = baseUrlFor(adapter);
 
-        try {
-            String resourceUri = "http://127.0.0.1:" + adapter.getMcpServerSpec().getPort() + "/mcp";
-            String token = signedJwt(new JWTClaimsSet.Builder()
-                    .issuer("http://127.0.0.1:" + mockAsPort)
-                    .audience(resourceUri)
-                    .expirationTime(new Date(System.currentTimeMillis() + 300_000))
-                    .claim("scope", "tools:read")
-                    .build());
+            try {
+                String resourceUri = "http://127.0.0.1:" + adapter.getMcpServerSpec().getPort() + "/mcp";
+                String token = signedJwt(new JWTClaimsSet.Builder()
+                        .issuer("http://127.0.0.1:" + mockAsPort)
+                        .audience(resourceUri)
+                        .expirationTime(new Date(System.currentTimeMillis() + 300_000))
+                        .claim("scope", "tools:read")
+                        .build());
 
-            HttpResponse<String> response = client.send(
-                    HttpRequest.newBuilder(URI.create(baseUrl))
-                            .POST(HttpRequest.BodyPublishers.ofString(
-                                    "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}"))
-                            .header("Content-Type", "application/json")
-                            .header("Authorization", "Bearer " + token)
-                            .build(),
-                    HttpResponse.BodyHandlers.ofString());
+                HttpResponse<String> response = client.send(
+                        HttpRequest.newBuilder(URI.create(baseUrl))
+                                .POST(HttpRequest.BodyPublishers.ofString(discoverBody()))
+                                .header("Content-Type", "application/json")
+                                .header("MCP-Protocol-Version", ProtocolDispatcher.MCP_PROTOCOL_VERSION)
+                                .header("Mcp-Method", "server/discover")
+                                .header("Authorization", "Bearer " + token)
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
 
-            assertEquals(403, response.statusCode(),
-                    "Token missing required scope should return 403");
+                assertEquals(403, response.statusCode(),
+                        "Token missing required scope should return 403");
 
-            String wwwAuth = response.headers().firstValue("WWW-Authenticate").orElse("");
-            assertTrue(wwwAuth.contains("insufficient_scope"));
-            assertTrue(wwwAuth.contains("resource_metadata"));
-        } finally {
-            adapter.stop();
+                String wwwAuth = response.headers().firstValue("WWW-Authenticate").orElse("");
+                assertTrue(wwwAuth.contains("insufficient_scope"));
+                assertTrue(wwwAuth.contains("resource_metadata"));
+            } finally {
+                adapter.stop();
+            }
         }
     }
 
@@ -363,6 +372,12 @@ class McpOAuth2IntegrationTest {
         try (ServerSocket socket = new ServerSocket(0)) {
             return socket.getLocalPort();
         }
+    }
+
+    private static String discoverBody() {
+        return "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"server/discover\","
+                + "\"params\":{\"_meta\":{\"io.modelcontextprotocol/protocolVersion\":\""
+                + ProtocolDispatcher.MCP_PROTOCOL_VERSION + "\"}}}";
     }
 
 }

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/McpServerResourceTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/McpServerResourceTest.java
@@ -33,10 +33,13 @@ import io.ikanos.spec.IkanosSpec;
 import io.ikanos.spec.exposes.mcp.McpServerSpec;
 
 /**
- * Unit tests for the Restlet-based MCP Streamable HTTP transport.
- * 
- * Validates POST dispatch, DELETE session removal, GET rejection, empty body handling,
- * and malformed JSON handling through actual HTTP calls.
+ * Unit tests for the Restlet-based MCP Streamable HTTP transport (protocol revision
+ * {@code 2026-07-28}).
+ *
+ * <p>Validates POST dispatch, GET/DELETE rejection (protocol-level sessions and the GET stream
+ * endpoint were removed in this revision), empty body handling, malformed JSON handling, and the
+ * new mandatory request-metadata headers ({@code MCP-Protocol-Version}, {@code Mcp-Method},
+ * {@code Mcp-Name}) through actual HTTP calls.</p>
  */
 class McpServerResourceTest {
 
@@ -47,213 +50,269 @@ class McpServerResourceTest {
     @Test
     void getShouldReturn405WithNotSupportedMessage() throws Exception {
         McpServerAdapter adapter = startAdapterOnFreePort();
-        HttpClient client = HttpClient.newHttpClient();
-        String baseUrl = baseUrlFor(adapter);
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            String baseUrl = baseUrlFor(adapter);
 
-        try {
-            HttpResponse<String> response = client.send(
-                    HttpRequest.newBuilder(URI.create(baseUrl)).GET().build(),
-                    HttpResponse.BodyHandlers.ofString());
+            try {
+                HttpResponse<String> response = client.send(
+                        HttpRequest.newBuilder(URI.create(baseUrl)).GET().build(),
+                        HttpResponse.BodyHandlers.ofString());
 
-            assertEquals(405, response.statusCode());
-            assertEquals("GET not supported", response.body());
-        } finally {
-            adapter.stop();
+                assertEquals(405, response.statusCode());
+                assertEquals("GET not supported", response.body());
+            } finally {
+                adapter.stop();
+            }
+        }
+    }
+
+    @Test
+    void deleteShouldReturn405RegardlessOfSessionHeader() throws Exception {
+        McpServerAdapter adapter = startAdapterOnFreePort();
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            String baseUrl = baseUrlFor(adapter);
+
+            try {
+                HttpResponse<String> withoutHeader = client.send(
+                        HttpRequest.newBuilder(URI.create(baseUrl))
+                                .method("DELETE", HttpRequest.BodyPublishers.noBody())
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
+                assertEquals(405, withoutHeader.statusCode());
+
+                HttpResponse<String> withStaleSessionHeader = client.send(
+                        HttpRequest.newBuilder(URI.create(baseUrl))
+                                .method("DELETE", HttpRequest.BodyPublishers.noBody())
+                                .header("Mcp-Session-Id", "some-legacy-session-id")
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
+                assertEquals(405, withStaleSessionHeader.statusCode(),
+                        "A stale Mcp-Session-Id header from a pre-2026-07-28 client must be ignored");
+            } finally {
+                adapter.stop();
+            }
         }
     }
 
     @Test
     void postWithEmptyBodyShouldReturnParseError() throws Exception {
         McpServerAdapter adapter = startAdapterOnFreePort();
-        HttpClient client = HttpClient.newHttpClient();
-        String baseUrl = baseUrlFor(adapter);
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            String baseUrl = baseUrlFor(adapter);
 
-        try {
-            HttpResponse<String> response = client.send(
-                    HttpRequest.newBuilder(URI.create(baseUrl))
-                            .POST(HttpRequest.BodyPublishers.ofString(""))
-                            .header("Content-Type", "application/json")
-                            .build(),
-                    HttpResponse.BodyHandlers.ofString());
+            try {
+                HttpResponse<String> response = client.send(
+                        HttpRequest.newBuilder(URI.create(baseUrl))
+                                .POST(HttpRequest.BodyPublishers.ofString(""))
+                                .header("Content-Type", "application/json")
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
 
-            assertEquals(200, response.statusCode());
-            JsonNode body = JSON.readTree(response.body());
-            assertEquals(-32700, body.path("error").path("code").asInt());
-            assertTrue(body.path("error").path("message").asText().contains("empty body"));
-        } finally {
-            adapter.stop();
+                assertEquals(400, response.statusCode());
+                JsonNode body = JSON.readTree(response.body());
+                assertEquals(-32700, body.path("error").path("code").asInt());
+                assertTrue(body.path("error").path("message").asText().contains("empty body"));
+            } finally {
+                adapter.stop();
+            }
         }
     }
 
     @Test
     void postWithMalformedJsonShouldReturnParseError() throws Exception {
         McpServerAdapter adapter = startAdapterOnFreePort();
-        HttpClient client = HttpClient.newHttpClient();
-        String baseUrl = baseUrlFor(adapter);
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            String baseUrl = baseUrlFor(adapter);
 
-        try {
-            HttpResponse<String> response = client.send(
-                    HttpRequest.newBuilder(URI.create(baseUrl))
-                            .POST(HttpRequest.BodyPublishers.ofString("{"))
-                            .header("Content-Type", "application/json")
-                            .build(),
-                    HttpResponse.BodyHandlers.ofString());
+            try {
+                HttpResponse<String> response = client.send(
+                        HttpRequest.newBuilder(URI.create(baseUrl))
+                                .POST(HttpRequest.BodyPublishers.ofString("{"))
+                                .header("Content-Type", "application/json")
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
 
-            assertEquals(200, response.statusCode());
-            JsonNode body = JSON.readTree(response.body());
-            assertEquals(-32700, body.path("error").path("code").asInt());
-        } finally {
-            adapter.stop();
-        }
-    }
-
-    @Test
-    void initializeShouldReturnSessionIdHeader() throws Exception {
-        McpServerAdapter adapter = startAdapterOnFreePort();
-        HttpClient client = HttpClient.newHttpClient();
-        String baseUrl = baseUrlFor(adapter);
-
-        try {
-            HttpResponse<String> response = client.send(
-                    HttpRequest.newBuilder(URI.create(baseUrl))
-                            .POST(HttpRequest.BodyPublishers.ofString(
-                                    "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}"))
-                            .header("Content-Type", "application/json")
-                            .build(),
-                    HttpResponse.BodyHandlers.ofString());
-
-            assertEquals(200, response.statusCode());
-            String sessionId =
-                    response.headers().firstValue("Mcp-Session-Id").orElse(null);
-            assertNotNull(sessionId);
-
-            JsonNode body = JSON.readTree(response.body());
-            assertEquals("2.0", body.path("jsonrpc").asText());
-            assertEquals(1, body.path("id").asInt());
-            assertNotNull(body.path("result").path("protocolVersion").asText());
-        } finally {
-            adapter.stop();
-        }
-    }
-
-    @Test
-    void notificationsInitializedShouldReturn202() throws Exception {
-        McpServerAdapter adapter = startAdapterOnFreePort();
-        HttpClient client = HttpClient.newHttpClient();
-        String baseUrl = baseUrlFor(adapter);
-
-        try {
-            HttpResponse<String> response = client.send(
-                    HttpRequest.newBuilder(URI.create(baseUrl))
-                            .POST(HttpRequest.BodyPublishers.ofString(
-                                    "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}"))
-                            .header("Content-Type", "application/json")
-                            .build(),
-                    HttpResponse.BodyHandlers.ofString());
-
-            assertEquals(202, response.statusCode());
-            assertTrue(response.body() == null || response.body().isBlank());
-        } finally {
-            adapter.stop();
-        }
-    }
-
-    @Test
-    void deleteShouldReturn200AndRemoveSession() throws Exception {
-        McpServerAdapter adapter = startAdapterOnFreePort();
-        HttpClient client = HttpClient.newHttpClient();
-        String baseUrl = baseUrlFor(adapter);
-
-        try {
-            // First initialize to get a session ID
-            HttpResponse<String> initResponse = client.send(
-                    HttpRequest.newBuilder(URI.create(baseUrl))
-                            .POST(HttpRequest.BodyPublishers.ofString(
-                                    "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}"))
-                            .header("Content-Type", "application/json")
-                            .build(),
-                    HttpResponse.BodyHandlers.ofString());
-            String sessionId =
-                    initResponse.headers().firstValue("Mcp-Session-Id").orElse(null);
-            assertNotNull(sessionId);
-
-            // DELETE with session ID
-            HttpResponse<String> deleteResponse = client.send(
-                    HttpRequest.newBuilder(URI.create(baseUrl))
-                            .method("DELETE", HttpRequest.BodyPublishers.noBody())
-                            .header("Mcp-Session-Id", sessionId)
-                            .build(),
-                    HttpResponse.BodyHandlers.ofString());
-
-            assertEquals(200, deleteResponse.statusCode());
-        } finally {
-            adapter.stop();
-        }
-    }
-
-    @Test
-    void deleteShouldReturn200EvenWithoutSessionHeader() throws Exception {
-        McpServerAdapter adapter = startAdapterOnFreePort();
-        HttpClient client = HttpClient.newHttpClient();
-        String baseUrl = baseUrlFor(adapter);
-
-        try {
-            HttpResponse<String> response = client.send(
-                    HttpRequest.newBuilder(URI.create(baseUrl))
-                            .method("DELETE", HttpRequest.BodyPublishers.noBody())
-                            .build(),
-                    HttpResponse.BodyHandlers.ofString());
-
-            assertEquals(200, response.statusCode());
-        } finally {
-            adapter.stop();
+                assertEquals(400, response.statusCode());
+                JsonNode body = JSON.readTree(response.body());
+                assertEquals(-32700, body.path("error").path("code").asInt());
+            } finally {
+                adapter.stop();
+            }
         }
     }
 
     @Test
     void postShouldReturnMethodNotFoundForUnknownRpcMethod() throws Exception {
         McpServerAdapter adapter = startAdapterOnFreePort();
-        HttpClient client = HttpClient.newHttpClient();
-        String baseUrl = baseUrlFor(adapter);
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            String baseUrl = baseUrlFor(adapter);
 
-        try {
-            HttpResponse<String> response = client.send(
-                    HttpRequest.newBuilder(URI.create(baseUrl))
-                            .POST(HttpRequest.BodyPublishers.ofString(
-                                    "{\"jsonrpc\":\"2.0\",\"id\":9,\"method\":\"unknown/method\"}"))
-                            .header("Content-Type", "application/json")
-                            .build(),
-                    HttpResponse.BodyHandlers.ofString());
+            try {
+                HttpResponse<String> response = client.send(
+                        HttpRequest.newBuilder(URI.create(baseUrl))
+                                .POST(HttpRequest.BodyPublishers.ofString(
+                                        "{\"jsonrpc\":\"2.0\",\"id\":9,\"method\":\"unknown/method\"}"))
+                                .header("Content-Type", "application/json")
+                                .header("Mcp-Method", "unknown/method")
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
 
-            assertEquals(200, response.statusCode());
-            JsonNode body = JSON.readTree(response.body());
-            assertEquals(-32601, body.path("error").path("code").asInt());
-            assertFalse(body.path("error").path("message").asText().isBlank());
-        } finally {
-            adapter.stop();
+                assertEquals(404, response.statusCode());
+                JsonNode body = JSON.readTree(response.body());
+                assertEquals(-32601, body.path("error").path("code").asInt());
+                assertFalse(body.path("error").path("message").asText().isBlank());
+            } finally {
+                adapter.stop();
+            }
+        }
+    }
+
+    @Test
+    void postShouldReturnHeaderMismatchWhenMcpMethodHeaderIsMissing() throws Exception {
+        McpServerAdapter adapter = startAdapterOnFreePort();
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            String baseUrl = baseUrlFor(adapter);
+
+            try {
+                HttpResponse<String> response = client.send(
+                        HttpRequest.newBuilder(URI.create(baseUrl))
+                                .POST(HttpRequest.BodyPublishers.ofString(
+                                        "{\"jsonrpc\":\"2.0\",\"id\":9,\"method\":\"tools/list\",\"params\":{}}"))
+                                .header("Content-Type", "application/json")
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
+
+                assertEquals(400, response.statusCode());
+                JsonNode body = JSON.readTree(response.body());
+                assertEquals(-32020, body.path("error").path("code").asInt());
+                assertTrue(body.path("error").path("message").asText().contains("Mcp-Method"));
+            } finally {
+                adapter.stop();
+            }
         }
     }
 
     @Test
     void postShouldReturnInvalidRequestForBadJsonRpcVersion() throws Exception {
         McpServerAdapter adapter = startAdapterOnFreePort();
-        HttpClient client = HttpClient.newHttpClient();
-        String baseUrl = baseUrlFor(adapter);
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            String baseUrl = baseUrlFor(adapter);
 
-        try {
-            HttpResponse<String> response = client.send(
-                    HttpRequest.newBuilder(URI.create(baseUrl))
-                            .POST(HttpRequest.BodyPublishers.ofString(
-                                    "{\"jsonrpc\":\"1.0\",\"id\":1,\"method\":\"initialize\"}"))
-                            .header("Content-Type", "application/json")
-                            .build(),
-                    HttpResponse.BodyHandlers.ofString());
+            try {
+                HttpResponse<String> response = client.send(
+                        HttpRequest.newBuilder(URI.create(baseUrl))
+                                .POST(HttpRequest.BodyPublishers.ofString(
+                                        "{\"jsonrpc\":\"1.0\",\"id\":1,\"method\":\"tools/list\","
+                                                + "\"params\":{\"_meta\":{\"io.modelcontextprotocol/protocolVersion\":\""
+                                                + ProtocolDispatcher.MCP_PROTOCOL_VERSION + "\"}}}"))
+                                .header("Content-Type", "application/json")
+                                .header("MCP-Protocol-Version", ProtocolDispatcher.MCP_PROTOCOL_VERSION)
+                                .header("Mcp-Method", "tools/list")
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
 
-            assertEquals(200, response.statusCode());
-            JsonNode body = JSON.readTree(response.body());
-            assertEquals(-32600, body.path("error").path("code").asInt());
-        } finally {
-            adapter.stop();
+                assertEquals(400, response.statusCode());
+                JsonNode body = JSON.readTree(response.body());
+                assertEquals(-32600, body.path("error").path("code").asInt());
+            } finally {
+                adapter.stop();
+            }
+        }
+    }
+
+    @Test
+    void serverDiscoverShouldSucceedWithValidHeaders() throws Exception {
+        McpServerAdapter adapter = startAdapterOnFreePort();
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            String baseUrl = baseUrlFor(adapter);
+
+            try {
+                HttpResponse<String> response = client.send(
+                        HttpRequest.newBuilder(URI.create(baseUrl))
+                                .POST(HttpRequest.BodyPublishers.ofString(
+                                        "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"server/discover\","
+                                                + "\"params\":{\"_meta\":{\"io.modelcontextprotocol/protocolVersion\":\""
+                                                + ProtocolDispatcher.MCP_PROTOCOL_VERSION + "\"}}}"))
+                                .header("Content-Type", "application/json")
+                                .header("MCP-Protocol-Version", ProtocolDispatcher.MCP_PROTOCOL_VERSION)
+                                .header("Mcp-Method", "server/discover")
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
+
+                assertEquals(200, response.statusCode());
+                assertFalse(response.headers().firstValue("Mcp-Session-Id").isPresent(),
+                        "This revision no longer mints session IDs");
+
+                JsonNode body = JSON.readTree(response.body());
+                assertEquals("2.0", body.path("jsonrpc").asText());
+                assertEquals(1, body.path("id").asInt());
+
+                JsonNode supportedVersions = body.path("result").path("supportedVersions");
+                assertTrue(supportedVersions.isArray() && !supportedVersions.isEmpty());
+                assertEquals(ProtocolDispatcher.MCP_PROTOCOL_VERSION, supportedVersions.get(0).asText());
+            } finally {
+                adapter.stop();
+            }
+        }
+    }
+
+    @Test
+    void toolsCallShouldSucceedWithValidHeaders() throws Exception {
+        McpServerAdapter adapter = startAdapterOnFreePort();
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            String baseUrl = baseUrlFor(adapter);
+
+            try {
+                HttpResponse<String> response = client.send(
+                        HttpRequest.newBuilder(URI.create(baseUrl))
+                                .POST(HttpRequest.BodyPublishers.ofString(
+                                        "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\","
+                                                + "\"params\":{\"name\":\"query-database\",\"arguments\":{},"
+                                                + "\"_meta\":{\"io.modelcontextprotocol/protocolVersion\":\""
+                                                + ProtocolDispatcher.MCP_PROTOCOL_VERSION + "\"}}}"))
+                                .header("Content-Type", "application/json")
+                                .header("MCP-Protocol-Version", ProtocolDispatcher.MCP_PROTOCOL_VERSION)
+                                .header("Mcp-Method", "tools/call")
+                                .header("Mcp-Name", "=?base64?cXVlcnktZGF0YWJhc2U=?=")
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
+
+                assertEquals(200, response.statusCode());
+                JsonNode body = JSON.readTree(response.body());
+                assertNotNull(body.path("result"));
+            } finally {
+                adapter.stop();
+            }
+        }
+    }
+
+    @Test
+    void toolsCallShouldReturnHeaderMismatchWhenMcpNameHeaderDoesNotMatchBody() throws Exception {
+        McpServerAdapter adapter = startAdapterOnFreePort();
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            String baseUrl = baseUrlFor(adapter);
+
+            try {
+                HttpResponse<String> response = client.send(
+                        HttpRequest.newBuilder(URI.create(baseUrl))
+                                .POST(HttpRequest.BodyPublishers.ofString(
+                                        "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\","
+                                                + "\"params\":{\"name\":\"query-database\",\"arguments\":{},"
+                                                + "\"_meta\":{\"io.modelcontextprotocol/protocolVersion\":\""
+                                                + ProtocolDispatcher.MCP_PROTOCOL_VERSION + "\"}}}"))
+                                .header("Content-Type", "application/json")
+                                .header("MCP-Protocol-Version", ProtocolDispatcher.MCP_PROTOCOL_VERSION)
+                                .header("Mcp-Method", "tools/call")
+                                .header("Mcp-Name", "does-not-match")
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
+
+                assertEquals(400, response.statusCode());
+                JsonNode body = JSON.readTree(response.body());
+                assertEquals(-32020, body.path("error").path("code").asInt());
+            } finally {
+                adapter.stop();
+            }
         }
     }
 
@@ -265,12 +324,12 @@ class McpServerResourceTest {
     private static McpServerAdapter startAdapterOnFreePort() throws Exception {
         String resourcePath = "src/test/resources/mcp/mcp-capability.yaml";
         IkanosSpec spec = YAML.readValue(new File(resourcePath), IkanosSpec.class);
-        McpServerSpec mcpServerSpec = (McpServerSpec) spec.getCapability().getExposes().get(0);
+        McpServerSpec mcpServerSpec = (McpServerSpec) spec.getCapability().getExposes().getFirst();
         mcpServerSpec.setPort(findFreePort());
         mcpServerSpec.setAddress("127.0.0.1");
 
         Capability capability = new Capability(spec);
-        McpServerAdapter adapter = (McpServerAdapter) capability.getServerAdapters().get(0);
+        McpServerAdapter adapter = (McpServerAdapter) capability.getServerAdapters().getFirst();
         adapter.start();
         return adapter;
     }

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/McpToolHintsIntegrationTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/McpToolHintsIntegrationTest.java
@@ -130,7 +130,8 @@ public class McpToolHintsIntegrationTest {
         ProtocolDispatcher dispatcher = new ProtocolDispatcher(adapter);
 
         JsonNode response = dispatcher.dispatch(JSON.readTree(
-                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}"));
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\",\"params\":{\"_meta\":{\"io.modelcontextprotocol/protocolVersion\":\"%s\"}}}"
+                        .formatted(ProtocolDispatcher.MCP_PROTOCOL_VERSION))).responseBody();
 
         JsonNode tools = response.path("result").path("tools");
         assertEquals(3, tools.size(), "Should have three tools");

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ObservabilityMcpHttpLayerTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ObservabilityMcpHttpLayerTest.java
@@ -133,6 +133,7 @@ class ObservabilityMcpHttpLayerTest {
 
         McpServerResource resource = new McpServerResource();
         Request request = new Request(Method.POST, "http://localhost/mcp");
+        addMcpHeaders(request, "get-forecast");
         Response response = new Response(request);
         resource.init(ctx, request, response);
         return resource;
@@ -142,8 +143,16 @@ class ObservabilityMcpHttpLayerTest {
         return new StringRepresentation(
                 """
                 {"jsonrpc":"2.0","id":1,"method":"tools/call",\
-                "params":{"name":"%s","arguments":{"location":"Paris"}}}""".formatted(toolName),
+                "params":{"name":"%s","arguments":{"location":"Paris"},\
+                "_meta":{"io.modelcontextprotocol/protocolVersion":"%s"}}}"""
+                        .formatted(toolName, ProtocolDispatcher.MCP_PROTOCOL_VERSION),
                 MediaType.APPLICATION_JSON);
+    }
+
+    private static void addMcpHeaders(Request request, String toolName) {
+        request.getHeaders().add("MCP-Protocol-Version", ProtocolDispatcher.MCP_PROTOCOL_VERSION);
+        request.getHeaders().add("Mcp-Method", "tools/call");
+        request.getHeaders().add("Mcp-Name", toolName);
     }
 
     // ─── tests ────────────────────────────────────────────────────────────────
@@ -170,7 +179,7 @@ class ObservabilityMcpHttpLayerTest {
         McpServerAdapter adapter = (McpServerAdapter) capability.getServerAdapters().get(0);
         ProtocolDispatcher capturingDispatcher = new ProtocolDispatcher(adapter) {
             @Override
-            public com.fasterxml.jackson.databind.node.ObjectNode dispatch(
+            public io.ikanos.engine.exposes.mcp.model.DispatchResult dispatch(
                     com.fasterxml.jackson.databind.JsonNode root) {
                 // At this point we are inside the SERVER span scope created by McpServerResource
                 capturedTraceId.set(MDC.get(TelemetryBootstrap.MDC_TRACE_ID));
@@ -187,6 +196,7 @@ class ObservabilityMcpHttpLayerTest {
 
         McpServerResource observedResource = new McpServerResource();
         Request request = new Request(Method.POST, "http://localhost/mcp");
+        addMcpHeaders(request, "get-forecast");
         Response response = new Response(request);
         observedResource.init(ctx, request, response);
 

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ObservabilityMcpStdioIntegrationTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ObservabilityMcpStdioIntegrationTest.java
@@ -1,0 +1,226 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp;
+
+import static io.ikanos.engine.observability.OtelTestFixtures.stringAttribute;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.ikanos.Capability;
+import io.ikanos.engine.observability.OtelTestFixtures;
+import io.ikanos.engine.observability.TelemetryBootstrap;
+import io.ikanos.spec.IkanosSpec;
+import io.ikanos.spec.util.VersionHelper;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+
+/**
+ * Integration tests verifying that the stdio MCP transport ({@link StdioJsonRpcHandler}) produces
+ * the same OTel span hierarchy and MDC population as the Streamable HTTP transport ({@link
+ * McpServerResource}), including W3C trace context extraction from {@code params._meta} — the
+ * only carrier available on stdio, which has no HTTP headers (see {@link
+ * io.ikanos.engine.observability.McpMetaTraceContextBridge}).
+ *
+ * <p>Mirrors {@link ObservabilityMcpHttpLayerTest} (MDC) and {@link
+ * io.ikanos.engine.exposes.rest.ObservabilityRestIntegrationTest} (traceparent extraction) for
+ * the stdio transport.</p>
+ */
+class ObservabilityMcpStdioIntegrationTest {
+
+    private static final String SCHEMA_VERSION = VersionHelper.getSchemaVersion();
+
+    private final InMemorySpanExporter exporter = InMemorySpanExporter.create();
+
+    @BeforeEach
+    void setUp() {
+        OpenTelemetrySdk sdk = OpenTelemetrySdk.builder()
+                .setTracerProvider(OtelTestFixtures.tracerProvider(exporter))
+                .setPropagators(OtelTestFixtures.w3cPropagators())
+                .build();
+        TelemetryBootstrap.init(sdk);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TelemetryBootstrap.reset();
+        exporter.reset();
+        MDC.clear();
+    }
+
+    // ─── helpers ──────────────────────────────────────────────────────────────
+
+    private Capability capabilityFromYaml(String yaml) throws Exception {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        IkanosSpec spec = mapper.readValue(yaml, IkanosSpec.class);
+        return new Capability(spec);
+    }
+
+    private static String weatherStdioCapabilityYaml() {
+        return """
+                ikanos: "%s"
+                info:
+                  display: "weather-stdio-capability"
+                capability:
+                  exposes:
+                    - type: "mcp"
+                      transport: "stdio"
+                      namespace: "weather"
+                      tools:
+                        - name: "get-forecast"
+                          description: "Returns the weather forecast for a location"
+                          ref: "forecast.get-forecast"
+                          inputParameters:
+                            - name: "location"
+                              type: "string"
+                              description: "City name"
+                              required: true
+                  aggregates:
+                    - namespace: "forecast"
+                      flows:
+                        - name: "get-forecast"
+                          inputParameters:
+                            - name: "location"
+                              type: "string"
+                          outputParameters:
+                            - name: "summary"
+                              type: "string"
+                              value: "Sunny"
+                  consumes: []
+                """.formatted(SCHEMA_VERSION);
+    }
+
+    private static String toolsCallRequest(String toolName, String metaExtra) {
+        return """
+                {"jsonrpc":"2.0","id":1,"method":"tools/call",\
+                "params":{"name":"%s","arguments":{"location":"Paris"},\
+                "_meta":{"io.modelcontextprotocol/protocolVersion":"%s"%s}}}
+                """.formatted(toolName, ProtocolDispatcher.MCP_PROTOCOL_VERSION, metaExtra).strip();
+    }
+
+    private ObjectMapper runStdio(ProtocolDispatcher dispatcher, String requestLine)
+            throws Exception {
+        ByteArrayInputStream in = new ByteArrayInputStream(
+                (requestLine + "\n").getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        new StdioJsonRpcHandler(dispatcher, in, out).run();
+
+        this.lastOutput = out.toString(StandardCharsets.UTF_8).strip();
+        return dispatcher.getMapper();
+    }
+
+    private String lastOutput;
+
+    // ─── tests ────────────────────────────────────────────────────────────────
+
+    @Test
+    void stdioToolsCallShouldProduceServerSpanWithCorrectAttributes() throws Exception {
+        Capability capability = capabilityFromYaml(weatherStdioCapabilityYaml());
+        McpServerAdapter adapter = (McpServerAdapter) capability.getServerAdapters().getFirst();
+        ProtocolDispatcher dispatcher = new ProtocolDispatcher(adapter);
+
+        ObjectMapper mapper = runStdio(dispatcher, toolsCallRequest("get-forecast", ""));
+
+        JsonNode response = mapper.readTree(lastOutput);
+        assertEquals(1, response.path("id").asInt());
+
+        List<SpanData> spans = exporter.getFinishedSpanItems();
+        SpanData serverSpan = spans.stream()
+                .filter(s -> s.getName().equals("mcp.request"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Missing mcp.request span: " + spans));
+
+        assertEquals(SpanKind.SERVER, serverSpan.getKind());
+        assertEquals("mcp",
+                stringAttribute(serverSpan.getAttributes(), TelemetryBootstrap.ATTR_ADAPTER_TYPE));
+        assertEquals("tools/call",
+                stringAttribute(serverSpan.getAttributes(), TelemetryBootstrap.ATTR_OPERATION_ID));
+        assertEquals("weather-stdio-capability",
+                stringAttribute(serverSpan.getAttributes(), TelemetryBootstrap.ATTR_CAPABILITY));
+    }
+
+    @Test
+    void stdioToolsCallShouldExtractInboundMetaTraceparent() throws Exception {
+        Capability capability = capabilityFromYaml(weatherStdioCapabilityYaml());
+        McpServerAdapter adapter = (McpServerAdapter) capability.getServerAdapters().getFirst();
+        ProtocolDispatcher dispatcher = new ProtocolDispatcher(adapter);
+
+        // stdio has no HTTP headers — params._meta is the only carrier for trace context.
+        String traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        String metaExtra = ",\"traceparent\":\"" + traceparent + "\"";
+
+        runStdio(dispatcher, toolsCallRequest("get-forecast", metaExtra));
+
+        List<SpanData> spans = exporter.getFinishedSpanItems();
+        SpanData serverSpan = spans.stream()
+                .filter(s -> s.getName().equals("mcp.request"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Missing mcp.request span: " + spans));
+
+        assertEquals("4bf92f3577b34da6a3ce929d0e0e4736", serverSpan.getTraceId(),
+                "Server span should continue the trace carried in params._meta.traceparent");
+        assertEquals("00f067aa0ba902b7", serverSpan.getParentSpanId(),
+                "Server span parent should be the inbound _meta-carried span");
+    }
+
+    @Test
+    void stdioToolsCallShouldPopulateMdcTraceIdAndSpanIdDuringExecution() throws Exception {
+        Capability capability = capabilityFromYaml(weatherStdioCapabilityYaml());
+        McpServerAdapter adapter = (McpServerAdapter) capability.getServerAdapters().get(0);
+
+        AtomicReference<String> capturedTraceId =
+                new java.util.concurrent.atomic.AtomicReference<>();
+        AtomicReference<String> capturedSpanId =
+                new java.util.concurrent.atomic.AtomicReference<>();
+
+        ProtocolDispatcher capturingDispatcher = new ProtocolDispatcher(adapter) {
+            @Override
+            public io.ikanos.engine.exposes.mcp.model.DispatchResult dispatch(JsonNode root) {
+                // Runs within the SERVER span scope opened by dispatchWithTracing().
+                capturedTraceId.set(MDC.get(TelemetryBootstrap.MDC_TRACE_ID));
+                capturedSpanId.set(MDC.get(TelemetryBootstrap.MDC_SPAN_ID));
+                return super.dispatch(root);
+            }
+        };
+
+        runStdio(capturingDispatcher, toolsCallRequest("get-forecast", ""));
+
+        assertNotNull(capturedTraceId.get(), "MDC trace_id must be non-null during stdio dispatch");
+        assertFalse(capturedTraceId.get().isBlank());
+        assertNotNull(capturedSpanId.get(), "MDC span_id must be non-null during stdio dispatch");
+        assertFalse(capturedSpanId.get().isBlank());
+
+        // MDC must be cleared once the stdio handler has processed the line.
+        assertNull(MDC.get(TelemetryBootstrap.MDC_TRACE_ID),
+                "MDC trace_id must be cleared after stdio dispatch completes");
+        assertNull(MDC.get(TelemetryBootstrap.MDC_SPAN_ID),
+                "MDC span_id must be cleared after stdio dispatch completes");
+    }
+}

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ProtocolDispatcherCoverageTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ProtocolDispatcherCoverageTest.java
@@ -13,11 +13,6 @@
  */
 package io.ikanos.engine.exposes.mcp;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import java.io.File;
-import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -25,6 +20,13 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.ikanos.Capability;
 import io.ikanos.spec.IkanosSpec;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class ProtocolDispatcherCoverageTest {
 
@@ -34,7 +36,7 @@ class ProtocolDispatcherCoverageTest {
     void dispatchShouldReturnInternalErrorWhenRequestIsNull() throws Exception {
         ProtocolDispatcher dispatcher = dispatcherFrom("src/test/resources/mcp/mcp-capability.yaml");
 
-        ObjectNode response = dispatcher.dispatch(null);
+        ObjectNode response = dispatcher.dispatch(null).responseBody();
 
         assertNotNull(response);
         assertEquals(-32600, response.path("error").path("code").asInt());
@@ -44,11 +46,12 @@ class ProtocolDispatcherCoverageTest {
     }
 
     @Test
-    void initializeShouldAdvertiseOnlyToolsWhenNoResourcesOrPrompts() throws Exception {
+    void serverDiscoverShouldAdvertiseOnlyToolsWhenNoResourcesOrPrompts() throws Exception {
         ProtocolDispatcher dispatcher = dispatcherFrom("src/test/resources/mcp/mcp-capability.yaml");
 
-        JsonNode response = dispatcher.dispatch(JSON.readTree(
-                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}"));
+        JsonNode response = dispatcher.dispatch(JSON.readTree(withProtocolVersion("""
+                {"jsonrpc":"2.0","id":1,"method":"server/discover","params":{}}
+                """))).responseBody();
 
         JsonNode capabilities = response.path("result").path("capabilities");
         assertFalse(capabilities.path("tools").isMissingNode());
@@ -60,14 +63,14 @@ class ProtocolDispatcherCoverageTest {
     void toolsCallUnknownToolShouldReturnInvalidParams() throws Exception {
         ProtocolDispatcher dispatcher = dispatcherFrom("src/test/resources/mcp/mcp-capability.yaml");
 
-        JsonNode response = dispatcher.dispatch(JSON.readTree("""
+        JsonNode response = dispatcher.dispatch(JSON.readTree(withProtocolVersion("""
                 {
                   "jsonrpc":"2.0",
                   "id":2,
                   "method":"tools/call",
                   "params":{"name":"does-not-exist","arguments":{}}
                 }
-                """));
+                """))).responseBody();
 
         assertEquals(-32602, response.path("error").path("code").asInt());
         assertFalse(response.path("error").path("message").asText().isBlank());
@@ -78,57 +81,42 @@ class ProtocolDispatcherCoverageTest {
         ProtocolDispatcher dispatcher =
                 dispatcherFrom("src/test/resources/mcp/mcp-resources-prompts-capability.yaml");
 
-        JsonNode readNullParams = dispatcher.dispatch(JSON.readTree(
-                "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"resources/read\"}"));
+        JsonNode readNullParams = dispatcher.dispatch(JSON.readTree(withProtocolVersion(
+                "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"resources/read\"}"))).responseBody();
         assertEquals(-32602, readNullParams.path("error").path("code").asInt());
 
-        JsonNode readUnknownUri = dispatcher.dispatch(JSON.readTree(
-                "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"resources/read\",\"params\":{\"uri\":\"data://unknown\"}}"));
+        JsonNode readUnknownUri = dispatcher.dispatch(JSON.readTree(withProtocolVersion(
+                "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"resources/read\",\"params\":{\"uri\":\"data://unknown\"}}")))
+                .responseBody();
         assertEquals(-32602, readUnknownUri.path("error").path("code").asInt());
 
-        JsonNode promptsNullParams = dispatcher.dispatch(JSON.readTree(
-                "{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"prompts/get\"}"));
+        JsonNode promptsNullParams = dispatcher.dispatch(JSON.readTree(withProtocolVersion(
+                "{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"prompts/get\"}"))).responseBody();
         assertEquals(-32602, promptsNullParams.path("error").path("code").asInt());
     }
 
     @Test
-    void jsonRpcEnvelopeBuildersShouldHandleNullAndPresentIds() throws Exception {
+    void toolsCallShouldReturnIsErrorResultOnUnexpectedExecutionFailure() throws Exception {
         ProtocolDispatcher dispatcher = dispatcherFrom("src/test/resources/mcp/mcp-capability.yaml");
 
-        ObjectNode resultNoId = dispatcher.buildJsonRpcResult(null, JSON.createObjectNode());
-        assertEquals("2.0", resultNoId.path("jsonrpc").asText());
-        assertTrueMissing(resultNoId.path("id"));
+        JsonNode response = dispatcher.dispatch(JSON.readTree(withProtocolVersion("""
+                {
+                    "jsonrpc":"2.0",
+                    "id":15,
+                    "method":"tools/call",
+                    "params":{
+                        "name":"query-database",
+                        "arguments":{"name":"x"}
+                    }
+                }
+                """))).responseBody();
 
-        JsonNode id = JSON.getNodeFactory().numberNode(7);
-        ObjectNode errorWithId = dispatcher.buildJsonRpcError(id, -1, "x");
-        assertEquals(7, errorWithId.path("id").asInt());
-
-        ObjectNode errorNullId = dispatcher.buildJsonRpcError(null, -1, "x");
-        assertEquals(true, errorNullId.path("id").isNull());
+        assertEquals("2.0", response.path("jsonrpc").asText());
+        assertEquals(15, response.path("id").asInt());
+        assertEquals(true, response.path("result").path("isError").asBoolean());
+        assertEquals("text", response.path("result").path("content").get(0).path("type")
+                        .asText());
     }
-
-        @Test
-        void toolsCallShouldReturnIsErrorResultOnUnexpectedExecutionFailure() throws Exception {
-                ProtocolDispatcher dispatcher = dispatcherFrom("src/test/resources/mcp/mcp-capability.yaml");
-
-                JsonNode response = dispatcher.dispatch(JSON.readTree("""
-                                {
-                                    "jsonrpc":"2.0",
-                                    "id":15,
-                                    "method":"tools/call",
-                                    "params":{
-                                        "name":"query-database",
-                                        "arguments":{"name":"x"}
-                                    }
-                                }
-                                """));
-
-                assertEquals("2.0", response.path("jsonrpc").asText());
-                assertEquals(15, response.path("id").asInt());
-                assertEquals(true, response.path("result").path("isError").asBoolean());
-                assertEquals("text", response.path("result").path("content").get(0).path("type")
-                                .asText());
-        }
 
     private static ProtocolDispatcher dispatcherFrom(String resourcePath) throws Exception {
         ObjectMapper yaml = new ObjectMapper(new YAMLFactory())
@@ -136,6 +124,16 @@ class ProtocolDispatcherCoverageTest {
         IkanosSpec spec = yaml.readValue(new File(resourcePath), IkanosSpec.class);
         Capability capability = new Capability(spec);
         return new ProtocolDispatcher((McpServerAdapter) capability.getServerAdapters().get(0));
+    }
+
+    private static String withProtocolVersion(String requestJson) throws Exception {
+        ObjectNode request = (ObjectNode) JSON.readTree(requestJson);
+        ObjectNode params = request.has("params") && request.get("params").isObject()
+                ? (ObjectNode) request.get("params")
+                : request.putObject("params");
+        params.putObject("_meta").put("io.modelcontextprotocol/protocolVersion",
+                ProtocolDispatcher.MCP_PROTOCOL_VERSION);
+        return JSON.writeValueAsString(request);
     }
 
     private static void assertTrueMissing(JsonNode node) {

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ProtocolDispatcherNegativeTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ProtocolDispatcherNegativeTest.java
@@ -13,17 +13,22 @@
  */
 package io.ikanos.engine.exposes.mcp;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import java.io.File;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.ikanos.Capability;
 import io.ikanos.spec.IkanosSpec;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class ProtocolDispatcherNegativeTest {
 
@@ -44,9 +49,9 @@ public class ProtocolDispatcherNegativeTest {
 
     @Test
     public void dispatchShouldRejectInvalidJsonRpcVersion() throws Exception {
-        JsonNode response = dispatcher.dispatch(mapper.readTree("""
-                {"jsonrpc":"1.0","id":1,"method":"ping"}
-                """));
+        JsonNode response = dispatcher.dispatch(mapper.readTree(withProtocolVersion("""
+                {"jsonrpc":"1.0","id":1,"method":"tools/list"}
+                """))).responseBody();
 
         assertEquals(-32600, response.path("error").path("code").asInt());
     }
@@ -55,26 +60,26 @@ public class ProtocolDispatcherNegativeTest {
     public void dispatchShouldRejectUnknownMethod() throws Exception {
         JsonNode response = dispatcher.dispatch(mapper.readTree("""
                 {"jsonrpc":"2.0","id":2,"method":"unknown/method"}
-                """));
+                """)).responseBody();
 
         assertEquals(-32601, response.path("error").path("code").asInt());
     }
 
     @Test
-    public void dispatchShouldRejectToolsCallWithoutParams() throws Exception {
-        JsonNode response = dispatcher.dispatch(mapper.readTree("""
+    public void dispatchShouldRejectToolsCallWithoutName() throws Exception {
+        JsonNode response = dispatcher.dispatch(mapper.readTree(withProtocolVersion("""
                 {"jsonrpc":"2.0","id":3,"method":"tools/call"}
-                """));
+                """))).responseBody();
 
         assertEquals(-32602, response.path("error").path("code").asInt());
-        assertEquals("Invalid params: missing params", response.path("error").path("message").asText());
+        assertEquals("Invalid params: Unknown tool: ", response.path("error").path("message").asText());
     }
 
     @Test
     public void dispatchShouldRejectResourcesReadWithoutUri() throws Exception {
-        JsonNode response = dispatcher.dispatch(mapper.readTree("""
+        JsonNode response = dispatcher.dispatch(mapper.readTree(withProtocolVersion("""
                 {"jsonrpc":"2.0","id":4,"method":"resources/read","params":{}}
-                """));
+                """))).responseBody();
 
         assertEquals(-32602, response.path("error").path("code").asInt());
         assertEquals("Invalid params: uri is required", response.path("error").path("message").asText());
@@ -82,12 +87,34 @@ public class ProtocolDispatcherNegativeTest {
 
     @Test
     public void dispatchShouldRejectPromptsGetWithoutName() throws Exception {
-        JsonNode response = dispatcher.dispatch(mapper.readTree("""
+        JsonNode response = dispatcher.dispatch(mapper.readTree(withProtocolVersion("""
                 {"jsonrpc":"2.0","id":5,"method":"prompts/get","params":{}}
-                """));
+                """))).responseBody();
 
         assertNotNull(response.path("error"));
         assertEquals(-32602, response.path("error").path("code").asInt());
         assertEquals("Invalid params: name is required", response.path("error").path("message").asText());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"prompts/get", "tools/call", "resources/read"})
+    public void dispatchShouldRejectWithoutProtocolVersion(String method) throws Exception {
+        JsonNode response = dispatcher.dispatch(mapper.readTree("""
+                {"jsonrpc":"2.0","id":5,"method":"%s"}
+                """.formatted(method))).responseBody();
+
+        assertNotNull(response.path("error"));
+        assertEquals(-32022, response.path("error").path("code").asInt());
+        assertEquals("Unsupported protocol version", response.path("error").path("message").asText());
+    }
+
+    private String withProtocolVersion(String requestJson) throws Exception {
+        ObjectNode request = (ObjectNode) mapper.readTree(requestJson);
+        ObjectNode params = request.has("params") && request.get("params").isObject()
+                ? (ObjectNode) request.get("params")
+                : request.putObject("params");
+        params.putObject("_meta").put("io.modelcontextprotocol/protocolVersion",
+                ProtocolDispatcher.MCP_PROTOCOL_VERSION);
+        return mapper.writeValueAsString(request);
     }
 }

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ResourcesPromptsIntegrationTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/ResourcesPromptsIntegrationTest.java
@@ -259,16 +259,16 @@ public class ResourcesPromptsIntegrationTest {
         assertEquals("ping", localAdapter.getTools().get(0).name());
     }
 
-    // ── MCP protocol: initialize ──────────────────────────────────────────────────────────────────
+    // ── MCP protocol: server/discover ─────────────────────────────────────────────────────────────
 
     @Test
-    public void testInitializeAdvertisesResourcesAndPrompts() throws Exception {
+    public void testServerDiscoverAdvertisesResourcesAndPrompts() throws Exception {
         String requestJson = """
-                {"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}
+                {"jsonrpc":"2.0","id":1,"method":"server/discover","params":{}}
                 """;
         ObjectNode response = dispatch(requestJson);
 
-        assertNotNull(response, "initialize should return a response");
+        assertNotNull(response, "server/discover should return a response");
         JsonNode result = response.path("result");
 
         JsonNode capabilities = result.path("capabilities");
@@ -644,9 +644,15 @@ public class ResourcesPromptsIntegrationTest {
     // ── Helpers ───────────────────────────────────────────────────────────────────────────────────
 
     private ObjectNode dispatch(String requestJson) throws Exception {
-        JsonNode request = jsonMapper.readTree(requestJson);
+        ObjectNode request = (ObjectNode) jsonMapper.readTree(requestJson);
+        ObjectNode params = request.has("params") && request.get("params").isObject()
+                ? (ObjectNode) request.get("params")
+                : request.putObject("params");
+        params.putObject("_meta").put("io.modelcontextprotocol/protocolVersion",
+                ProtocolDispatcher.MCP_PROTOCOL_VERSION);
+
         var dispatcher = new io.ikanos.engine.exposes.mcp.ProtocolDispatcher(adapter);
-        return dispatcher.dispatch(request);
+        return dispatcher.dispatch(request).responseBody();
     }
 
 }

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/StdioIntegrationTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/StdioIntegrationTest.java
@@ -93,30 +93,29 @@ public class StdioIntegrationTest {
     }
 
     @Test
-    public void testStdioInitializeProtocol() throws Exception {
+    public void testStdioServerDiscoverProtocol() throws Exception {
         McpServerAdapter adapter = (McpServerAdapter) capability.getServerAdapters().get(0);
 
-        // Simulate an initialize request via the protocol dispatcher
+        // Simulate a server/discover request via the protocol dispatcher
         ProtocolDispatcher dispatcher = new ProtocolDispatcher(adapter);
         ObjectMapper mapper = new ObjectMapper();
 
-        String initRequest = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\","
-                + "\"params\":{\"protocolVersion\":\"2025-11-25\","
-                + "\"clientInfo\":{\"name\":\"test\",\"version\":\"1.0\"},"
-                + "\"capabilities\":{}}}";
+        String discoverRequest = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"server/discover\","
+                + "\"params\":{\"_meta\":{\"io.modelcontextprotocol/protocolVersion\":\""
+                + ProtocolDispatcher.MCP_PROTOCOL_VERSION + "\"}}}";
 
-        JsonNode request = mapper.readTree(initRequest);
-        JsonNode response = dispatcher.dispatch(request);
+        JsonNode request = mapper.readTree(discoverRequest);
+        JsonNode response = dispatcher.dispatch(request).responseBody();
 
-        assertNotNull(response, "Initialize should return a response");
+        assertNotNull(response, "server/discover should return a response");
         assertEquals("2.0", response.path("jsonrpc").asText());
         assertEquals(1, response.path("id").asInt());
 
         JsonNode result = response.get("result");
         assertNotNull(result, "Should have a result");
-        assertEquals("2025-11-25", result.path("protocolVersion").asText());
-        assertEquals("test-mcp-stdio",
-                result.path("serverInfo").path("name").asText());
+        JsonNode supportedVersions = result.path("supportedVersions");
+        assertTrue(supportedVersions.isArray() && supportedVersions.size() > 0);
+        assertEquals(ProtocolDispatcher.MCP_PROTOCOL_VERSION, supportedVersions.get(0).asText());
     }
 
     @Test
@@ -126,9 +125,11 @@ public class StdioIntegrationTest {
         ProtocolDispatcher dispatcher = new ProtocolDispatcher(adapter);
         ObjectMapper mapper = new ObjectMapper();
 
-        String listRequest = "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\"}";
+        String listRequest = "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\","
+                + "\"params\":{\"_meta\":{\"io.modelcontextprotocol/protocolVersion\":\""
+                + ProtocolDispatcher.MCP_PROTOCOL_VERSION + "\"}}}";
 
-        JsonNode response = dispatcher.dispatch(mapper.readTree(listRequest));
+        JsonNode response = dispatcher.dispatch(mapper.readTree(listRequest)).responseBody();
 
         assertNotNull(response);
         JsonNode tools = response.path("result").path("tools");
@@ -138,32 +139,22 @@ public class StdioIntegrationTest {
     }
 
     @Test
-    public void testStdioNotificationReturnsNull() throws Exception {
+    public void testStdioUnsupportedProtocolVersionReturnsError() throws Exception {
         McpServerAdapter adapter = (McpServerAdapter) capability.getServerAdapters().get(0);
 
         ProtocolDispatcher dispatcher = new ProtocolDispatcher(adapter);
         ObjectMapper mapper = new ObjectMapper();
 
-        String notification = "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}";
+        // A request without a matching protocolVersion in _meta must be rejected —
+        // the initialize/notifications/initialized handshake no longer exists in 2026-07-28,
+        // every request must self-describe its protocol version.
+        String requestWithoutVersion = "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/list\"}";
 
-        JsonNode response = dispatcher.dispatch(mapper.readTree(notification));
-        assertNull(response, "Notifications should return null (no response)");
-    }
-
-    @Test
-    public void testStdioPingProtocol() throws Exception {
-        McpServerAdapter adapter = (McpServerAdapter) capability.getServerAdapters().get(0);
-
-        ProtocolDispatcher dispatcher = new ProtocolDispatcher(adapter);
-        ObjectMapper mapper = new ObjectMapper();
-
-        String pingRequest = "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"ping\"}";
-
-        JsonNode response = dispatcher.dispatch(mapper.readTree(pingRequest));
+        JsonNode response = dispatcher.dispatch(mapper.readTree(requestWithoutVersion)).responseBody();
 
         assertNotNull(response);
-        assertEquals(3, response.path("id").asInt());
-        assertNotNull(response.get("result"), "Ping should return an empty result");
+        assertEquals(-32022, response.path("error").path("code").asInt(),
+                "Missing/unsupported protocol version should return UnsupportedProtocolVersion (-32022)");
     }
 
     @Test
@@ -172,14 +163,14 @@ public class StdioIntegrationTest {
 
         ProtocolDispatcher dispatcher = new ProtocolDispatcher(adapter);
 
-        // Build a multi-line input: initialize + tools/list + ping
-        String input = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\","
-                + "\"params\":{\"protocolVersion\":\"2025-11-25\","
-                + "\"clientInfo\":{\"name\":\"test\",\"version\":\"1.0\"},"
-                + "\"capabilities\":{}}}\n"
-                + "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n"
-                + "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\"}\n"
-                + "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"ping\"}\n";
+        String metaSuffix = "\"_meta\":{\"io.modelcontextprotocol/protocolVersion\":\""
+                + ProtocolDispatcher.MCP_PROTOCOL_VERSION + "\"}";
+
+        // Build a multi-line input: server/discover + tools/list
+        String input = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"server/discover\","
+                + "\"params\":{" + metaSuffix + "}}\n"
+                + "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\","
+                + "\"params\":{" + metaSuffix + "}}\n";
 
         ByteArrayInputStream in = new ByteArrayInputStream(
                 input.getBytes(StandardCharsets.UTF_8));
@@ -191,27 +182,23 @@ public class StdioIntegrationTest {
         String output = out.toString(StandardCharsets.UTF_8);
         String[] lines = output.strip().split("\\n");
 
-        // Should have 3 responses (notification has no response)
-        assertEquals(3, lines.length,
-                "Should have 3 response lines (initialize, tools/list, ping)");
+        // Should have 2 responses (server/discover, tools/list)
+        assertEquals(2, lines.length,
+                "Should have 2 response lines (server/discover, tools/list)");
 
         ObjectMapper mapper = new ObjectMapper();
 
-        // Verify initialize response
-        JsonNode initResponse = mapper.readTree(lines[0]);
-        assertEquals(1, initResponse.path("id").asInt());
-        assertEquals("2025-11-25",
-                initResponse.path("result").path("protocolVersion").asText());
+        // Verify server/discover response
+        JsonNode discoverResponse = mapper.readTree(lines[0]);
+        assertEquals(1, discoverResponse.path("id").asInt());
+        assertEquals(ProtocolDispatcher.MCP_PROTOCOL_VERSION,
+                discoverResponse.path("result").path("supportedVersions").get(0).asText());
 
         // Verify tools/list response
         JsonNode toolsResponse = mapper.readTree(lines[1]);
         assertEquals(2, toolsResponse.path("id").asInt());
         assertEquals("query-database",
                 toolsResponse.path("result").path("tools").get(0).path("name").asText());
-
-        // Verify ping response
-        JsonNode pingResponse = mapper.readTree(lines[2]);
-        assertEquals(3, pingResponse.path("id").asInt());
     }
 
     @Test

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/handler/PromptsGetHandlerTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/handler/PromptsGetHandlerTest.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.ikanos.engine.exposes.mcp.McpServerAdapter;
+import io.ikanos.engine.exposes.mcp.model.HandlerFailureResult;
+import io.ikanos.engine.exposes.mcp.model.HandlerResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.ikanos.engine.exposes.mcp.model.JsonRpcError.INVALID_PARAMS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+class PromptsGetHandlerTest {
+
+    ObjectMapper mapper = new ObjectMapper();
+    McpServerAdapter adapter = mock();
+    McpCallHandler handler = new PromptsGetHandler(adapter, List.of(), List.of(), List.of());
+
+    @Test
+    void handleShouldRejectWithoutParams() throws Exception {
+        // Given
+        JsonNode request = mapper.readTree("""
+                {"jsonrpc":"2.0","id":4,"method":"prompts/get"}
+                """);
+
+        // When
+        HandlerFailureResult result = (HandlerFailureResult) handler.handle(request);
+
+        // Then
+        assertThat(result.rpcError()).isEqualTo(INVALID_PARAMS);
+    }
+}

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/handler/ResourcesReadHandlerTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/handler/ResourcesReadHandlerTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.ikanos.engine.exposes.mcp.McpServerAdapter;
+import io.ikanos.engine.exposes.mcp.model.HandlerFailureResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.ikanos.engine.exposes.mcp.model.JsonRpcError.INVALID_PARAMS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class ResourcesReadHandlerTest {
+
+    ObjectMapper mapper = new ObjectMapper();
+    McpServerAdapter adapter = mock();
+    McpCallHandler handler = new ResourcesReadHandler(adapter, List.of(), List.of(), List.of());
+
+    @Test
+    void handleShouldRejectWithoutParams() throws Exception {
+        // Given
+        JsonNode request = mapper.readTree("""
+                {"jsonrpc":"2.0","id":4,"method":"resources/read"}
+                """);
+
+        // When
+        HandlerFailureResult result = (HandlerFailureResult) handler.handle(request);
+
+        // Then
+        assertThat(result.rpcError()).isEqualTo(INVALID_PARAMS);
+    }
+}

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/handler/ToolsCallHandlerTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/handler/ToolsCallHandlerTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.ikanos.engine.exposes.mcp.McpServerAdapter;
+import io.ikanos.engine.exposes.mcp.model.HandlerFailureResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.ikanos.engine.exposes.mcp.model.JsonRpcError.INVALID_PARAMS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class ToolsCallHandlerTest {
+
+    ObjectMapper mapper = new ObjectMapper();
+    McpServerAdapter adapter = mock();
+    McpCallHandler handler = new ToolsCallHandler(adapter, List.of(), List.of(), List.of());
+
+    @Test
+    void handleShouldRejectWithoutParams() throws Exception {
+        // Given
+        JsonNode request = mapper.readTree("""
+                {"jsonrpc":"2.0","id":4,"method":"tools/call"}
+                """);
+
+        // When
+        HandlerFailureResult result = (HandlerFailureResult) handler.handle(request);
+
+        // Then
+        assertThat(result.rpcError()).isEqualTo(INVALID_PARAMS);
+    }
+}

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/processor/CacheDataAppenderTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/processor/CacheDataAppenderTest.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp.processor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.ikanos.exception.ProcessorException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CacheDataAppenderTest {
+
+    ObjectMapper mapper = new ObjectMapper();
+    DispatchPostProcessor processor = new CacheDataAppender(300, "public");
+
+    @Test
+    void applyShouldAddCacheData() throws ProcessorException {
+        // Given
+        ObjectNode response = mapper.createObjectNode();
+        response.set("result", mapper.createObjectNode());
+
+        // When
+        processor.apply(response);
+
+        // Then
+        assertThat(response.path("result").path("ttlMs").asInt()).isEqualTo(300);
+        assertThat(response.path("result").path("cacheScope").asText()).isEqualTo("public");
+    }
+}

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/processor/ProtocolsVersionsValidatorTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/processor/ProtocolsVersionsValidatorTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp.processor;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.ikanos.engine.exposes.mcp.ProtocolDispatcher;
+import io.ikanos.exception.ProcessorException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ProtocolsVersionsValidatorTest {
+
+    ObjectMapper mapper = new ObjectMapper();
+    DispatchPreProcessor processor = new ProtocolsVersionsValidator(mapper);
+
+    @Test
+    void applyWithValidRequestShouldSucceed() throws Exception {
+        // Given
+        JsonNode request = mapper.readTree("""
+                {
+                  "jsonrpc": "%s",
+                  "id": 1,
+                  "method": "tools/list",
+                  "params": {
+                    "_meta": {
+                      "io.modelcontextprotocol/protocolVersion": "%s"
+                    }
+                  }
+                }""".formatted(ProtocolDispatcher.JSONRPC_VERSION, ProtocolDispatcher.MCP_PROTOCOL_VERSION));
+
+        // When, Then
+        Assertions.assertDoesNotThrow(() -> processor.apply(request));
+    }
+
+    @Test
+    void applyWithInvalidRequestShouldThrow() throws Exception {
+        // Given
+        JsonNode requestWithBadJsonRpcVersion = mapper.readTree("""
+                {
+                  "jsonrpc": "0.1",
+                  "id": 1,
+                  "method": "tools/list",
+                  "params": {
+                    "_meta": {
+                      "io.modelcontextprotocol/protocolVersion": "%s"
+                    }
+                  }
+                }""".formatted(ProtocolDispatcher.MCP_PROTOCOL_VERSION));
+        JsonNode requestWithBadProtocolVersion = mapper.readTree("""
+                {
+                  "jsonrpc": "%s",
+                  "id": 1,
+                  "method": "tools/list",
+                  "params": {
+                    "_meta": {
+                      "io.modelcontextprotocol/protocolVersion": "2018-01-01"
+                    }
+                  }
+                }""".formatted(ProtocolDispatcher.JSONRPC_VERSION));
+
+        // When, Then
+        Assertions.assertThrows(ProcessorException.class, () -> processor.apply(requestWithBadJsonRpcVersion));
+        Assertions.assertThrows(ProcessorException.class, () -> processor.apply(requestWithBadProtocolVersion));
+    }
+}

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/processor/ServerDataAppenderTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/mcp/processor/ServerDataAppenderTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.exposes.mcp.processor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.ikanos.Capability;
+import io.ikanos.engine.exposes.mcp.McpServerAdapter;
+import io.ikanos.engine.exposes.mcp.ProtocolDispatcher;
+import io.ikanos.exception.ProcessorException;
+import io.ikanos.spec.IkanosSpec;
+import io.ikanos.spec.InfoSpec;
+import io.ikanos.spec.exposes.mcp.McpServerSpec;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ServerDataAppenderTest {
+
+    static ObjectMapper mapper = new ObjectMapper();
+    static InfoSpec info = mock(InfoSpec.class);
+    static IkanosSpec spec = mock(IkanosSpec.class);
+    static Capability capability = mock(Capability.class);
+    static McpServerAdapter adapter = mock(McpServerAdapter.class);
+    static McpServerSpec mcpServerSpec = mock(McpServerSpec.class);
+    DispatchPostProcessor processor = new ServerDataAppender(adapter, mapper);
+
+    @BeforeAll
+    static void setup() {
+        when(info.getVersion()).thenReturn("1.0.0");
+        when(spec.getInfo()).thenReturn(info);
+        when(mcpServerSpec.getNamespace()).thenReturn("ikanos");
+        when(capability.getSpec()).thenReturn(spec);
+        when(adapter.getCapability()).thenReturn(capability);
+        when(adapter.getMcpServerSpec()).thenReturn(mcpServerSpec);
+    }
+
+    @Test
+    void applyShouldAddServerData() throws ProcessorException {
+        // Given
+        ObjectNode response = mapper.createObjectNode();
+        response.set("result", mapper.createObjectNode());
+
+        // When
+        processor.apply(response);
+
+        // Then
+        assertThat(response.path("jsonrpc").asText()).isEqualTo(ProtocolDispatcher.JSONRPC_VERSION);
+        assertThat(response.path("result").path("_meta").path("io.modelcontextprotocol/serverInfo")
+                .path("name").asText()).isEqualTo("ikanos");
+        assertThat(response.path("result").path("_meta").path("io.modelcontextprotocol/serverInfo")
+                .path("version").asText()).isEqualTo("1.0.0");
+    }
+}

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/rest/AggregateSharedMockIntegrationTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/rest/AggregateSharedMockIntegrationTest.java
@@ -52,7 +52,9 @@ public class AggregateSharedMockIntegrationTest {
 
         JsonNode mcpResponse = dispatcher.dispatch(JSON.readTree(
                 "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\"," +
-                        "\"params\":{\"name\":\"hello\",\"arguments\":{\"name\":\"Nina\"}}}"));
+                        "\"params\":{\"name\":\"hello\",\"arguments\":{\"name\":\"Nina\"}," +
+                        "\"_meta\":{\"io.modelcontextprotocol/protocolVersion\":\"" + ProtocolDispatcher.MCP_PROTOCOL_VERSION + "\"}}}"))
+                .responseBody();
 
         assertFalse(mcpResponse.path("result").path("isError").asBoolean(),
                 "MCP tools/call should not fail for aggregate mock ref");

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/observability/McpMetaTraceContextBridgeTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/observability/McpMetaTraceContextBridgeTest.java
@@ -1,0 +1,248 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.observability;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.restlet.Request;
+import org.restlet.data.Method;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Integration tests for {@link McpMetaTraceContextBridge} — W3C trace context extraction from
+ * the {@code params._meta} object of an MCP JSON-RPC request (transport-agnostic carrier per
+ * the MCP {@code 2026-07-28} revision, mirroring {@link ContextPropagationTest} for the
+ * HTTP-header carrier).
+ */
+public class McpMetaTraceContextBridgeTest {
+
+    private final InMemorySpanExporter exporter = InMemorySpanExporter.create();
+    private final ObjectMapper mapper = new ObjectMapper();
+    private OpenTelemetrySdk sdk;
+
+    @BeforeEach
+    void setUp() {
+        sdk = OpenTelemetrySdk.builder()
+                .setTracerProvider(OtelTestFixtures.tracerProvider(exporter))
+                .setPropagators(OtelTestFixtures.w3cPropagators())
+                .build();
+        TelemetryBootstrap.init(sdk);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TelemetryBootstrap.reset();
+        exporter.reset();
+    }
+
+    @Test
+    void extractContextShouldRecoverTraceAndSpanIds() throws Exception {
+        JsonNode request = mapper.readTree("""
+                {
+                  "jsonrpc": "2.0",
+                  "id": 2,
+                  "method": "tools/call",
+                  "params": {
+                    "name": "get-forecast",
+                    "_meta": {
+                      "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+                    }
+                  }
+                }
+                """);
+
+        Context extracted = McpMetaTraceContextBridge.extractContext(request);
+
+        Span serverSpan = sdk.getTracer("test")
+                .spanBuilder("test.request")
+                .setSpanKind(SpanKind.SERVER)
+                .setParent(extracted)
+                .startSpan();
+        serverSpan.end();
+
+        SpanData data = exporter.getFinishedSpanItems().getFirst();
+        assertEquals("4bf92f3577b34da6a3ce929d0e0e4736", data.getTraceId());
+        assertEquals("00f067aa0ba902b7", data.getParentSpanId());
+    }
+
+    @Test
+    void extractContextShouldFallBackToCurrentContextWhenMetaAbsent() throws Exception {
+        JsonNode request = mapper.readTree("""
+                {
+                  "jsonrpc": "2.0",
+                  "id": 2,
+                  "method": "tools/call",
+                  "params": {
+                    "name": "get-forecast"
+                  }
+                }
+                """);
+
+        Context extracted = McpMetaTraceContextBridge.extractContext(request);
+
+        Span serverSpan = sdk.getTracer("test")
+                .spanBuilder("test.request")
+                .setSpanKind(SpanKind.SERVER)
+                .setParent(extracted)
+                .startSpan();
+        serverSpan.end();
+
+        SpanData data = exporter.getFinishedSpanItems().getFirst();
+        // No remote parent — the span is its own trace root.
+        assertEquals("0000000000000000", data.getParentSpanId());
+    }
+
+    @Test
+    void headerGetterShouldReturnSingletonInstance() {
+        assertSame(McpMetaTraceContextGetter.INSTANCE, McpMetaTraceContextBridge.headerGetter());
+    }
+
+    // ─── extractContext(JsonNode, Request) — layered HTTP + _meta carrier ──────
+
+    @Test
+    void extractContextWithHttpRequestShouldPreferMetaOverHttpHeader() throws Exception {
+        JsonNode request = mapper.readTree("""
+                {
+                  "jsonrpc": "2.0",
+                  "id": 2,
+                  "method": "tools/call",
+                  "params": {
+                    "name": "get-forecast",
+                    "_meta": {
+                      "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+                    }
+                  }
+                }
+                """);
+
+        Request httpRequest = new Request(Method.POST, "http://localhost/mcp");
+        httpRequest.getHeaders().add("traceparent",
+                "00-abcdef0123456789abcdef0123456789-fedcba9876543210-01");
+
+        Context extracted = McpMetaTraceContextBridge.extractContext(request, httpRequest);
+
+        Span serverSpan = sdk.getTracer("test")
+                .spanBuilder("test.request")
+                .setSpanKind(SpanKind.SERVER)
+                .setParent(extracted)
+                .startSpan();
+        serverSpan.end();
+
+        SpanData data = exporter.getFinishedSpanItems().getFirst();
+        assertEquals("4bf92f3577b34da6a3ce929d0e0e4736", data.getTraceId(),
+                "_meta trace context should take precedence over the HTTP header");
+        assertEquals("00f067aa0ba902b7", data.getParentSpanId());
+    }
+
+    @Test
+    void extractContextWithHttpRequestShouldFallBackToHttpHeaderWhenMetaAbsent() throws Exception {
+        JsonNode request = mapper.readTree("""
+                {
+                  "jsonrpc": "2.0",
+                  "id": 2,
+                  "method": "tools/call",
+                  "params": {
+                    "name": "get-forecast"
+                  }
+                }
+                """);
+
+        Request httpRequest = new Request(Method.POST, "http://localhost/mcp");
+        httpRequest.getHeaders().add("traceparent",
+                "00-abcdef0123456789abcdef0123456789-fedcba9876543210-01");
+
+        Context extracted = McpMetaTraceContextBridge.extractContext(request, httpRequest);
+
+        Span serverSpan = sdk.getTracer("test")
+                .spanBuilder("test.request")
+                .setSpanKind(SpanKind.SERVER)
+                .setParent(extracted)
+                .startSpan();
+        serverSpan.end();
+
+        SpanData data = exporter.getFinishedSpanItems().getFirst();
+        assertEquals("abcdef0123456789abcdef0123456789", data.getTraceId(),
+                "should fall back to the HTTP header when _meta carries no trace context");
+        assertEquals("fedcba9876543210", data.getParentSpanId());
+    }
+
+    @Test
+    void extractContextWithHttpRequestShouldFallBackToCurrentContextWhenBothCarriersAbsent()
+            throws Exception {
+        JsonNode request = mapper.readTree("""
+                {
+                  "jsonrpc": "2.0",
+                  "id": 2,
+                  "method": "tools/call",
+                  "params": {
+                    "name": "get-forecast"
+                  }
+                }
+                """);
+
+        Request httpRequest = new Request(Method.POST, "http://localhost/mcp");
+
+        Context extracted = McpMetaTraceContextBridge.extractContext(request, httpRequest);
+
+        Span serverSpan = sdk.getTracer("test")
+                .spanBuilder("test.request")
+                .setSpanKind(SpanKind.SERVER)
+                .setParent(extracted)
+                .startSpan();
+        serverSpan.end();
+
+        SpanData data = exporter.getFinishedSpanItems().getFirst();
+        assertEquals("0000000000000000", data.getParentSpanId());
+    }
+
+    @Test
+    void extractContextWithHttpRequestShouldHandleNullHttpRequest() throws Exception {
+        JsonNode request = mapper.readTree("""
+                {
+                  "jsonrpc": "2.0",
+                  "id": 2,
+                  "method": "tools/call",
+                  "params": {
+                    "name": "get-forecast",
+                    "_meta": {
+                      "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+                    }
+                  }
+                }
+                """);
+
+        Context extracted = McpMetaTraceContextBridge.extractContext(request, (Request) null);
+
+        Span serverSpan = sdk.getTracer("test")
+                .spanBuilder("test.request")
+                .setSpanKind(SpanKind.SERVER)
+                .setParent(extracted)
+                .startSpan();
+        serverSpan.end();
+
+        SpanData data = exporter.getFinishedSpanItems().getFirst();
+        assertEquals("4bf92f3577b34da6a3ce929d0e0e4736", data.getTraceId());
+    }
+}

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/observability/McpMetaTraceContextGetterTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/observability/McpMetaTraceContextGetterTest.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright 2025-2026 Naftiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.ikanos.engine.observability;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class McpMetaTraceContextGetterTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void getShouldReturnMetaValue() throws Exception {
+        JsonNode request = mapper.readTree("""
+                {
+                  "jsonrpc": "2.0",
+                  "id": 2,
+                  "method": "tools/call",
+                  "params": {
+                    "name": "get_weather",
+                    "_meta": {
+                      "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+                    }
+                  }
+                }
+                """);
+
+        String value = McpMetaTraceContextGetter.INSTANCE.get(request, "traceparent");
+        assertEquals("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01", value);
+    }
+
+    @Test
+    void getShouldReturnNullForMissingKey() throws Exception {
+        JsonNode request = mapper.readTree("""
+                {
+                  "jsonrpc": "2.0",
+                  "id": 2,
+                  "method": "tools/call",
+                  "params": {
+                    "name": "get_weather",
+                    "_meta": {}
+                  }
+                }
+                """);
+
+        assertNull(McpMetaTraceContextGetter.INSTANCE.get(request, "traceparent"));
+    }
+
+    @Test
+    void getShouldReturnNullWhenMetaAbsent() throws Exception {
+        JsonNode request = mapper.readTree("""
+                {
+                  "jsonrpc": "2.0",
+                  "id": 2,
+                  "method": "tools/call",
+                  "params": {
+                    "name": "get_weather"
+                  }
+                }
+                """);
+
+        assertNull(McpMetaTraceContextGetter.INSTANCE.get(request, "traceparent"));
+    }
+
+    @Test
+    void getShouldReturnNullWhenParamsAbsent() throws Exception {
+        JsonNode request = mapper.readTree("""
+                {
+                  "jsonrpc": "2.0",
+                  "id": 2,
+                  "method": "ping"
+                }
+                """);
+
+        assertNull(McpMetaTraceContextGetter.INSTANCE.get(request, "traceparent"));
+    }
+
+    @Test
+    void getShouldReturnNullForNullRequest() {
+        assertNull(McpMetaTraceContextGetter.INSTANCE.get(null, "traceparent"));
+    }
+
+    @Test
+    @SuppressWarnings("null") // deliberately passing null to @Nonnull param
+    void getShouldReturnNullForNullKey() throws Exception {
+        JsonNode request = mapper.readTree("""
+                {
+                  "params": {
+                    "_meta": {
+                      "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+                    }
+                  }
+                }
+                """);
+
+        assertNull(McpMetaTraceContextGetter.INSTANCE.get(request, null));
+    }
+
+    @Test
+    void getShouldReturnNullWhenMetaValueIsNullNode() throws Exception {
+        JsonNode request = mapper.readTree("""
+                {
+                  "params": {
+                    "_meta": {
+                      "traceparent": null
+                    }
+                  }
+                }
+                """);
+
+        assertNull(McpMetaTraceContextGetter.INSTANCE.get(request, "traceparent"));
+    }
+
+    @Test
+    void keysShouldReturnAllMetaKeys() throws Exception {
+        JsonNode request = mapper.readTree("""
+                {
+                  "params": {
+                    "_meta": {
+                      "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+                      "tracestate": "vendor=value",
+                      "baggage": "key=value"
+                    }
+                  }
+                }
+                """);
+
+        Iterable<String> keys = McpMetaTraceContextGetter.INSTANCE.keys(request);
+        assertNotNull(keys);
+
+        List<String> keyList = new ArrayList<>();
+        keys.forEach(keyList::add);
+        assertEquals(3, keyList.size());
+        assertTrue(keyList.containsAll(List.of("traceparent", "tracestate", "baggage")));
+    }
+
+    @Test
+    void keysShouldReturnEmptyForNullRequest() {
+        Iterable<String> keys = McpMetaTraceContextGetter.INSTANCE.keys(null);
+        assertFalse(keys.iterator().hasNext());
+    }
+
+    @Test
+    void keysShouldReturnEmptyWhenMetaAbsent() throws Exception {
+        JsonNode request = mapper.readTree("""
+                {
+                  "params": {
+                    "name": "get_weather"
+                  }
+                }
+                """);
+
+        Iterable<String> keys = McpMetaTraceContextGetter.INSTANCE.keys(request);
+        assertFalse(keys.iterator().hasNext());
+    }
+
+    @Test
+    void keysShouldReturnEmptyWhenMetaIsNotAnObject() throws Exception {
+        JsonNode request = mapper.readTree("""
+                {
+                  "params": {
+                    "_meta": "not-an-object"
+                  }
+                }
+                """);
+
+        Iterable<String> keys = McpMetaTraceContextGetter.INSTANCE.keys(request);
+        assertFalse(keys.iterator().hasNext());
+    }
+}

--- a/modules/ikanos-engine/src/test/java/io/ikanos/tutorial/AbstractShipyardMcpClientIntegrationTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/tutorial/AbstractShipyardMcpClientIntegrationTest.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import io.github.microcks.testcontainers.MicrocksContainer;
+import io.ikanos.engine.exposes.mcp.ProtocolDispatcher;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 
@@ -164,38 +165,13 @@ abstract class AbstractShipyardMcpClientIntegrationTest {
     }
 
     /**
-     * Runs the MCP {@code initialize} + {@code notifications/initialized} handshake and
-     * returns the session ID issued by the server.
-     */
-    protected String initialize(HttpClient http) throws Exception {
-        String initBody = """
-                {"jsonrpc":"2.0","id":1,"method":"initialize",
-                 "params":{"protocolVersion":"2025-11-25",
-                           "clientInfo":{"name":"test-client","version":"1.0"},
-                           "capabilities":{}}}
-                """;
-
-        HttpResponse<String> initResp = http.send(buildPost(initBody), string());
-        assertEquals(200, initResp.statusCode(), "initialize must succeed");
-
-        String sessionId = initResp.headers().firstValue("Mcp-Session-Id")
-                .orElseThrow(() -> new AssertionError("No Mcp-Session-Id in initialize response"));
-
-        http.send(buildPost("""
-                {"jsonrpc":"2.0","method":"notifications/initialized"}
-                """, sessionId), string());
-
-        return sessionId;
-    }
-
-    /**
      * Sends {@code tools/list} and returns the {@code result.tools} array.
      */
-    protected JsonNode callToolsList(HttpClient http, String sessionId) throws Exception {
+    protected JsonNode callToolsList(HttpClient http) throws Exception {
         HttpResponse<String> response = http.send(
                 buildPost("""
                         {"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
-                        """, sessionId),
+                        """),
                 string());
         assertEquals(200, response.statusCode());
         return json.readTree(response.body()).path("result").path("tools");
@@ -205,16 +181,16 @@ abstract class AbstractShipyardMcpClientIntegrationTest {
      * Sends {@code tools/call}, asserts {@code isError} is false, and returns the parsed
      * JSON payload from {@code result.content[0].text}.
      */
-    protected JsonNode callTool(HttpClient http, String sessionId, String body) throws Exception {
-        return doCallTool(http, sessionId, body, true).orElseThrow();
+    protected JsonNode callTool(HttpClient http, String body) throws Exception {
+        return doCallTool(http, body, true).orElseThrow();
     }
 
-    protected Optional<JsonNode> callTool(HttpClient http, String sessionId, String body, boolean contentExpected) throws Exception {
-        return doCallTool(http, sessionId, body, contentExpected);
+    protected Optional<JsonNode> callTool(HttpClient http, String body, boolean contentExpected) throws Exception {
+        return doCallTool(http, body, contentExpected);
     }
 
-    private Optional<JsonNode> doCallTool(HttpClient http, String sessionId, String body, boolean contentExpected) throws IOException, InterruptedException {
-        HttpResponse<String> response = http.send(buildPost(body, sessionId), string());
+    private Optional<JsonNode> doCallTool(HttpClient http, String body, boolean contentExpected) throws IOException, InterruptedException {
+        HttpResponse<String> response = http.send(buildPost(body), string());
         assertEquals(200, response.statusCode());
 
         JsonNode envelope = json.readTree(response.body());
@@ -232,10 +208,6 @@ abstract class AbstractShipyardMcpClientIntegrationTest {
     }
 
     protected HttpRequest buildPost(String body) {
-        return buildPost(body, null);
-    }
-
-    protected HttpRequest buildPost(String body, String sessionId) {
         if (mcpServerToken == null) {
             File defaultSecretsFile = new File(DEFAULT_TUTORIAL_SECRETS_FILE);
             if (defaultSecretsFile.exists()) {
@@ -247,17 +219,53 @@ abstract class AbstractShipyardMcpClientIntegrationTest {
             }
         }
 
+        String enrichedBody = withProtocolVersionMeta(body.strip());
         HttpRequest.Builder builder = HttpRequest.newBuilder()
                 .uri(URI.create(serverUrl))
                 .header("Content-Type", "application/json")
-                .POST(HttpRequest.BodyPublishers.ofString(body.strip()));
+                .header("MCP-Protocol-Version", ProtocolDispatcher.MCP_PROTOCOL_VERSION)
+                .POST(HttpRequest.BodyPublishers.ofString(enrichedBody));
         if (mcpServerToken != null) {
             builder.header("Authorization", "Bearer " + mcpServerToken);
         }
-        if (sessionId != null) {
-            builder.header("Mcp-Session-Id", sessionId);
+
+        try {
+            JsonNode request = json.readTree(enrichedBody);
+            String rpcMethod = request.path("method").asText("");
+            if (!rpcMethod.isEmpty()) {
+                builder.header("Mcp-Method", rpcMethod);
+            }
+            String toolOrPromptName = request.path("params").path("name").asText(null);
+            String resourceUri = request.path("params").path("uri").asText(null);
+            if (toolOrPromptName != null) {
+                builder.header("Mcp-Name", toolOrPromptName);
+            } else if (resourceUri != null) {
+                builder.header("Mcp-Name", resourceUri);
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to parse JSON-RPC request body for header injection", e);
         }
+
         return builder.build();
+    }
+
+    /**
+     * Injects {@code params._meta["io.modelcontextprotocol/protocolVersion"]} into a raw
+     * JSON-RPC request body, creating {@code params} if it is absent.
+     */
+    private String withProtocolVersionMeta(String requestJson) {
+        try {
+            com.fasterxml.jackson.databind.node.ObjectNode request =
+                    (com.fasterxml.jackson.databind.node.ObjectNode) json.readTree(requestJson);
+            com.fasterxml.jackson.databind.node.ObjectNode params =
+                    request.has("params") && request.get("params").isObject()
+                            ? (com.fasterxml.jackson.databind.node.ObjectNode) request.get("params")
+                            : request.putObject("params");
+            params.putObject("_meta").put("io.modelcontextprotocol/protocolVersion", ProtocolDispatcher.MCP_PROTOCOL_VERSION);
+            return json.writeValueAsString(request);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to inject protocolVersion into request body", e);
+        }
     }
 
     protected static HttpResponse.BodyHandler<String> string() {

--- a/modules/ikanos-engine/src/test/java/io/ikanos/tutorial/Step10ShipyardRestAdapterIntegrationTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/tutorial/Step10ShipyardRestAdapterIntegrationTest.java
@@ -77,8 +77,8 @@ public class Step10ShipyardRestAdapterIntegrationTest
         int mcpPort = findFreePort();
         int skillPort = findFreePort();
 
-        spec.getCapability().getExposes().get(0).setPort(mcpPort);
-        spec.getCapability().getExposes().get(0).setAddress("localhost");
+        spec.getCapability().getExposes().getFirst().setPort(mcpPort);
+        spec.getCapability().getExposes().getFirst().setAddress("localhost");
 
         RestServerSpec restSpec = (RestServerSpec) spec.getCapability().getExposes().stream()
                 .filter(e -> e instanceof RestServerSpec)
@@ -105,18 +105,20 @@ public class Step10ShipyardRestAdapterIntegrationTest
 
     @Test
     public void restListShipsShouldReturnShipsArray() throws Exception {
-        HttpClient http = HttpClient.newHttpClient();
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create("http://localhost:" + restPort + "/ships"))
-                .GET()
-                .build();
+        HttpResponse<String> response;
+        try (HttpClient http = HttpClient.newHttpClient()) {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create("http://localhost:" + restPort + "/ships"))
+                    .GET()
+                    .build();
 
-        HttpResponse<String> response = http.send(request, string());
+            response = http.send(request, string());
+        }
         assertEquals(200, response.statusCode(), "GET /ships must succeed");
 
         JsonNode ships = json.readTree(response.body());
         assertTrue(ships.isArray(), "GET /ships must return an array");
-        assertTrue(ships.size() > 0, "Ships array must not be empty");
+        assertFalse(ships.isEmpty(), "Ships array must not be empty");
 
         JsonNode firstShip = ships.get(0);
         assertTrue(firstShip.has("imo"), "Ship must have imo field");
@@ -128,27 +130,29 @@ public class Step10ShipyardRestAdapterIntegrationTest
 
     @Test
     public void restCreateVoyageShouldReturnMappedVoyageObject() throws Exception {
-        HttpClient http = HttpClient.newHttpClient();
+        HttpResponse<String> response;
+        try (HttpClient http = HttpClient.newHttpClient()) {
 
-        String voyagePayload = """
-                {
-                  "shipImo": "IMO-9321483",
-                  "departurePort": "Oslo",
-                  "arrivalPort": "Singapore",
-                  "departureDate": "2026-04-10",
-                  "arrivalDate": "2026-05-02",
-                  "crewIds": ["CREW-001", "CREW-003"],
-                  "cargoIds": ["CARGO-2024-0451"]
-                }
-                """;
+            String voyagePayload = """
+                    {
+                      "shipImo": "IMO-9321483",
+                      "departurePort": "Oslo",
+                      "arrivalPort": "Singapore",
+                      "departureDate": "2026-04-10",
+                      "arrivalDate": "2026-05-02",
+                      "crewIds": ["CREW-001", "CREW-003"],
+                      "cargoIds": ["CARGO-2024-0451"]
+                    }
+                    """;
 
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create("http://localhost:" + restPort + "/voyages"))
-                .POST(HttpRequest.BodyPublishers.ofString(voyagePayload))
-                .header("Content-Type", "application/json")
-                .build();
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create("http://localhost:" + restPort + "/voyages"))
+                    .POST(HttpRequest.BodyPublishers.ofString(voyagePayload))
+                    .header("Content-Type", "application/json")
+                    .build();
 
-        HttpResponse<String> response = http.send(request, string());
+            response = http.send(request, string());
+        }
         assertEquals(201, response.statusCode(), "POST /voyages must return 201 Created");
 
         JsonNode voyage = json.readTree(response.body());
@@ -167,7 +171,7 @@ public class Step10ShipyardRestAdapterIntegrationTest
         assertEquals("2026-05-02", dates.path("arrival").asText(), "dates.arrival must map");
 
         assertTrue(voyage.path("crewIds").isArray(), "crewIds must be an array");
-        assertTrue(voyage.path("crewIds").size() > 0, "crewIds must not be empty");
+        assertFalse(voyage.path("crewIds").isEmpty(), "crewIds must not be empty");
         assertTrue(voyage.path("cargoIds").isArray(), "cargoIds must be an array");
         assertFalse(voyage.path("status").asText().isBlank(), "status must not be blank");
     }
@@ -177,8 +181,7 @@ public class Step10ShipyardRestAdapterIntegrationTest
         int skillPort = findFreePort();
         SkillServerAdapter skillAdapter = startIsolatedSkillServer(skillPort);
 
-        try {
-            HttpClient http = HttpClient.newHttpClient();
+        try (HttpClient http = HttpClient.newHttpClient()) {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create("http://localhost:" + skillPort + "/skills"))
                     .GET()
@@ -206,8 +209,7 @@ public class Step10ShipyardRestAdapterIntegrationTest
         int skillPort = findFreePort();
         SkillServerAdapter skillAdapter = startIsolatedSkillServer(skillPort);
 
-        try {
-            HttpClient http = HttpClient.newHttpClient();
+        try (HttpClient http = HttpClient.newHttpClient()) {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create("http://localhost:" + skillPort + "/skills/fleet-ops"))
                     .GET()
@@ -250,7 +252,7 @@ public class Step10ShipyardRestAdapterIntegrationTest
     private SkillServerAdapter startIsolatedSkillServer(int skillPort) throws Exception {
         IkanosSpec spec = loadPatchedStep10Spec();
 
-        spec.getCapability().getExposes().get(0).setPort(findFreePort());
+        spec.getCapability().getExposes().getFirst().setPort(findFreePort());
 
         RestServerSpec restSpec = (RestServerSpec) spec.getCapability().getExposes().stream()
                 .filter(e -> e instanceof RestServerSpec)

--- a/modules/ikanos-engine/src/test/java/io/ikanos/tutorial/Step11ShipyardFleetManifestIntegrationTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/tutorial/Step11ShipyardFleetManifestIntegrationTest.java
@@ -76,8 +76,8 @@ public class Step11ShipyardFleetManifestIntegrationTest
         int mcpPort = findFreePort();
         int skillPort = findFreePort();
 
-        spec.getCapability().getExposes().get(0).setPort(mcpPort);
-        spec.getCapability().getExposes().get(0).setAddress("localhost");
+        spec.getCapability().getExposes().getFirst().setPort(mcpPort);
+        spec.getCapability().getExposes().getFirst().setAddress("localhost");
 
         RestServerSpec restSpec = (RestServerSpec) spec.getCapability().getExposes().stream()
                 .filter(e -> e instanceof RestServerSpec)
@@ -105,9 +105,8 @@ public class Step11ShipyardFleetManifestIntegrationTest
     @Test
     public void toolsListShouldAdvertiseSixTools() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode tools = callToolsList(http, sessionId);
+        JsonNode tools = callToolsList(http);
 
         assertEquals(6, tools.size(), "step-11 MCP exposes exactly six tools");
         assertEquals("list-ships", tools.get(0).path("name").asText());
@@ -121,9 +120,8 @@ public class Step11ShipyardFleetManifestIntegrationTest
     @Test
     public void getShipWithCrewInputSchemaShouldDeclareImoParameter() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode getShipWithCrew = callToolsList(http, sessionId).get(4);
+        JsonNode getShipWithCrew = callToolsList(http).get(4);
 
         JsonNode props = getShipWithCrew.path("inputSchema").path("properties");
         assertTrue(props.has("imo"), "get-ship-with-crew must declare imo parameter");
@@ -143,9 +141,8 @@ public class Step11ShipyardFleetManifestIntegrationTest
     @Test
     public void getVoyageManifestInputSchemaShouldDeclareVoyageIdParameter() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode getVoyageManifest = callToolsList(http, sessionId).get(5);
+        JsonNode getVoyageManifest = callToolsList(http).get(5);
 
         JsonNode props = getVoyageManifest.path("inputSchema").path("properties");
         assertTrue(props.has("voyageId"), "get-voyage-manifest must declare voyageId parameter");
@@ -167,8 +164,7 @@ public class Step11ShipyardFleetManifestIntegrationTest
         int skillPort = findFreePort();
         SkillServerAdapter skillAdapter = startIsolatedSkillServer(skillPort);
 
-        try {
-            HttpClient http = HttpClient.newHttpClient();
+        try (HttpClient http = HttpClient.newHttpClient()) {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create("http://localhost:" + skillPort + "/skills/voyage-ops"))
                     .GET()
@@ -199,14 +195,13 @@ public class Step11ShipyardFleetManifestIntegrationTest
         IkanosSpec spec = loadSpec(CAPABILITY_FILE);
         disableMcpAuthentication(spec);
 
-
         return spec;
     }
 
     private SkillServerAdapter startIsolatedSkillServer(int skillPort) throws Exception {
         IkanosSpec spec = loadPatchedStep11Spec();
 
-        spec.getCapability().getExposes().get(0).setPort(findFreePort());
+        spec.getCapability().getExposes().getFirst().setPort(findFreePort());
 
         RestServerSpec restSpec = (RestServerSpec) spec.getCapability().getExposes().stream()
                 .filter(e -> e instanceof RestServerSpec)

--- a/modules/ikanos-engine/src/test/java/io/ikanos/tutorial/Step1ShipyardMcpClientIntegrationTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/tutorial/Step1ShipyardMcpClientIntegrationTest.java
@@ -31,12 +31,12 @@ import com.fasterxml.jackson.databind.JsonNode;
  * from a remote MCP client perspective.
  *
  * <p>The test starts a real Jetty-backed MCP server loaded from the tutorial YAML, then
- * drives the full MCP Streamable HTTP protocol handshake — exactly as an external MCP
+ * drives the MCP Streamable HTTP protocol (revision 2026-07-28) — exactly as an external MCP
  * client (e.g. Claude Desktop, Cursor, or the MCP Inspector) would:</p>
  *
  * <ol>
- *   <li>{@code initialize} — establishes a session and negotiates protocol version</li>
- *   <li>{@code notifications/initialized} — client confirms readiness</li>
+ *   <li>{@code server/discover} — negotiates the protocol version and discovers capabilities
+ *       (this revision is stateless: there is no {@code initialize} handshake or session)</li>
  *   <li>{@code tools/list} — discovers the available tools</li>
  *   <li>{@code tools/call} — invokes {@code get-ship}, which returns a single mock ship
  *       object with mapped output fields</li>
@@ -57,45 +57,40 @@ public class Step1ShipyardMcpClientIntegrationTest
         startServerFromSpec(loadSpec(CAPABILITY_FILE));
     }
 
-    // ── MCP protocol handshake ───────────────────────────────────────────────
+    // ── MCP protocol: server/discover ────────────────────────────────────────
 
     @Test
-    public void initializeShouldNegotiateProtocolVersionAndReturnSessionId() throws Exception {
-        HttpClient http = HttpClient.newHttpClient();
+    public void serverDiscoverShouldAdvertiseSupportedProtocolVersionAndCapabilities() throws Exception {
+        HttpResponse<String> response;
+        try (HttpClient http = HttpClient.newHttpClient()) {
 
-        String initBody = """
-                {"jsonrpc":"2.0","id":1,"method":"initialize",
-                 "params":{"protocolVersion":"2025-11-25",
-                           "clientInfo":{"name":"test-client","version":"1.0"},
-                           "capabilities":{}}}
-                """;
+            String discoverBody = """
+                    {"jsonrpc":"2.0","id":1,"method":"server/discover","params":{}}
+                    """;
 
-        HttpResponse<String> response = http.send(buildPost(initBody), string());
+            response = http.send(buildPost(discoverBody), string());
+        }
 
         assertEquals(200, response.statusCode());
 
         JsonNode result = json.readTree(response.body()).path("result");
-        assertEquals("2025-11-25", result.path("protocolVersion").asText(),
-                "Server must confirm the requested protocol version");
-        assertEquals("shipyard-tools", result.path("serverInfo").path("name").asText(),
-                "Server name must match the capability namespace");
+        JsonNode supportedVersions = result.path("supportedVersions");
+        assertTrue(supportedVersions.isArray() && !supportedVersions.isEmpty(),
+                "Server must advertise its supported protocol versions");
         assertNotNull(result.path("capabilities").path("tools"),
                 "Capabilities block must advertise tools");
-
-        assertTrue(response.headers().firstValue("Mcp-Session-Id").isPresent(),
-                "Server must return a session ID on initialize");
     }
 
     @Test
-        public void toolsListShouldAdvertiseGetShipTool() throws Exception {
-        HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
-
-        HttpResponse<String> response = http.send(
-                buildPost("""
-                        {"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
-                        """, sessionId),
-                string());
+    public void toolsListShouldAdvertiseGetShipTool() throws Exception {
+        HttpResponse<String> response;
+        try (HttpClient http = HttpClient.newHttpClient()) {
+            response = http.send(
+                    buildPost("""
+                            {"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
+                            """),
+                    string());
+        }
 
         assertEquals(200, response.statusCode());
 
@@ -112,16 +107,16 @@ public class Step1ShipyardMcpClientIntegrationTest
     // ── Tool call — hits real mocks.ikanos.net ──────────────────────────────
 
     @Test
-        public void getShipToolCallShouldReturnMappedShipObject() throws Exception {
-        HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
-
-        HttpResponse<String> response = http.send(
-                buildPost("""
-                        {"jsonrpc":"2.0","id":3,"method":"tools/call",
-                         "params":{"name":"get-ship","arguments":{"imo_number":"IMO-9321483"}}}
-                        """, sessionId),
-                string());
+    public void getShipToolCallShouldReturnMappedShipObject() throws Exception {
+        HttpResponse<String> response;
+        try (HttpClient http = HttpClient.newHttpClient()) {
+            response = http.send(
+                    buildPost("""
+                            {"jsonrpc":"2.0","id":3,"method":"tools/call",
+                             "params":{"name":"get-ship","arguments":{"imo_number":"IMO-9321483"}}}
+                            """),
+                    string());
+        }
 
         assertEquals(200, response.statusCode());
 

--- a/modules/ikanos-engine/src/test/java/io/ikanos/tutorial/Step2ShipyardMcpClientIntegrationTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/tutorial/Step2ShipyardMcpClientIntegrationTest.java
@@ -65,9 +65,8 @@ public class Step2ShipyardMcpClientIntegrationTest
     @Test
     public void toolsListShouldAdvertiseBothTools() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode tools = callToolsList(http, sessionId);
+        JsonNode tools = callToolsList(http);
 
         assertEquals(2, tools.size(), "step-2 exposes exactly two tools");
 
@@ -79,9 +78,8 @@ public class Step2ShipyardMcpClientIntegrationTest
     @Test
     public void listShipsInputSchemaShouldDeclareOptionalStatusParameter() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode tools = callToolsList(http, sessionId);
+        JsonNode tools = callToolsList(http);
         JsonNode listShips = tools.get(0);
 
         JsonNode props = listShips.path("inputSchema").path("properties");
@@ -103,9 +101,8 @@ public class Step2ShipyardMcpClientIntegrationTest
     @Test
     public void getShipInputSchemaShouldDeclareRequiredImoParameter() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode tools = callToolsList(http, sessionId);
+        JsonNode tools = callToolsList(http);
         JsonNode getShip = tools.get(1);
 
         JsonNode props = getShip.path("inputSchema").path("properties");
@@ -128,15 +125,14 @@ public class Step2ShipyardMcpClientIntegrationTest
     @Test
     public void listShipsWithoutFilterShouldReturnMappedShipArray() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode ships = callTool(http, sessionId, """
+        JsonNode ships = callTool(http, """
                 {"jsonrpc":"2.0","id":3,"method":"tools/call",
                  "params":{"name":"list-ships","arguments":{}}}
                 """);
 
         assertTrue(ships.isArray(), "list-ships must return an array");
-        assertTrue(ships.size() > 0, "Ship list must not be empty");
+        assertFalse(ships.isEmpty(), "Ship list must not be empty");
 
         JsonNode first = ships.get(0);
         assertTrue(first.has("imo"),    "Must have 'imo'");
@@ -151,15 +147,14 @@ public class Step2ShipyardMcpClientIntegrationTest
     @Test
     public void listShipsFilteredByStatusShouldReturnOnlyMatchingShips() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode ships = callTool(http, sessionId, """
+        JsonNode ships = callTool(http, """
                 {"jsonrpc":"2.0","id":3,"method":"tools/call",
                  "params":{"name":"list-ships","arguments":{"status":"active"}}}
                 """);
 
         assertTrue(ships.isArray(), "list-ships must return an array");
-        assertTrue(ships.size() > 0, "Filtered list must not be empty");
+        assertFalse(ships.isEmpty(), "Filtered list must not be empty");
 
         // Every ship returned by the mock must have status=active
         for (JsonNode ship : ships) {
@@ -173,10 +168,9 @@ public class Step2ShipyardMcpClientIntegrationTest
     @Test
     public void getShipShouldResolveMustacheWithAndReturnSingleShip() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
         // The 'with' mapping resolves imo → imo_number, which fills /ships/{{imo_number}}
-        JsonNode ship = callTool(http, sessionId, """
+        JsonNode ship = callTool(http, """
                 {"jsonrpc":"2.0","id":3,"method":"tools/call",
                  "params":{"name":"get-ship","arguments":{"imo":"IMO-9321483"}}}
                 """);

--- a/modules/ikanos-engine/src/test/java/io/ikanos/tutorial/Step3ShipyardMcpClientIntegrationTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/tutorial/Step3ShipyardMcpClientIntegrationTest.java
@@ -13,6 +13,7 @@
  */
 package io.ikanos.tutorial;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -77,16 +78,21 @@ public class Step3ShipyardMcpClientIntegrationTest
         startServerFromSpec(spec);
     }
 
-    // ── initialize — proves binds resolved and auth pipeline is live ─────────
+    // ── server/discover — proves binds resolved and auth pipeline is live ────
 
     @Test
-    public void initializeShouldSucceedWithBindsAndAuth() throws Exception {
-        HttpClient http = HttpClient.newHttpClient();
+    public void serverDiscoverShouldSucceedWithBindsAndAuth() throws Exception {
+        // server/discover call returning 200 proves binds were resolved
+        // and the bearer auth pipeline accepted the request.
+        try (HttpClient http = HttpClient.newHttpClient()) {
 
-        String sessionId = initialize(http);
+            String discoverBody = """
+                    {"jsonrpc":"2.0","id":1,"method":"server/discover","params":{}}
+                    """;
 
-        assertNotNull(sessionId, "Server must issue a session ID after initialize");
-        assertFalse(sessionId.isBlank(), "Session ID must not be blank");
+            HttpResponse<String> response = http.send(buildPost(discoverBody), string());
+            assertThat(response.statusCode()).isEqualTo(200);
+        }
     }
 
     // ── tools/list ───────────────────────────────────────────────────────────
@@ -94,9 +100,8 @@ public class Step3ShipyardMcpClientIntegrationTest
     @Test
     public void toolsListShouldAdvertiseBothTools() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode tools = callToolsList(http, sessionId);
+        JsonNode tools = callToolsList(http);
 
         assertEquals(2, tools.size(), "step-3 exposes exactly two tools");
         assertEquals("list-ships", tools.get(0).path("name").asText());
@@ -106,9 +111,8 @@ public class Step3ShipyardMcpClientIntegrationTest
     @Test
     public void listShipsInputSchemaShouldDeclareOptionalStatusParameter() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode tools = callToolsList(http, sessionId);
+        JsonNode tools = callToolsList(http);
         JsonNode listShips = tools.get(0);
 
         JsonNode props = listShips.path("inputSchema").path("properties");
@@ -130,9 +134,8 @@ public class Step3ShipyardMcpClientIntegrationTest
     @Test
     public void getShipInputSchemaShouldDeclareRequiredImoParameter() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode tools = callToolsList(http, sessionId);
+        JsonNode tools = callToolsList(http);
         JsonNode getShip = tools.get(1);
 
         JsonNode props = getShip.path("inputSchema").path("properties");
@@ -155,15 +158,14 @@ public class Step3ShipyardMcpClientIntegrationTest
     @Test
     public void listShipsWithBearerAuthShouldReturnMappedShipArray() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode ships = callTool(http, sessionId, """
+        JsonNode ships = callTool(http, """
                 {"jsonrpc":"2.0","id":3,"method":"tools/call",
                  "params":{"name":"list-ships","arguments":{}}}
                 """);
 
         assertTrue(ships.isArray(), "list-ships must return an array");
-        assertTrue(ships.size() > 0, "Ship list must not be empty");
+        assertFalse(ships.isEmpty(), "Ship list must not be empty");
 
         // Verify the output mapping is correctly applied (imo_number → imo, vessel_name → name …)
         JsonNode first = ships.get(0);
@@ -180,22 +182,21 @@ public class Step3ShipyardMcpClientIntegrationTest
 
     @Test
     public void getShipWithBearerAuthShouldResolveMustacheAndReturnSingleShip() throws Exception {
-        HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
+        try (HttpClient http = HttpClient.newHttpClient()) {
 
-        JsonNode ship = callTool(http, sessionId, """
-                {"jsonrpc":"2.0","id":3,"method":"tools/call",
-                 "params":{"name":"get-ship","arguments":{"imo":"IMO-9321483"}}}
-                """);
-
-        assertTrue(ship.isObject(), "get-ship must return a JSON object");
-        assertTrue(ship.has("imo"),    "Must have 'imo'");
-        assertTrue(ship.has("name"),   "Must have 'name'");
-        assertTrue(ship.has("type"),   "Must have 'type'");
-        assertTrue(ship.has("flag"),   "Must have 'flag'");
-        assertTrue(ship.has("status"), "Must have 'status'");
-        assertEquals("IMO-9321483", ship.path("imo").asText(),
-                "Returned imo must match the requested IMO number");
+            JsonNode ship = callTool(http, """
+                    {"jsonrpc":"2.0","id":3,"method":"tools/call",
+                     "params":{"name":"get-ship","arguments":{"imo":"IMO-9321483"}}}
+                    """);
+            assertTrue(ship.isObject(), "get-ship must return a JSON object");
+            assertTrue(ship.has("imo"),    "Must have 'imo'");
+            assertTrue(ship.has("name"),   "Must have 'name'");
+            assertTrue(ship.has("type"),   "Must have 'type'");
+            assertTrue(ship.has("flag"),   "Must have 'flag'");
+            assertTrue(ship.has("status"), "Must have 'status'");
+            assertEquals("IMO-9321483", ship.path("imo").asText(),
+                    "Returned imo must match the requested IMO number");
+        }
     }
 
     // ── authentication pipeline — validates fix for issue #482 ───────────────
@@ -218,45 +219,51 @@ public class Step3ShipyardMcpClientIntegrationTest
         useMcpServerToken(SECRETS_FILE);
         startServerFromSpecWithAuth(spec);
 
-        HttpClient http = HttpClient.newHttpClient();
-        String initBody = """
-                {"jsonrpc":"2.0","id":1,"method":"initialize",
-                 "params":{"protocolVersion":"2025-11-25",
-                           "clientInfo":{"name":"test-client","version":"1.0"},
-                           "capabilities":{}}}
-                """;
+        HttpResponse<String> noToken;
+        try (HttpClient http = HttpClient.newHttpClient()) {
+            String discoverBody = """
+                    {"jsonrpc":"2.0","id":1,"method":"server/discover",
+                     "params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"%s"}}}
+                    """.formatted(io.ikanos.engine.exposes.mcp.ProtocolDispatcher.MCP_PROTOCOL_VERSION);
 
-        // Correct token from secrets.yaml should be accepted (issue #482 fix)
-        HttpResponse<String> accepted = http.send(
-                HttpRequest.newBuilder(URI.create(serverUrl))
-                        .POST(HttpRequest.BodyPublishers.ofString(initBody.strip()))
-                        .header("Content-Type", "application/json")
-                        .header("Authorization", "Bearer " + mcpServerToken)
-                        .build(),
-                HttpResponse.BodyHandlers.ofString());
+            // Correct token from secrets.yaml should be accepted (issue #482 fix)
+            HttpResponse<String> accepted = http.send(
+                    HttpRequest.newBuilder(URI.create(serverUrl))
+                            .POST(HttpRequest.BodyPublishers.ofString(discoverBody.strip()))
+                            .header("Content-Type", "application/json")
+                            .header("MCP-Protocol-Version", io.ikanos.engine.exposes.mcp.ProtocolDispatcher.MCP_PROTOCOL_VERSION)
+                            .header("Mcp-Method", "server/discover")
+                            .header("Authorization", "Bearer " + mcpServerToken)
+                            .build(),
+                    HttpResponse.BodyHandlers.ofString());
 
-        assertEquals(200, accepted.statusCode(),
-                "Correct token resolved from file binding must be accepted (issue #482)");
+            assertEquals(200, accepted.statusCode(),
+                    "Correct token resolved from file binding must be accepted (issue #482)");
 
-        // Wrong token must be rejected
-        HttpResponse<String> rejected = http.send(
-                HttpRequest.newBuilder(URI.create(serverUrl))
-                        .POST(HttpRequest.BodyPublishers.ofString(initBody.strip()))
-                        .header("Content-Type", "application/json")
-                        .header("Authorization", "Bearer wrong-token")
-                        .build(),
-                HttpResponse.BodyHandlers.ofString());
+            // Wrong token must be rejected
+            HttpResponse<String> rejected = http.send(
+                    HttpRequest.newBuilder(URI.create(serverUrl))
+                            .POST(HttpRequest.BodyPublishers.ofString(discoverBody.strip()))
+                            .header("Content-Type", "application/json")
+                            .header("MCP-Protocol-Version", io.ikanos.engine.exposes.mcp.ProtocolDispatcher.MCP_PROTOCOL_VERSION)
+                            .header("Mcp-Method", "server/discover")
+                            .header("Authorization", "Bearer wrong-token")
+                            .build(),
+                    HttpResponse.BodyHandlers.ofString());
 
-        assertEquals(401, rejected.statusCode(),
-                "Wrong token must be rejected");
+            assertEquals(401, rejected.statusCode(),
+                    "Wrong token must be rejected");
 
-        // Missing token must be rejected
-        HttpResponse<String> noToken = http.send(
-                HttpRequest.newBuilder(URI.create(serverUrl))
-                        .POST(HttpRequest.BodyPublishers.ofString(initBody.strip()))
-                        .header("Content-Type", "application/json")
-                        .build(),
-                HttpResponse.BodyHandlers.ofString());
+            // Missing token must be rejected
+            noToken = http.send(
+                    HttpRequest.newBuilder(URI.create(serverUrl))
+                            .POST(HttpRequest.BodyPublishers.ofString(discoverBody.strip()))
+                            .header("Content-Type", "application/json")
+                            .header("MCP-Protocol-Version", io.ikanos.engine.exposes.mcp.ProtocolDispatcher.MCP_PROTOCOL_VERSION)
+                            .header("Mcp-Method", "server/discover")
+                            .build(),
+                    HttpResponse.BodyHandlers.ofString());
+        }
 
         assertEquals(401, noToken.statusCode(),
                 "Request without token must be rejected");

--- a/modules/ikanos-engine/src/test/java/io/ikanos/tutorial/Step4ShipyardMcpClientIntegrationTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/tutorial/Step4ShipyardMcpClientIntegrationTest.java
@@ -76,9 +76,8 @@ public class Step4ShipyardMcpClientIntegrationTest
     @Test
     public void toolsListShouldAdvertiseBothTools() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode tools = callToolsList(http, sessionId);
+        JsonNode tools = callToolsList(http);
 
         assertEquals(2, tools.size(), "step-4 exposes exactly two tools");
         assertEquals("list-ships", tools.get(0).path("name").asText());
@@ -88,9 +87,8 @@ public class Step4ShipyardMcpClientIntegrationTest
     @Test
     public void listShipsInputSchemaShouldDeclareOptionalStatusParameter() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode listShips = callToolsList(http, sessionId).get(0);
+        JsonNode listShips = callToolsList(http).get(0);
 
         JsonNode props = listShips.path("inputSchema").path("properties");
         assertTrue(props.has("status"), "list-ships inputSchema must declare 'status'");
@@ -110,9 +108,8 @@ public class Step4ShipyardMcpClientIntegrationTest
     @Test
     public void getShipInputSchemaShouldDeclareRequiredImoParameter() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode getShip = callToolsList(http, sessionId).get(1);
+        JsonNode getShip = callToolsList(http).get(1);
 
         JsonNode props = getShip.path("inputSchema").path("properties");
         assertTrue(props.has("imo"), "get-ship inputSchema must declare 'imo'");
@@ -134,14 +131,13 @@ public class Step4ShipyardMcpClientIntegrationTest
     @Test
     public void listShipsShouldReturnMappedFlatFields() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode ships = callTool(http, sessionId, """
+        JsonNode ships = callTool(http, """
                 {"jsonrpc":"2.0","id":3,"method":"tools/call",
                  "params":{"name":"list-ships","arguments":{}}}
                 """);
 
-        assertTrue(ships.isArray() && ships.size() > 0, "list-ships must return a non-empty array");
+        assertTrue(ships.isArray() && !ships.isEmpty(), "list-ships must return a non-empty array");
 
         JsonNode first = ships.get(0);
         assertTrue(first.has("imo"),    "Must have 'imo'");
@@ -158,9 +154,8 @@ public class Step4ShipyardMcpClientIntegrationTest
     @Test
     public void getShipShouldReturnFlatFieldsAndNestedSpecsObject() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode ship = callTool(http, sessionId, """
+        JsonNode ship = callTool(http, """
                 {"jsonrpc":"2.0","id":3,"method":"tools/call",
                  "params":{"name":"get-ship","arguments":{"imo":"IMO-9321483"}}}
                 """);

--- a/modules/ikanos-engine/src/test/java/io/ikanos/tutorial/Step5ShipyardMcpClientIntegrationTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/tutorial/Step5ShipyardMcpClientIntegrationTest.java
@@ -88,9 +88,8 @@ public class Step5ShipyardMcpClientIntegrationTest
     @Test
     public void toolsListShouldAdvertiseThreeTools() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode tools = callToolsList(http, sessionId);
+        JsonNode tools = callToolsList(http);
 
         assertEquals(3, tools.size(), "step-5 exposes exactly three tools");
         assertEquals("list-ships",          tools.get(0).path("name").asText());
@@ -101,9 +100,8 @@ public class Step5ShipyardMcpClientIntegrationTest
     @Test
     public void listShipsInputSchemaShouldDeclareOptionalStatusParameter() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode listShips = callToolsList(http, sessionId).get(0);
+        JsonNode listShips = callToolsList(http).get(0);
 
         JsonNode props = listShips.path("inputSchema").path("properties");
         assertTrue(props.has("status"), "list-ships inputSchema must declare 'status'");
@@ -123,9 +121,8 @@ public class Step5ShipyardMcpClientIntegrationTest
     @Test
     public void getShipInputSchemaShouldDeclareRequiredImoParameter() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode getShip = callToolsList(http, sessionId).get(1);
+        JsonNode getShip = callToolsList(http).get(1);
 
         JsonNode props = getShip.path("inputSchema").path("properties");
         assertTrue(props.has("imo"), "get-ship inputSchema must declare 'imo'");
@@ -145,9 +142,8 @@ public class Step5ShipyardMcpClientIntegrationTest
     @Test
     public void listLegacyVesselsInputSchemaShouldDeclareOptionalStatusParameter() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode listLegacy = callToolsList(http, sessionId).get(2);
+        JsonNode listLegacy = callToolsList(http).get(2);
 
         JsonNode props = listLegacy.path("inputSchema").path("properties");
         assertTrue(props.has("status"), "list-legacy-vessels inputSchema must declare 'status'");
@@ -169,14 +165,13 @@ public class Step5ShipyardMcpClientIntegrationTest
     @Test
     public void listShipsShouldReturnMappedFlatFields() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode ships = callTool(http, sessionId, """
+        JsonNode ships = callTool(http, """
                 {"jsonrpc":"2.0","id":3,"method":"tools/call",
                  "params":{"name":"list-ships","arguments":{}}}
                 """);
 
-        assertTrue(ships.isArray() && ships.size() > 0, "list-ships must return a non-empty array");
+        assertTrue(ships.isArray() && !ships.isEmpty(), "list-ships must return a non-empty array");
 
         JsonNode first = ships.get(0);
         assertTrue(first.has("imo"),    "Must have 'imo'");
@@ -193,9 +188,8 @@ public class Step5ShipyardMcpClientIntegrationTest
     @Test
     public void getShipShouldReturnFlatFieldsAndNestedSpecsObject() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode ship = callTool(http, sessionId, """
+        JsonNode ship = callTool(http, """
                 {"jsonrpc":"2.0","id":3,"method":"tools/call",
                  "params":{"name":"get-ship","arguments":{"imo":"IMO-9321483"}}}
                 """);
@@ -225,14 +219,13 @@ public class Step5ShipyardMcpClientIntegrationTest
     @Test
     public void listLegacyVesselsShouldReturnMappedVesselArray() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode vessels = callTool(http, sessionId, """
+        JsonNode vessels = callTool(http, """
                 {"jsonrpc":"2.0","id":3,"method":"tools/call",
                  "params":{"name":"list-legacy-vessels","arguments":{}}}
                 """);
 
-        assertTrue(vessels.isArray() && vessels.size() > 0,
+        assertTrue(vessels.isArray() && !vessels.isEmpty(),
                 "list-legacy-vessels must return a non-empty array");
 
         JsonNode first = vessels.get(0);

--- a/modules/ikanos-engine/src/test/java/io/ikanos/tutorial/Step6ShipyardMcpClientIntegrationTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/tutorial/Step6ShipyardMcpClientIntegrationTest.java
@@ -57,9 +57,8 @@ public class Step6ShipyardMcpClientIntegrationTest
     @Test
     public void toolsListShouldAdvertiseFourTools() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode tools = callToolsList(http, sessionId);
+        JsonNode tools = callToolsList(http);
 
         assertEquals(5, tools.size(), "step-6 exposes exactly five tools");
         assertEquals("list-ships",          tools.get(0).path("name").asText());
@@ -72,9 +71,8 @@ public class Step6ShipyardMcpClientIntegrationTest
     @Test
     public void createVoyageInputSchemaShouldDeclareRequiredFields() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode createVoyage = callToolsList(http, sessionId).get(3);
+        JsonNode createVoyage = callToolsList(http).get(3);
 
         JsonNode props = createVoyage.path("inputSchema").path("properties");
         assertTrue(props.has("shipImo"), "create-voyage inputSchema must declare 'shipImo'");
@@ -127,9 +125,8 @@ public class Step6ShipyardMcpClientIntegrationTest
     @Test
     public void createVoyageShouldReturnMappedVoyageObject() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode voyage = callTool(http, sessionId, """
+        JsonNode voyage = callTool(http, """
                 {"jsonrpc":"2.0","id":4,"method":"tools/call",
                  "params":{"name":"create-voyage","arguments":{
                    "shipImo":"IMO-9321483",
@@ -157,7 +154,7 @@ public class Step6ShipyardMcpClientIntegrationTest
         assertEquals("2026-05-02", dates.path("arrival").asText(), "dates.arrival must map");
 
         assertTrue(voyage.path("crewIds").isArray(), "crewIds must be an array");
-        assertTrue(voyage.path("crewIds").size() > 0, "crewIds must not be empty");
+        assertFalse(voyage.path("crewIds").isEmpty(), "crewIds must not be empty");
         assertTrue(voyage.path("cargoIds").isArray(), "cargoIds must be an array");
         assertFalse(voyage.path("status").asText().isBlank(), "status must not be blank");
     }
@@ -166,10 +163,9 @@ public class Step6ShipyardMcpClientIntegrationTest
     void refreshCrewShouldReturnEmptyResult() throws Exception {
         // Given
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
         // When
-        Optional<JsonNode> result = callTool(http, sessionId, """
+        Optional<JsonNode> result = callTool(http, """
                 {"jsonrpc":"2.0","id":4,"method":"tools/call",
                  "params":{"name":"refresh-crew","arguments":{
                    "imo_number":"IMO-9876543"

--- a/modules/ikanos-engine/src/test/java/io/ikanos/tutorial/Step7ShipyardMcpClientIntegrationTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/tutorial/Step7ShipyardMcpClientIntegrationTest.java
@@ -54,9 +54,8 @@ public class Step7ShipyardMcpClientIntegrationTest
     @Test
     public void toolsListShouldAdvertiseFiveTools() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode tools = callToolsList(http, sessionId);
+        JsonNode tools = callToolsList(http);
 
         assertEquals(5, tools.size(), "step-7 exposes exactly five tools");
         assertEquals("list-ships",          tools.get(0).path("name").asText());
@@ -69,9 +68,8 @@ public class Step7ShipyardMcpClientIntegrationTest
     @Test
     public void getShipWithCrewInputSchemaShouldDeclareRequiredImoParameter() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode getShipWithCrew = callToolsList(http, sessionId).get(4);
+        JsonNode getShipWithCrew = callToolsList(http).get(4);
 
         JsonNode props = getShipWithCrew.path("inputSchema").path("properties");
         assertTrue(props.has("imo"), "get-ship-with-crew inputSchema must declare 'imo'");
@@ -91,9 +89,8 @@ public class Step7ShipyardMcpClientIntegrationTest
     @Test
     public void getShipWithCrewShouldReturnMappedShipAndCrewObject() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode result = callTool(http, sessionId, """
+        JsonNode result = callTool(http, """
                 {"jsonrpc":"2.0","id":5,"method":"tools/call",
                  "params":{"name":"get-ship-with-crew","arguments":{"imo":"IMO-9321483"}}}
                 """);
@@ -113,7 +110,7 @@ public class Step7ShipyardMcpClientIntegrationTest
         assertTrue(result.has("crew"), "mapped output must have crew");
         JsonNode crew = result.get("crew");
         assertTrue(crew.isArray(), "crew must be an array");
-        assertTrue(crew.size() > 0, "crew must not be empty");
+        assertFalse(crew.isEmpty(), "crew must not be empty");
 
         JsonNode first = crew.get(0);
         assertTrue(first.has("fullName"), "crew entries must have fullName");

--- a/modules/ikanos-engine/src/test/java/io/ikanos/tutorial/Step8ShipyardMcpClientIntegrationTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/tutorial/Step8ShipyardMcpClientIntegrationTest.java
@@ -63,9 +63,8 @@ public class Step8ShipyardMcpClientIntegrationTest
     @Test
     public void toolsListShouldAdvertiseFiveTools() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode tools = callToolsList(http, sessionId);
+        JsonNode tools = callToolsList(http);
 
         assertEquals(5, tools.size(), "step-8 MCP exposes exactly five tools");
         assertEquals("list-ships",          tools.get(0).path("name").asText());
@@ -78,9 +77,8 @@ public class Step8ShipyardMcpClientIntegrationTest
     @Test
     public void createVoyageInputSchemaShouldDeclareRequiredFields() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode createVoyage = callToolsList(http, sessionId).get(3);
+        JsonNode createVoyage = callToolsList(http).get(3);
 
         JsonNode props = createVoyage.path("inputSchema").path("properties");
         assertTrue(props.has("shipImo"), "create-voyage inputSchema must declare 'shipImo'");
@@ -133,9 +131,8 @@ public class Step8ShipyardMcpClientIntegrationTest
     @Test
     public void createVoyageShouldReturnMappedVoyageObject() throws Exception {
         HttpClient http = HttpClient.newHttpClient();
-        String sessionId = initialize(http);
 
-        JsonNode voyage = callTool(http, sessionId, """
+        JsonNode voyage = callTool(http, """
                 {"jsonrpc":"2.0","id":4,"method":"tools/call",
                  "params":{"name":"create-voyage","arguments":{
                    "shipImo":"IMO-9321483",
@@ -173,8 +170,7 @@ public class Step8ShipyardMcpClientIntegrationTest
         int skillPort = findFreePort();
         SkillServerAdapter skillAdapter = startIsolatedSkillServer(skillPort);
 
-        try {
-            HttpClient http = HttpClient.newHttpClient();
+        try (HttpClient http = HttpClient.newHttpClient()){
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create("http://localhost:" + skillPort + "/skills"))
                     .GET()
@@ -202,8 +198,7 @@ public class Step8ShipyardMcpClientIntegrationTest
         int skillPort = findFreePort();
         SkillServerAdapter skillAdapter = startIsolatedSkillServer(skillPort);
 
-        try {
-            HttpClient http = HttpClient.newHttpClient();
+        try (HttpClient http = HttpClient.newHttpClient()) {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create("http://localhost:" + skillPort + "/skills/fleet-ops"))
                     .GET()

--- a/modules/ikanos-spec/src/main/java/io/ikanos/spec/InfoSpec.java
+++ b/modules/ikanos-spec/src/main/java/io/ikanos/spec/InfoSpec.java
@@ -31,6 +31,8 @@ public class InfoSpec {
 
     private volatile String modified;
 
+    private volatile String version;
+
     private final List<StakeholderSpec> stakeholders;
 
     public InfoSpec(String display, String description, String created, String modified) {
@@ -80,6 +82,14 @@ public class InfoSpec {
 
     public void setModified(String modified) {
         this.modified = modified;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
     }
 
     public List<StakeholderSpec> getStakeholders() {

--- a/modules/ikanos-spec/src/main/java/io/ikanos/spec/exposes/mcp/McpServerSpec.java
+++ b/modules/ikanos-spec/src/main/java/io/ikanos/spec/exposes/mcp/McpServerSpec.java
@@ -48,6 +48,12 @@ public class McpServerSpec extends ServerSpec {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private volatile String maxBinarySize;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private volatile Integer ttlMs;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private volatile String cacheScope;
+
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonDeserialize(using = McpServerToolMapDeserializer.class)
     private final Map<String, McpServerToolSpec> tools =
@@ -112,6 +118,22 @@ public class McpServerSpec extends ServerSpec {
 
     public void setMaxBinarySize(String maxBinarySize) {
         this.maxBinarySize = maxBinarySize;
+    }
+
+    public Integer getTtlMs() {
+        return ttlMs;
+    }
+
+    public void setTtlMs(Integer ttlMs) {
+        this.ttlMs = ttlMs;
+    }
+
+    public String getCacheScope() {
+        return cacheScope;
+    }
+
+    public void setCacheScope(String cacheScope) {
+        this.cacheScope = cacheScope;
     }
 
     public Map<String, McpServerToolSpec> getTools() {

--- a/modules/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
+++ b/modules/ikanos-spec/src/main/resources/schemas/ikanos-schema.json
@@ -231,6 +231,14 @@
       "description": "A binary size with a mandatory unit (`B`, `KiB`, `MiB`, or `GiB`), e.g. `512KiB`, `5MiB`, `1GiB`. The unit is required to avoid ambiguity (a bare number has no scale).",
       "pattern": "^\\d+(\\.\\d+)?(B|KiB|MiB|GiB)$"
     },
+    "CacheScope": {
+      "type": "string",
+      "description": "Controls whether shared intermediaries may cache the response.",
+      "enum": [
+        "public",
+        "private"
+      ]
+    },
     "ConsumedInputParameter": {
       "type": "object",
       "description": "Describes a single function parameter. A unique parameter is defined by a combination of a name and location.",
@@ -721,6 +729,10 @@
           "pattern": "^\\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01])$",
           "description": "The date when the capability was last modified"
         },
+        "version": {
+          "type": "string",
+          "description": "The version of the capability"
+        },
         "stakeholders": {
           "type": "array",
           "description": "List of stakeholders related to this capability. It can be used for discovery and filtering purposes.",
@@ -1096,6 +1108,14 @@
         "maxBinarySize": {
           "$ref": "#/$defs/BinarySize",
           "description": "Maximum allowed binary response size before base64-encoding. Accepts sizes like '512KiB', '10MiB', '1GiB'. Default: 10MiB. Can be overridden per consumed operation via `maxBinarySize`."
+        },
+        "ttlMs": {
+          "type": "integer",
+          "description": "A freshness hint (in milliseconds) allowing clients to cache responses and reduce polling. If set to '0', the client will always make a request to the server."
+        },
+        "cacheScope": {
+          "$ref": "#/$defs/CacheScope",
+          "description": "Controls whether shared intermediaries may cache the response."
         },
         "authentication": {
           "$ref": "#/$defs/Authentication",


### PR DESCRIPTION
## Related Issue

Closes https://github.com/naftiko/ikanos/issues/662

---

## What does this PR do?

Migrate MCP to 2026-07-28 version
Add new properties to the schema:
* The caching properties
* A version to identify the server

---

## Tests

Lots of tests had to be refactored to adapt to the new protocol + addition of some tests for new features

---

## Documentation

Migration documentation: https://app.notion.com/p/MCP-Protocol-Migration-2025-11-25-2026-07-28-3ad4adce3d028093b26cf023ab76762d

<!-- If this PR modifies github actions for example -->

- [ ] Update Notion documentation
- [ ] Ensure our internal technical documentation (specs, user docs, test docs) reflects the current implementation (no drift)

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main`
- [ ] Small and focused — one concern per PR
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

<!-- If this PR was created or assisted by an AI agent, provide metadata below (YAML) -->

```yaml
# agent_name:
# llm:
# tool:
# confidence:          # low | medium | high
# source_event:
# discovery_method:    # runtime_observation | code_review | test_failure | user_report
# review_focus:        # e.g. ClassName.java:line-range
```
