### PR TITLE
fix: failing tuto validation

### DIFF
--- a/.github/workflows/validate-tuto-examples.yml
+++ b/.github/workflows/validate-tuto-examples.yml
@@ -31,15 +31,10 @@ jobs:
     - name: Build project
       run: mvn package -DskipTests -q
 
-    - name: Create secrets file
+    - name: Copy secrets file
       run: |
         mkdir -p shared
-        cat > shared/secrets.yaml << EOF
-        registry-bearer-token: ${{ secrets.REGISTRY_TOKEN }}
-        registry-api-version: ${{ secrets.REGISTRY_VERSION }}
-        dockyard-api-key: ${{ secrets.DOCKYARD_API_KEY }}
-        mcp-server-token: ${{ secrets.MCP_SERVER_TOKEN }}
-        EOF
+        cp modules/ikanos-docs/tutorial/shared/secrets.yaml shared/secrets.yaml
 
     - name: Start Microcks
       run: |
@@ -62,10 +57,10 @@ jobs:
         done
 
     - name: Run tests
-      env:
-        MCP_SERVER_TOKEN: ${{ secrets.MCP_SERVER_TOKEN }}
       run: |
         set -e
+        
+        MCP_SERVER_TOKEN=$(yq -r '.mcp-server-token' shared/secrets.yaml)
 
         PID=""
 


### PR DESCRIPTION
## Related Issue

no related issue

---

## What does this PR do?

Fixes the "Validate Shipyard tutorial examples" CI job failing on fork PRs.
Since these were never real secrets (just mock/dummy values used to exercise auth code paths in tests), this PR stops sourcing them via the secrets: context entirely. Instead, the workflow now copies the existing committed fixture at modules/ikanos-docs/tutorial/shared/secrets.yaml directly into shared/secrets.yaml, and reads mcp-server-token from that file at test-run time instead of via an env:-injected secret.

---

## Tests

<!-- Describe tests added or modified. If none, explain why. -->

---

## Documentation

<!-- If this PR modifies github actions for example -->

- [ ] Update Notion documentation
- [ ] Ensure our internal technical documentation (specs, user docs, test docs) reflects the current implementation (no drift)

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main`
- [ ] Small and focused — one concern per PR
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

