### PR TITLE
feat: point to pr-review skill's external-contributor guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,6 +243,9 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow. Key rules:
 - When asked to review a PR, load and follow the `pr-review` skill via the `agents-shared`
   capability — see `.github/instructions/agents-shared.instructions.md` for the discovery
   and sync procedure. The skill is served from `golden-repo-naftiko/agents-shared` (naftiko/shipyard#23).
+  When the PR is from an external/cross-repository contributor, also apply the skill's
+  "External contributors — extra care" subsection (Part A) — deeper security analysis before
+  flagging, non-blocking form findings, LLM-assistance disclosure, and a welcoming tone.
 - When asked to fix a bug, investigate an issue, or address PR review feedback, load and follow the `bugfix` skill via the `agents-shared` capability — see `.github/instructions/agents-shared.instructions.md` for the discovery and sync procedure — before doing anything else. It targets **Java/Maven** repositories (its build/test core assumes `mvn`); fixing a bash script or CI workflow that lives inside such a repo is in scope, but non-Java/Maven application code (C++, TypeScript, …) is not. It does **not** hardcode the repository name — it derives `<owner/repo>` from the working directory, so it is reusable across Java/Maven repos
 - When resuming after a context compaction (conversation summary), always re-read any active skill's `SKILL.md` before continuing — compaction erases step formalism, workflow constraints, and all details defined in the skill
 - When editing documentation, skill, or instruction files (`.md`, `SKILL.md`, `AGENTS.md`), re-read the **entire file** after applying edits and before committing — to catch terminology drift, broken cross-references, and inconsistencies between sections that targeted edits cannot detect


### PR DESCRIPTION
## Related Issue

Refs naftiko/golden-repo-naftiko#54

---

## What does this PR do?

Adds a one-line pointer in the PR-review contribution rules to the `pr-review` skill's new
"External contributors — extra care" subsection (added in `golden-repo-naftiko` via the
companion PR tracked by naftiko/golden-repo-naftiko#54).

No behavior change on its own — this only makes the existing `pr-review` bullet point to the
new subsection so agents apply it when reviewing a PR from an external/cross-repository
contributor (deeper security analysis before flagging, non-blocking form findings,
LLM-assistance disclosure, welcoming tone).

---

## Tests

N/A — documentation-only change (`AGENTS.md`), no code path affected.

---

## Documentation

- [ ] Update Notion documentation
- [x] Ensure our internal technical documentation (specs, user docs, test docs) reflects the current implementation (no drift) — `AGENTS.md` is the only doc affected and is updated by this PR

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Naftiko - Claude Sonnet 5
tool: VS Code Copilot Chat
confidence: high
source_event: PR review debrief (naftiko/ikanos#707) revealed a gap in the pr-review skill for external contributors
discovery_method: code_review
review_focus: AGENTS.md contribution-workflow section
```
