### PR TITLE
fix: treat omitted basic/digest password as empty instead of NPE

### DIFF
--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/consumes/http/HttpClientAdapter.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/consumes/http/HttpClientAdapter.java
@@ -181,9 +181,7 @@ public class HttpClientAdapter extends ClientAdapter {
                     challengeResponse.setIdentifier(
                             Resolver.resolveMustacheTemplate(basicAuth.getUsername(), extendedParameters));
                     challengeResponse.setSecret(Resolver
-                            .resolveMustacheTemplate(
-                                    basicAuth.getPassword() == null ? "" : new String(basicAuth.getPassword()),
-                                    extendedParameters)
+                            .resolveMustacheTemplate(passwordOrEmpty(basicAuth.getPassword()), extendedParameters)
                             .toCharArray());
                     clientRequest.setChallengeResponse(challengeResponse);
                     break;
@@ -195,8 +193,7 @@ public class HttpClientAdapter extends ClientAdapter {
                     challengeResponse.setIdentifier(
                             Resolver.resolveMustacheTemplate(digestAuth.getUsername(), extendedParameters));
                     challengeResponse.setSecret(Resolver.resolveMustacheTemplate(
-                            digestAuth.getPassword() == null ? "" : new String(digestAuth.getPassword()),
-                            extendedParameters).toCharArray());
+                            passwordOrEmpty(digestAuth.getPassword()), extendedParameters).toCharArray());
                     clientRequest.setChallengeResponse(challengeResponse);
                     break;
 
@@ -238,6 +235,10 @@ public class HttpClientAdapter extends ClientAdapter {
             // Use existing challenge response if present
             clientRequest.setChallengeResponse(serverRequest.getChallengeResponse());
         }
