### PR TITLE
feat: document the DCO sign-off requirement

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,6 +31,7 @@ Closes #<!-- issue number -->
 - [ ] Rebased on latest `main`
 - [ ] Small and focused — one concern per PR
 - [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] Every commit is signed off (`git commit -s`) — the [DCO](https://probot.github.io/apps/dco/) check must pass
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,6 +226,12 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow. Key rules:
 - **All GitHub interactions must be in English** — issues, PR titles/bodies, inline review comments, and commit messages. The codebase and its community are English-first.
 - Branch from `main`: `feat/`, `fix/`, or `chore/` prefix
 - Use [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `chore:` — no scopes for now
+- **Sign off every commit — `git commit -s`, always.** A `Signed-off-by:` trailer matching the commit author is mandatory: the [DCO GitHub App](https://probot.github.io/apps/dco/) is a required check, and a single unsigned commit blocks the whole PR. Make `-s` reflexive on *every* `git commit` you run in this repo — it costs nothing when redundant, and retrofitting it later means rewriting history on a branch that may already be under review. The trailer must be produced by `-s` at commit time; never hand-write it into the body, and never sign off a commit whose author is someone else — the sign-off is that author's certification, not yours.
+- **After any history rewrite, re-verify the trailer before pushing** — an interactive rebase, a squash, or a `--amend` from another tool can silently drop it. Check the whole branch in one shot rather than waiting for CI to tell you:
+  ```bash
+  git log origin/main..HEAD --format='%h %s%n  signoff: %(trailers:key=Signed-off-by,valueonly)'
+  ```
+  An empty `signoff:` line is a commit the DCO check will reject. Fix the last commit with `git commit -s --amend --no-edit`, or a whole branch with `git rebase --signoff origin/main`. Both are idempotent on the trailer (no duplicate is added if one is already present) but **both rewrite the commit SHAs** — so run them only when a trailer is genuinely missing, and follow with `git push --force-with-lease` (never `--force`).
 - AGENTS.md improvements are `feat:`, not `chore:` — they add value to the agent workflow
 - Rebase on `main` before PR — linear history, no merge commits
 - One logical change per PR — keep it atomic

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,18 @@ bash ./scripts/pr-check-mac-linux.sh
         chore: bump dependencies
 
 - **Rebase on `main`** before requesting a review — we maintain a linear history (no merge commits)
+- **Sign off every commit** — by contributing, you certify the
+  [Developer Certificate of Origin](https://developercertificate.org/): you wrote the change, or
+  you have the right to submit it under the project's licence. `git commit -s` adds the required
+  `Signed-off-by:` trailer, which must match your commit author identity:
+
+        git commit -s -m "feat: add OAuth login"
+
+  The [DCO check](https://probot.github.io/apps/dco/) is **required** — one unsigned commit blocks
+  the whole PR, so make `-s` a habit rather than something to retrofit. If you forgot it, add it
+  to the last commit with `git commit -s --amend --no-edit`, or to every commit on the branch with
+  `git rebase --signoff origin/main`; both rewrite history, so finish with
+  `git push --force-with-lease`.
 - Use `git push --force-with-lease` (never `--force`)
 - Run the local validation script before opening your PR:
 


### PR DESCRIPTION
## Related Issue

Closes #712

---

## What does this PR do?

A DCO GitHub App is now installed on the repository, making `Signed-off-by` a **required check** —
a PR containing a single unsigned commit is blocked from merging. Nothing documented it, so
contributors discovered the rule only when CI failed, with no guidance on retrofitting the trailer
onto commits already pushed.

This PR documents the requirement in the three places a contributor actually looks:

| File | Audience | Content |
|---|---|---|
| `CONTRIBUTING.md` (§2 Develop) | external + human contributors | the DCO certification, `git commit -s`, and how to retrofit a missing trailer |
| `AGENTS.md` (Contribution Workflow) | agents | the same rule, plus verifying the trailer *before* pushing rather than relying on CI |
| `.github/PULL_REQUEST_TEMPLATE.md` (Checklist) | everyone | one checklist line |

Three points are deliberately spelled out rather than left as "add `-s`":

- **`-s` should be reflexive, not corrective.** The argument given is the asymmetric cost: a
  redundant `-s` costs nothing, a forgotten one means rewriting history on a branch that may
  already be under review.
- **Verification belongs before the push, not in CI.** An interactive rebase, a squash, or an
  `--amend` from another tool can silently drop the trailer, so the rule carries a one-shot command
  that checks every commit on the branch.
- **Never sign off another author's commit.** The sign-off is a personal certification; a
  `rebase --signoff` over a branch containing a third party's commit would certify on their behalf.

The rule is intentionally kept **repo-local**. Only the public repositories that accept external
contributions have the DCO app, so putting it in the transversal engineering Context would wrongly
constrain the others. The equivalent change for Polychro is `naftiko/polychro#132`.

---

## Tests

No tests — this PR only changes Markdown documentation (`AGENTS.md`, `CONTRIBUTING.md`, and the PR
template). There is no production or test code involved.

The commands documented in the new rules were verified by hand on this repository before being
written down:

- `git log origin/main..HEAD --format='… %(trailers:key=Signed-off-by,valueonly)'` correctly
  reports an empty field for an unsigned commit.
- `git commit -s --amend` is idempotent on the trailer (no duplicate when one is already present)
  but **does rewrite the commit SHA** — which is why the rule tells you to run it only when a
  trailer is genuinely missing.

---

## Documentation

- [ ] Update Notion documentation
- [x] Ensure our internal technical documentation (specs, user docs, test docs) reflects the current implementation (no drift)

This PR *is* the documentation update. No Notion page describes the contribution workflow, so
nothing to update there.

---

## Checklist

- [x] CI is green (build, tests, schema validation, security scans)
- [x] Rebased on latest `main`
- [x] Small and focused — one concern per PR
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Every commit is signed off (`git commit -s`) — the [DCO](https://probot.github.io/apps/dco/) check must pass

---

## Agent Context (optional)

```yaml
agent_name: GitHub Copilot
llm: Naftiko - Claude Opus 5
tool: VS Code
confidence: high
source_event: DCO app installed on the repo; PR #708 blocked by the check
discovery_method: user_report
review_focus: AGENTS.md (Contribution Workflow), CONTRIBUTING.md (§2 Develop)
```