+    }
+
+    private static String passwordOrEmpty(char[] password) {
+        return password == null ? "" : new String(password);
     }
 
     private Map<String, Object> getRequestParametersWithBindings(Map<String, Object> parameters) {

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/consumes/http/HttpClientAdapter.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/consumes/http/HttpClientAdapter.java
@@ -181,7 +181,9 @@ public class HttpClientAdapter extends ClientAdapter {
                     challengeResponse.setIdentifier(
                             Resolver.resolveMustacheTemplate(basicAuth.getUsername(), extendedParameters));
                     challengeResponse.setSecret(Resolver
-                            .resolveMustacheTemplate(new String(basicAuth.getPassword()), extendedParameters)
+                            .resolveMustacheTemplate(
+                                    basicAuth.getPassword() == null ? "" : new String(basicAuth.getPassword()),
+                                    extendedParameters)
                             .toCharArray());
                     clientRequest.setChallengeResponse(challengeResponse);
                     break;
@@ -193,7 +195,8 @@ public class HttpClientAdapter extends ClientAdapter {
                     challengeResponse.setIdentifier(
                             Resolver.resolveMustacheTemplate(digestAuth.getUsername(), extendedParameters));
                     challengeResponse.setSecret(Resolver.resolveMustacheTemplate(
-                            new String(digestAuth.getPassword()), extendedParameters).toCharArray());
+                            digestAuth.getPassword() == null ? "" : new String(digestAuth.getPassword()),
+                            extendedParameters).toCharArray());
                     clientRequest.setChallengeResponse(challengeResponse);
                     break;
 

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/ServerAdapter.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/ServerAdapter.java
@@ -141,8 +141,7 @@ public abstract class ServerAdapter extends Adapter {
                     expectedPassword = resolveTemplateChars(digest.getPassword());
                 }
 
-                if (expectedUsername == null || expectedPassword == null || identifier == null
-                        || secret == null) {
+                if (expectedUsername == null || identifier == null || secret == null) {
                     return Verifier.RESULT_INVALID;
                 }
 

--- a/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/ServerAdapter.java
+++ b/modules/ikanos-engine/src/main/java/io/ikanos/engine/exposes/ServerAdapter.java
@@ -166,11 +166,8 @@ public abstract class ServerAdapter extends Adapter {
     }
 
     private char[] resolveTemplateChars(char[] value) {
-        if (value == null) {
-            return null;
-        }
-        String resolved = resolveTemplate(new String(value));
-        return resolved == null ? null : resolved.toCharArray();
+        String resolved = resolveTemplate(new String(value == null ? new char[0] : value));
+        return resolved.toCharArray();
     }
 
     private static boolean secureEquals(String expected, String actual) {

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/consumes/http/AuthenticationTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/consumes/http/AuthenticationTest.java
@@ -15,7 +15,9 @@ package io.ikanos.engine.consumes.http;
 
 import io.ikanos.Capability;
 import io.ikanos.spec.IkanosSpec;
+import io.ikanos.spec.consumes.http.BasicAuthenticationSpec;
 import io.ikanos.spec.consumes.http.BearerAuthenticationSpec;
+import io.ikanos.spec.consumes.http.DigestAuthenticationSpec;
 import io.ikanos.spec.consumes.http.HttpClientSpec;
 import io.ikanos.spec.util.VersionHelper;
 import io.ikanos.utils.TestUtils;
@@ -24,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.restlet.Request;
 import org.restlet.data.Method;
 
+import java.util.Base64;
 import java.util.Map;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -55,6 +58,55 @@ public class AuthenticationTest {
 
         // Then
         assertThat(clientRequest.getChallengeResponse().getRawValue()).isEqualTo("notion-token");
+    }
+
+    @Test
+    public void basicAuthenticationWithNoPasswordShouldSendEmptyPasswordNotThrow() throws Exception {
+        // Given
+        Capability capability = getCapability();
+        BasicAuthenticationSpec authentication = new BasicAuthenticationSpec();
+        authentication.setType("basic");
+        authentication.setUsername("sk_test_FAKEKEY123");
+        // password intentionally left unset (null) - schema allows this
+        HttpClientSpec spec = new HttpClientSpec("stripe", "https://api.stripe.com/v1", authentication);
+
+        HttpClientAdapter adapter = new HttpClientAdapter(capability, spec);
+        Request clientRequest = new Request(Method.GET, "https://api.stripe.com/v1/charges");
+
+        // When
+        adapter.setChallengeResponse(null, clientRequest,
+                clientRequest.getResourceRef().toString(), Map.of());
+
+        // Then
+        String expected = Base64.getEncoder().encodeToString("sk_test_FAKEKEY123:".getBytes());
+        assertThat(clientRequest.getChallengeResponse().getIdentifier()).isEqualTo("sk_test_FAKEKEY123");
+        assertThat(String.valueOf(clientRequest.getChallengeResponse().getSecret())).isEqualTo("");
+        assertThat(Base64.getEncoder().encodeToString(
+                (clientRequest.getChallengeResponse().getIdentifier() + ":"
+                        + String.valueOf(clientRequest.getChallengeResponse().getSecret())).getBytes()))
+                .isEqualTo(expected);
+    }
+
+    @Test
+    public void digestAuthenticationWithNoPasswordShouldNotThrow() throws Exception {
+        // Given
+        Capability capability = getCapability();
+        DigestAuthenticationSpec authentication = new DigestAuthenticationSpec();
+        authentication.setType("digest");
+        authentication.setUsername("sk_test_FAKEKEY123");
+        // password intentionally left unset (null) - schema allows this
+        HttpClientSpec spec = new HttpClientSpec("digest-service", "https://api.example.com", authentication);
+
+        HttpClientAdapter adapter = new HttpClientAdapter(capability, spec);
+        Request clientRequest = new Request(Method.GET, "https://api.example.com/resource");
+
+        // When
+        adapter.setChallengeResponse(null, clientRequest,
+                clientRequest.getResourceRef().toString(), Map.of());
+
+        // Then
+        assertThat(clientRequest.getChallengeResponse().getIdentifier()).isEqualTo("sk_test_FAKEKEY123");
+        assertThat(String.valueOf(clientRequest.getChallengeResponse().getSecret())).isEqualTo("");
     }
 
     private Capability getCapability() throws Exception {

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/consumes/http/AuthenticationTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/consumes/http/AuthenticationTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.restlet.Request;
 import org.restlet.data.Method;
 
-import java.util.Base64;
 import java.util.Map;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -78,17 +77,12 @@ public class AuthenticationTest {
                 clientRequest.getResourceRef().toString(), Map.of());
 
         // Then
-        String expected = Base64.getEncoder().encodeToString("sk_test_FAKEKEY123:".getBytes());
         assertThat(clientRequest.getChallengeResponse().getIdentifier()).isEqualTo("sk_test_FAKEKEY123");
         assertThat(String.valueOf(clientRequest.getChallengeResponse().getSecret())).isEqualTo("");
-        assertThat(Base64.getEncoder().encodeToString(
-                (clientRequest.getChallengeResponse().getIdentifier() + ":"
-                        + String.valueOf(clientRequest.getChallengeResponse().getSecret())).getBytes()))
-                .isEqualTo(expected);
     }
 
     @Test
-    public void digestAuthenticationWithNoPasswordShouldNotThrow() throws Exception {
+    public void digestAuthenticationWithNoPasswordShouldSendEmptyPasswordNotThrow() throws Exception {
         // Given
         Capability capability = getCapability();
         DigestAuthenticationSpec authentication = new DigestAuthenticationSpec();

--- a/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/ServerAdapterAuthenticationTest.java
+++ b/modules/ikanos-engine/src/test/java/io/ikanos/engine/exposes/ServerAdapterAuthenticationTest.java
@@ -13,6 +13,7 @@
  */
 package io.ikanos.engine.exposes;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -22,6 +23,8 @@ import org.junit.jupiter.api.Test;
 import org.restlet.Restlet;
 import org.restlet.routing.Router;
 import org.restlet.security.ChallengeAuthenticator;
+import org.restlet.security.SecretVerifier;
+import org.restlet.security.Verifier;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -122,6 +125,42 @@ class ServerAdapterAuthenticationTest {
 
         assertInstanceOf(ChallengeAuthenticator.class, chain,
                 "Digest auth should produce ChallengeAuthenticator");
+    }
+
+    @Test
+    void basicChallengeAuthenticatorWithNoPasswordShouldAcceptEmptyPassword() throws Exception {
+        String authBlock = """
+                      authentication:
+                        type: "basic"
+                        username: "admin"
+                """;
+        ServerAdapter adapter = adapterFromYaml(MCP_YAML.formatted(schemaVersion, authBlock));
+
+        ChallengeAuthenticator chain = (ChallengeAuthenticator) adapter.buildServerChain(new Router());
+        SecretVerifier verifier = (SecretVerifier) chain.getVerifier();
+
+        assertEquals(Verifier.RESULT_VALID, verifier.verify("admin", new char[0]),
+                "Omitted password should be satisfied by an empty password on the incoming request");
+        assertEquals(Verifier.RESULT_INVALID, verifier.verify("admin", "wrong".toCharArray()),
+                "Omitted password should still reject an arbitrary non-empty password");
+    }
+
+    @Test
+    void digestChallengeAuthenticatorWithNoPasswordShouldAcceptEmptyPassword() throws Exception {
+        String authBlock = """
+                      authentication:
+                        type: "digest"
+                        username: "admin"
+                """;
+        ServerAdapter adapter = adapterFromYaml(MCP_YAML.formatted(schemaVersion, authBlock));
+
+        ChallengeAuthenticator chain = (ChallengeAuthenticator) adapter.buildServerChain(new Router());
+        SecretVerifier verifier = (SecretVerifier) chain.getVerifier();
+
+        assertEquals(Verifier.RESULT_VALID, verifier.verify("admin", new char[0]),
+                "Omitted password should be satisfied by an empty password on the incoming request");
+        assertEquals(Verifier.RESULT_INVALID, verifier.verify("admin", "wrong".toCharArray()),
+                "Omitted password should still reject an arbitrary non-empty password");
     }
 
     @Test


### PR DESCRIPTION
## Related Issue

Closes #699

---

## What does this PR do?

`type: basic`/`type: digest` auth with a username but no password is schema-valid (only `type` is required) but crashed at call time in `HttpClientAdapter.setChallengeResponse()`, which called `new String(null)` on the missing password char array.

Fixed both the `basic` and `digest` branches to treat a `null` password as an empty secret, matching the byte-identical output of the documented workaround (`password: ""`).

Also fixed the mirrored gap on the exposes side (`ServerAdapter.buildChallengeAuthenticator`/`resolveTemplateChars`): an omitted password there didn't crash, but the verifier treated a `null` expected password as always `RESULT_INVALID`, so a capability declaring basic/digest auth with an intentionally empty password could never be satisfied by incoming requests either.

---

## Tests

- Added `basicAuthenticationWithNoPasswordShouldSendEmptyPasswordNotThrow` and `digestAuthenticationWithNoPasswordShouldNotThrow` to `AuthenticationTest` (consumes/client side), asserting the resulting header/secret is empty rather than throwing.
- Added `basicChallengeAuthenticatorWithNoPasswordShouldAcceptEmptyPassword` and `digestChallengeAuthenticatorWithNoPasswordShouldAcceptEmptyPassword` to `ServerAdapterAuthenticationTest` (exposes/server side), asserting an empty incoming password is accepted while a non-empty guess is still rejected.

Verified locally (JDK 21):
- `mvn -pl modules/ikanos-engine -am test -Dtest=AuthenticationTest,ServerAdapterAuthenticationTest,HttpClientAdapterTest` — all pass, no regressions
- `mvn -pl modules/ikanos-engine -am test` (full module) — 832 tests, 0 failures (10 pre-existing errors are Testcontainers/Docker-environment tests, unrelated to this change, failing due to no local Docker daemon)

**Note on this PR's CI:** the two failing checks (`Unit Tests + JaCoCo`, `Validate Shipyard tutorial examples`) are not caused by this change — both fail on infra steps unavailable to fork-originated PRs:
- `Unit Tests + JaCoCo`: the Maven test run itself is green (832/832); the job only fails afterward when it tries to push the coverage badge to the `badges` branch and post a PR comment, both of which need write permissions `GITHUB_TOKEN` doesn't get on fork PRs (`403 Permission denied`, `Resource not accessible by integration`).
- `Validate Shipyard tutorial examples`: fails on `step-3-shipyard-auth.yml` because `secrets.REGISTRY_TOKEN` (and friends) aren't exposed to fork PR workflow runs, so `shared/secrets.yaml` ends up with an empty `registry-bearer-token` value.

Happy to have a maintainer re-run these from a branch on the base repo, or via `workflow_dispatch`, to confirm green.

---

## Documentation

- [ ] Update Notion documentation *(internal — n/a for external contribution)*
- [x] Ensure our internal technical documentation (specs, user docs, test docs) reflects the current implementation (no drift) — no spec/doc change needed

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans) — see note above; blocked by fork-PR infra limitations, not by this change
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)